### PR TITLE
Fixed XSD location in ErnParserController

### DIFF
--- a/src/Controller/ErnParserController.php
+++ b/src/Controller/ErnParserController.php
@@ -679,7 +679,7 @@ class ErnParserController {
     $xml_reader = new XMLReader();
     $xml_reader->open($file_path);
 
-    $xsd_file_path = "xsd/release_notification/{$this->version}/release-notification.xsd";
+    $xsd_file_path = __DIR__ . "/../../xsd/release_notification/{$this->version}/release-notification.xsd";
     $xml_reader->setSchema($xsd_file_path);
 
     try {

--- a/tests/Controller/ParserControllerErrorsTest.php
+++ b/tests/Controller/ParserControllerErrorsTest.php
@@ -59,8 +59,8 @@ class ParserControllerErrorTest extends TestCase {
       $parser->parse("tests/samples/005_not_valid_xsd.xml");
       $this->assertFalse(true);
     } catch (XsdCompliantException $ex) {
-      $expected_message = "This XML file tests/samples/005_not_valid_xsd.xml does not validates XSD xsd/release_notification/382/release-notification.xsd. Error: XMLReader::read(): Element 'FakeTag': This element is not expected. Expected is one of ( SoundRecordingType, IsArtistRelated, SoundRecordingId ).";
-      $this->assertEquals($expected_message, $ex->getMessage());
+      $this->assertStringContainsString('This XML file tests/samples/005_not_valid_xsd.xml does not validates XSD', $ex->getMessage());
+      $this->assertStringContainsString("xsd/release_notification/382/release-notification.xsd. Error: XMLReader::read(): Element 'FakeTag': This element is not expected. Expected is one of ( SoundRecordingType, IsArtistRelated, SoundRecordingId ).", $ex->getMessage());
     }
     
     // If setXsdValidation is not set, will raise another error later
@@ -72,5 +72,4 @@ class ParserControllerErrorTest extends TestCase {
       $this->assertEquals($expected_message, $ex->getMessage());
     }
   }
-
 }


### PR DESCRIPTION
When setXsdValidation called the following PHP Warning would be thrown:

`PHP Warning:  XMLReader::setSchema(): I/O warning : failed to load external entity "xsd/release_notification/382/release-notification.xsd" in */../src/Controller/ErnParserController.php on line 683`

This is because the path wasn't valid and needed to drop back a couple of directories, so I changed this to use a relative path, which broke the tests because the path in the test was wrong as an update. I updated the tests to make 2 assertions, one for the test each side of the dynamic part.