### PR TITLE
PHP Deprecation warning fix

### DIFF
--- a/src/Controller/ErnParserController.php
+++ b/src/Controller/ErnParserController.php
@@ -262,7 +262,13 @@ class ErnParserController {
     if ($class_name === "\DateInterval") {
       // For DateInterval can't instanciate with null
       return new DateInterval("PT0M0S");  // will be erased
-    } else if ($class_name === "\DedexBundle\Entity\Ern382\EventDateTimeType") {
+    }
+
+    if ($class_name === '\DateTime') {
+      return new $class_name('');
+    }
+
+    if ($class_name === "\DedexBundle\Entity\Ern382\EventDateTimeType") {
       return new \DedexBundle\Entity\Ern382\EventDateTimeType(new \DateTime()); // TODO
     }
 


### PR DESCRIPTION
The following error is thrown when DateTime is accessed via instanciateClass method.

`PHP Deprecated:  DateTime::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated in src/Controller/ErnParserController.php on line 269`

Warning not thrown when passing blank string instead of null.

Tests ran and confirm passing.