### PR TITLE
Support ern 42

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ notes.txt
 Dockerfile
 .phpunit.result.cache
 composer.lock
+CLAUDE.md
 
 # PHPUnit
 /phpunit.xml

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -65,3 +65,21 @@ Example for generating DDEX 411 entity classes:
 ```
 ./vendor/goetas-webservices/xsd2php/bin/xsd2php convert config/xsd2php.yaml xsd/release_notification/411/*.xsd
 ```
+
+With the following config file `config/xsd2php.yaml`:
+
+```yaml
+xsd2php:
+  namespaces:
+    'http://ddex.net/xml/ern/42': 'DedexBundle\Entity\Ern42'
+    'http://ddex.net/xml/avs/avs': 'DedexBundle\Entity\Ern42\Avs'
+  destinations_php:
+    'DedexBundle\Entity\Ern42': src/Entity/Ern42
+    'DedexBundle\Entity\Ern42\Avs': src/Entity/Ern42/Avs
+
+  destinations_jms:
+    'DedexBundle\Entity\Ern42': src/Entity/Ern42/metadata
+
+  naming_strategy: long # needed to avoid conflicts on Type files
+  path_generator: psr4 # optional and default
+```

--- a/src/Controller/ErnParserController.php
+++ b/src/Controller/ErnParserController.php
@@ -77,8 +77,12 @@ class ErnParserController {
    * NewReleaseMessage object from the right entity based on version, like:
    *     \DedexBundle\Entity\Ern382\NewReleaseMessage
    * or  \DedexBundle\Entity\Ern41\NewReleaseMessage
+   * or  \DedexBundle\Entity\Ern411\NewReleaseMessage
+   * or  \DedexBundle\Entity\Ern42\NewReleaseMessage
    * or  \DedexBundle\Entity\Ern382\PurgeReleaseMessage
    * or  \DedexBundle\Entity\Ern41\PurgeReleaseMessage
+   * or  \DedexBundle\Entity\Ern411\PurgeReleaseMessage
+   * or  \DedexBundle\Entity\Ern42\PurgeReleaseMessage
    */
   private $ern = null;
 
@@ -637,14 +641,14 @@ class ErnParserController {
   }
 
   /**
-   * Look for text xmlns:ern="http://ddex.net/xml/ern/382" or 41 in XML file
+   * Look for text xmlns:ern="http://ddex.net/xml/ern/382" or other version in XML file
    * @param filedescription $fp Open wml file. Considered as valid XML file at this point
    * @return string version such as "382" or "41"
    * @throws Exception
    */
   private function detectVersion($fp) {
     $version = null;
-    $supported_versions = ["411", "41", "382"];
+    $supported_versions = ["411", "41", "42", "382"];
 
     while (($buffer = fgets($fp, 4096)) !== false) {
       $trimed = trim($buffer);
@@ -768,7 +772,7 @@ class ErnParserController {
       throw new XmlLoadException("Can't load XML file: $file_path");
     }
 
-    $this->version = $this->detectVersion($fp); // 382 or 41
+    $this->version = $this->detectVersion($fp);
     // Validate xml against XSD
     $this->validateXml($file_path);
 

--- a/src/Controller/ErnParserController.php
+++ b/src/Controller/ErnParserController.php
@@ -756,6 +756,16 @@ class ErnParserController {
   }
 
   /**
+   * Return the detected version string (e.g. "382", "41", "411", "42").
+   * Available after parse() has been called.
+   *
+   * @return string|null
+   */
+  public function getVersion(): ?string {
+    return $this->version;
+  }
+
+  /**
    * This is the main parsing function that will go through the whole XML
    * 
    * @param string $file_path Location of XML path

--- a/src/Entity/Ern42/AdditionalTitleType.php
+++ b/src/Entity/Ern42/AdditionalTitleType.php
@@ -1,0 +1,322 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing AdditionalTitleType
+ *
+ * A Composite containing details of an AdditionalTitle.
+ * XSD Type: AdditionalTitle
+ */
+class AdditionalTitleType
+{
+    /**
+     * The Language and script for the Elements of the Title as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * A Territory to which the Title applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * A Type of the Title which defines its origin or the function it fulfils in relation to a Creation. Note: A Title may fulfil more than one role. Example: 'Help' may be both the OriginalTitle and the DisplayTitle for the well-known Beatles song. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $titleType
+     */
+    private $titleType = null;
+
+    /**
+     * The Namespace of the AdditionalTitleType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the AdditionalTitleType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * The text of the Title.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @var string $titleText
+     */
+    private $titleText = null;
+
+    /**
+     * A Composite containing details of a SubTitle of the Title, including Titles of Versions used to differentiate different versions of the same Title, as required by the GRid and ISRC ReferenceDescriptiveMetadataSets.
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplaySubTitleType[] $subTitle
+     */
+    private $subTitle = [
+        
+    ];
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the Elements of the Title as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the Elements of the Title as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the Title applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the Title applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as titleType
+     *
+     * A Type of the Title which defines its origin or the function it fulfils in relation to a Creation. Note: A Title may fulfil more than one role. Example: 'Help' may be both the OriginalTitle and the DisplayTitle for the well-known Beatles song. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getTitleType()
+    {
+        return $this->titleType;
+    }
+
+    /**
+     * Sets a new titleType
+     *
+     * A Type of the Title which defines its origin or the function it fulfils in relation to a Creation. Note: A Title may fulfil more than one role. Example: 'Help' may be both the OriginalTitle and the DisplayTitle for the well-known Beatles song. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $titleType
+     * @return self
+     */
+    public function setTitleType($titleType)
+    {
+        $this->titleType = $titleType;
+        return $this;
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the AdditionalTitleType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the AdditionalTitleType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the AdditionalTitleType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the AdditionalTitleType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+
+    /**
+     * Gets as titleText
+     *
+     * The text of the Title.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return string
+     */
+    public function getTitleText()
+    {
+        return $this->titleText;
+    }
+
+    /**
+     * Sets a new titleText
+     *
+     * The text of the Title.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param string $titleText
+     * @return self
+     */
+    public function setTitleText($titleText)
+    {
+        $this->titleText = $titleText;
+        return $this;
+    }
+
+    /**
+     * Adds as subTitle
+     *
+     * A Composite containing details of a SubTitle of the Title, including Titles of Versions used to differentiate different versions of the same Title, as required by the GRid and ISRC ReferenceDescriptiveMetadataSets.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplaySubTitleType $subTitle
+     */
+    public function addToSubTitle(\DedexBundle\Entity\Ern42\DisplaySubTitleType $subTitle)
+    {
+        $this->subTitle[] = $subTitle;
+        return $this;
+    }
+
+    /**
+     * isset subTitle
+     *
+     * A Composite containing details of a SubTitle of the Title, including Titles of Versions used to differentiate different versions of the same Title, as required by the GRid and ISRC ReferenceDescriptiveMetadataSets.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetSubTitle($index)
+    {
+        return isset($this->subTitle[$index]);
+    }
+
+    /**
+     * unset subTitle
+     *
+     * A Composite containing details of a SubTitle of the Title, including Titles of Versions used to differentiate different versions of the same Title, as required by the GRid and ISRC ReferenceDescriptiveMetadataSets.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetSubTitle($index)
+    {
+        unset($this->subTitle[$index]);
+    }
+
+    /**
+     * Gets as subTitle
+     *
+     * A Composite containing details of a SubTitle of the Title, including Titles of Versions used to differentiate different versions of the same Title, as required by the GRid and ISRC ReferenceDescriptiveMetadataSets.
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplaySubTitleType[]
+     */
+    public function getSubTitle()
+    {
+        return $this->subTitle;
+    }
+
+    /**
+     * Sets a new subTitle
+     *
+     * A Composite containing details of a SubTitle of the Title, including Titles of Versions used to differentiate different versions of the same Title, as required by the GRid and ISRC ReferenceDescriptiveMetadataSets.
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplaySubTitleType[] $subTitle
+     * @return self
+     */
+    public function setSubTitle(?array $subTitle = null)
+    {
+        $this->subTitle = $subTitle;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/AdministratingRecordCompanyRoleType.php
+++ b/src/Entity/Ern42/AdministratingRecordCompanyRoleType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing AdministratingRecordCompanyRoleType
+ *
+ * A Composite containing details of a AdministratingRecordCompanyRole.
+ * XSD Type: AdministratingRecordCompanyRole
+ */
+class AdministratingRecordCompanyRoleType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the AdministratingRecordCompanyRole. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the AdministratingRecordCompanyRole. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the AdministratingRecordCompanyRole. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the AdministratingRecordCompanyRole. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the AdministratingRecordCompanyRole. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the AdministratingRecordCompanyRole. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/AdministratingRecordCompanyWithReferenceType.php
+++ b/src/Entity/Ern42/AdministratingRecordCompanyWithReferenceType.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing AdministratingRecordCompanyWithReferenceType
+ *
+ * A Composite containing details of an AdministratingRecordCompany.
+ * Explanatory Note: This Composite is named AdministratingRecordCompanyWithReference to disambiguate it from the basic AdministratingRecordCompany Composite.
+ * XSD Type: AdministratingRecordCompanyWithReference
+ */
+class AdministratingRecordCompanyWithReferenceType
+{
+    /**
+     * A Reference for a Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @var string $recordCompanyPartyReference
+     */
+    private $recordCompanyPartyReference = null;
+
+    /**
+     * The role played by the Party responsible for administering Rights in a Resource or a Release.
+     *
+     * @var \DedexBundle\Entity\Ern42\AdministratingRecordCompanyRoleType $role
+     */
+    private $role = null;
+
+    /**
+     * Gets as recordCompanyPartyReference
+     *
+     * A Reference for a Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @return string
+     */
+    public function getRecordCompanyPartyReference()
+    {
+        return $this->recordCompanyPartyReference;
+    }
+
+    /**
+     * Sets a new recordCompanyPartyReference
+     *
+     * A Reference for a Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @param string $recordCompanyPartyReference
+     * @return self
+     */
+    public function setRecordCompanyPartyReference($recordCompanyPartyReference)
+    {
+        $this->recordCompanyPartyReference = $recordCompanyPartyReference;
+        return $this;
+    }
+
+    /**
+     * Gets as role
+     *
+     * The role played by the Party responsible for administering Rights in a Resource or a Release.
+     *
+     * @return \DedexBundle\Entity\Ern42\AdministratingRecordCompanyRoleType
+     */
+    public function getRole()
+    {
+        return $this->role;
+    }
+
+    /**
+     * Sets a new role
+     *
+     * The role played by the Party responsible for administering Rights in a Resource or a Release.
+     *
+     * @param \DedexBundle\Entity\Ern42\AdministratingRecordCompanyRoleType $role
+     * @return self
+     */
+    public function setRole(\DedexBundle\Entity\Ern42\AdministratingRecordCompanyRoleType $role)
+    {
+        $this->role = $role;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/AffiliationType.php
+++ b/src/Entity/Ern42/AffiliationType.php
@@ -1,0 +1,406 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing AffiliationType
+ *
+ * A Composite containing details of a business deal with another Party.
+ * XSD Type: Affiliation
+ */
+class AffiliationType
+{
+    /**
+     * The Name of the company.
+     *
+     * @var string $companyName
+     */
+    private $companyName = null;
+
+    /**
+     * A Reference for an affiliated Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @var string $partyAffiliateReference
+     */
+    private $partyAffiliateReference = null;
+
+    /**
+     * The Type of affiliated Party.
+     *
+     * @var string $type
+     */
+    private $type = null;
+
+    /**
+     * A Territory to which the affiliation details apply. Either this Element or ExcludedTerritory shall be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var \DedexBundle\Entity\Ern42\CurrentTerritoryCodeType[] $territoryCode
+     */
+    private $territoryCode = [
+        
+    ];
+
+    /**
+     * A Territory to which the affiliation details do not apply. Either this Element or Territory shall be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var \DedexBundle\Entity\Ern42\CurrentTerritoryCodeType[] $excludedTerritoryCode
+     */
+    private $excludedTerritoryCode = [
+        
+    ];
+
+    /**
+     * A Composite containing details about the Period of Time for which the society affiliation is valid.
+     * Further Reading: https://kb.ddex.net/general-implementation-guidance/licensing-the-standards/ddex-party-identifier-(dpid)
+     *
+     * @var \DedexBundle\Entity\Ern42\ValidityPeriodType $validityPeriod
+     */
+    private $validityPeriod = null;
+
+    /**
+     * A Composite containing details of a rights type.
+     *
+     * @var \DedexBundle\Entity\Ern42\SimpleRightsTypeType[] $rightsType
+     */
+    private $rightsType = [
+        
+    ];
+
+    /**
+     * Percentage of the specific Right that is represented by the society. A quarter share is represented by '25' (and not 0.25).
+     *
+     * @var float $percentageOfRightsAssignment
+     */
+    private $percentageOfRightsAssignment = null;
+
+    /**
+     * Gets as companyName
+     *
+     * The Name of the company.
+     *
+     * @return string
+     */
+    public function getCompanyName()
+    {
+        return $this->companyName;
+    }
+
+    /**
+     * Sets a new companyName
+     *
+     * The Name of the company.
+     *
+     * @param string $companyName
+     * @return self
+     */
+    public function setCompanyName($companyName)
+    {
+        $this->companyName = $companyName;
+        return $this;
+    }
+
+    /**
+     * Gets as partyAffiliateReference
+     *
+     * A Reference for an affiliated Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @return string
+     */
+    public function getPartyAffiliateReference()
+    {
+        return $this->partyAffiliateReference;
+    }
+
+    /**
+     * Sets a new partyAffiliateReference
+     *
+     * A Reference for an affiliated Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @param string $partyAffiliateReference
+     * @return self
+     */
+    public function setPartyAffiliateReference($partyAffiliateReference)
+    {
+        $this->partyAffiliateReference = $partyAffiliateReference;
+        return $this;
+    }
+
+    /**
+     * Gets as type
+     *
+     * The Type of affiliated Party.
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * Sets a new type
+     *
+     * The Type of affiliated Party.
+     *
+     * @param string $type
+     * @return self
+     */
+    public function setType($type)
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    /**
+     * Adds as territoryCode
+     *
+     * A Territory to which the affiliation details apply. Either this Element or ExcludedTerritory shall be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\CurrentTerritoryCodeType $territoryCode
+     */
+    public function addToTerritoryCode(\DedexBundle\Entity\Ern42\CurrentTerritoryCodeType $territoryCode)
+    {
+        $this->territoryCode[] = $territoryCode;
+        return $this;
+    }
+
+    /**
+     * isset territoryCode
+     *
+     * A Territory to which the affiliation details apply. Either this Element or ExcludedTerritory shall be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetTerritoryCode($index)
+    {
+        return isset($this->territoryCode[$index]);
+    }
+
+    /**
+     * unset territoryCode
+     *
+     * A Territory to which the affiliation details apply. Either this Element or ExcludedTerritory shall be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetTerritoryCode($index)
+    {
+        unset($this->territoryCode[$index]);
+    }
+
+    /**
+     * Gets as territoryCode
+     *
+     * A Territory to which the affiliation details apply. Either this Element or ExcludedTerritory shall be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return \DedexBundle\Entity\Ern42\CurrentTerritoryCodeType[]
+     */
+    public function getTerritoryCode()
+    {
+        return $this->territoryCode;
+    }
+
+    /**
+     * Sets a new territoryCode
+     *
+     * A Territory to which the affiliation details apply. Either this Element or ExcludedTerritory shall be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param \DedexBundle\Entity\Ern42\CurrentTerritoryCodeType[] $territoryCode
+     * @return self
+     */
+    public function setTerritoryCode(?array $territoryCode = null)
+    {
+        $this->territoryCode = $territoryCode;
+        return $this;
+    }
+
+    /**
+     * Adds as excludedTerritoryCode
+     *
+     * A Territory to which the affiliation details do not apply. Either this Element or Territory shall be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\CurrentTerritoryCodeType $excludedTerritoryCode
+     */
+    public function addToExcludedTerritoryCode(\DedexBundle\Entity\Ern42\CurrentTerritoryCodeType $excludedTerritoryCode)
+    {
+        $this->excludedTerritoryCode[] = $excludedTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * isset excludedTerritoryCode
+     *
+     * A Territory to which the affiliation details do not apply. Either this Element or Territory shall be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetExcludedTerritoryCode($index)
+    {
+        return isset($this->excludedTerritoryCode[$index]);
+    }
+
+    /**
+     * unset excludedTerritoryCode
+     *
+     * A Territory to which the affiliation details do not apply. Either this Element or Territory shall be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetExcludedTerritoryCode($index)
+    {
+        unset($this->excludedTerritoryCode[$index]);
+    }
+
+    /**
+     * Gets as excludedTerritoryCode
+     *
+     * A Territory to which the affiliation details do not apply. Either this Element or Territory shall be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return \DedexBundle\Entity\Ern42\CurrentTerritoryCodeType[]
+     */
+    public function getExcludedTerritoryCode()
+    {
+        return $this->excludedTerritoryCode;
+    }
+
+    /**
+     * Sets a new excludedTerritoryCode
+     *
+     * A Territory to which the affiliation details do not apply. Either this Element or Territory shall be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param \DedexBundle\Entity\Ern42\CurrentTerritoryCodeType[] $excludedTerritoryCode
+     * @return self
+     */
+    public function setExcludedTerritoryCode(?array $excludedTerritoryCode = null)
+    {
+        $this->excludedTerritoryCode = $excludedTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as validityPeriod
+     *
+     * A Composite containing details about the Period of Time for which the society affiliation is valid.
+     * Further Reading: https://kb.ddex.net/general-implementation-guidance/licensing-the-standards/ddex-party-identifier-(dpid)
+     *
+     * @return \DedexBundle\Entity\Ern42\ValidityPeriodType
+     */
+    public function getValidityPeriod()
+    {
+        return $this->validityPeriod;
+    }
+
+    /**
+     * Sets a new validityPeriod
+     *
+     * A Composite containing details about the Period of Time for which the society affiliation is valid.
+     * Further Reading: https://kb.ddex.net/general-implementation-guidance/licensing-the-standards/ddex-party-identifier-(dpid)
+     *
+     * @param \DedexBundle\Entity\Ern42\ValidityPeriodType $validityPeriod
+     * @return self
+     */
+    public function setValidityPeriod(?\DedexBundle\Entity\Ern42\ValidityPeriodType $validityPeriod = null)
+    {
+        $this->validityPeriod = $validityPeriod;
+        return $this;
+    }
+
+    /**
+     * Adds as rightsType
+     *
+     * A Composite containing details of a rights type.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\SimpleRightsTypeType $rightsType
+     */
+    public function addToRightsType(\DedexBundle\Entity\Ern42\SimpleRightsTypeType $rightsType)
+    {
+        $this->rightsType[] = $rightsType;
+        return $this;
+    }
+
+    /**
+     * isset rightsType
+     *
+     * A Composite containing details of a rights type.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRightsType($index)
+    {
+        return isset($this->rightsType[$index]);
+    }
+
+    /**
+     * unset rightsType
+     *
+     * A Composite containing details of a rights type.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRightsType($index)
+    {
+        unset($this->rightsType[$index]);
+    }
+
+    /**
+     * Gets as rightsType
+     *
+     * A Composite containing details of a rights type.
+     *
+     * @return \DedexBundle\Entity\Ern42\SimpleRightsTypeType[]
+     */
+    public function getRightsType()
+    {
+        return $this->rightsType;
+    }
+
+    /**
+     * Sets a new rightsType
+     *
+     * A Composite containing details of a rights type.
+     *
+     * @param \DedexBundle\Entity\Ern42\SimpleRightsTypeType[] $rightsType
+     * @return self
+     */
+    public function setRightsType(?array $rightsType = null)
+    {
+        $this->rightsType = $rightsType;
+        return $this;
+    }
+
+    /**
+     * Gets as percentageOfRightsAssignment
+     *
+     * Percentage of the specific Right that is represented by the society. A quarter share is represented by '25' (and not 0.25).
+     *
+     * @return float
+     */
+    public function getPercentageOfRightsAssignment()
+    {
+        return $this->percentageOfRightsAssignment;
+    }
+
+    /**
+     * Sets a new percentageOfRightsAssignment
+     *
+     * Percentage of the specific Right that is represented by the society. A quarter share is represented by '25' (and not 0.25).
+     *
+     * @param float $percentageOfRightsAssignment
+     * @return self
+     */
+    public function setPercentageOfRightsAssignment($percentageOfRightsAssignment)
+    {
+        $this->percentageOfRightsAssignment = $percentageOfRightsAssignment;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/AllTerritoryCodeType.php
+++ b/src/Entity/Ern42/AllTerritoryCodeType.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing AllTerritoryCodeType
+ *
+ * A Composite containing details of a TerritoryCode.
+ * XSD Type: AllTerritoryCode
+ */
+class AllTerritoryCodeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * A standard used for the TerritoryCode. This is represented in an XML schema as an XML Attribute. If this Attribute is not provided, it is assumed that the code is a TerritoryCode in accordance with ISO 3166-1 or 3166-2 standard (or Worldwide).
+     *
+     * @var string $identifierType
+     */
+    private $identifierType = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as identifierType
+     *
+     * A standard used for the TerritoryCode. This is represented in an XML schema as an XML Attribute. If this Attribute is not provided, it is assumed that the code is a TerritoryCode in accordance with ISO 3166-1 or 3166-2 standard (or Worldwide).
+     *
+     * @return string
+     */
+    public function getIdentifierType()
+    {
+        return $this->identifierType;
+    }
+
+    /**
+     * Sets a new identifierType
+     *
+     * A standard used for the TerritoryCode. This is represented in an XML schema as an XML Attribute. If this Attribute is not provided, it is assumed that the code is a TerritoryCode in accordance with ISO 3166-1 or 3166-2 standard (or Worldwide).
+     *
+     * @param string $identifierType
+     * @return self
+     */
+    public function setIdentifierType($identifierType)
+    {
+        $this->identifierType = $identifierType;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/AspectRatioType.php
+++ b/src/Entity/Ern42/AspectRatioType.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing AspectRatioType
+ *
+ * A Composite containing an AspectRatio and an AspectRatioType.
+ * XSD Type: AspectRatio
+ */
+class AspectRatioType
+{
+    /**
+     * @var float $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Type of the AspectRatio. This is represented in an XML schema as an XML Attribute. If this Attribute is not provided, it is assumed that the AspectRatio is a PixelAspectRatio.
+     *
+     * @var string $aspectRatioType
+     */
+    private $aspectRatioType = null;
+
+    /**
+     * Construct
+     *
+     * @param float $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param float $value
+     * @return float
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as aspectRatioType
+     *
+     * The Type of the AspectRatio. This is represented in an XML schema as an XML Attribute. If this Attribute is not provided, it is assumed that the AspectRatio is a PixelAspectRatio.
+     *
+     * @return string
+     */
+    public function getAspectRatioType()
+    {
+        return $this->aspectRatioType;
+    }
+
+    /**
+     * Sets a new aspectRatioType
+     *
+     * The Type of the AspectRatio. This is represented in an XML schema as an XML Attribute. If this Attribute is not provided, it is assumed that the AspectRatio is a PixelAspectRatio.
+     *
+     * @param string $aspectRatioType
+     * @return self
+     */
+    public function setAspectRatioType($aspectRatioType)
+    {
+        $this->aspectRatioType = $aspectRatioType;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/AudioCodecTypeType.php
+++ b/src/Entity/Ern42/AudioCodecTypeType.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing AudioCodecTypeType
+ *
+ * A Composite containing details of an AudioCodecType.
+ * XSD Type: AudioCodecType
+ */
+class AudioCodecTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Identifier of the Version of the AudioCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $version
+     */
+    private $version = null;
+
+    /**
+     * The Namespace of the AudioCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the AudioCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as version
+     *
+     * The Identifier of the Version of the AudioCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getVersion()
+    {
+        return $this->version;
+    }
+
+    /**
+     * Sets a new version
+     *
+     * The Identifier of the Version of the AudioCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $version
+     * @return self
+     */
+    public function setVersion($version)
+    {
+        $this->version = $version;
+        return $this;
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the AudioCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the AudioCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the AudioCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the AudioCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/AvRatingType.php
+++ b/src/Entity/Ern42/AvRatingType.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing AvRatingType
+ *
+ * A Composite containing details of a rating for an audio-visual Creation.
+ * XSD Type: AvRating
+ */
+class AvRatingType
+{
+    /**
+     * A Territory to which the AvRating applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * The text of the AvRating.
+     *
+     * @var string $rating
+     */
+    private $rating = null;
+
+    /**
+     * A Composite containing details of an Organization that issues the AvRating.
+     *
+     * @var \DedexBundle\Entity\Ern42\RatingAgencyType $agency
+     */
+    private $agency = null;
+
+    /**
+     * A Composite containing details of a Reason for a rating being applied.
+     *
+     * @var \DedexBundle\Entity\Ern42\RatingReasonType $reason
+     */
+    private $reason = null;
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the AvRating applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the AvRating applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+
+    /**
+     * Gets as rating
+     *
+     * The text of the AvRating.
+     *
+     * @return string
+     */
+    public function getRating()
+    {
+        return $this->rating;
+    }
+
+    /**
+     * Sets a new rating
+     *
+     * The text of the AvRating.
+     *
+     * @param string $rating
+     * @return self
+     */
+    public function setRating($rating)
+    {
+        $this->rating = $rating;
+        return $this;
+    }
+
+    /**
+     * Gets as agency
+     *
+     * A Composite containing details of an Organization that issues the AvRating.
+     *
+     * @return \DedexBundle\Entity\Ern42\RatingAgencyType
+     */
+    public function getAgency()
+    {
+        return $this->agency;
+    }
+
+    /**
+     * Sets a new agency
+     *
+     * A Composite containing details of an Organization that issues the AvRating.
+     *
+     * @param \DedexBundle\Entity\Ern42\RatingAgencyType $agency
+     * @return self
+     */
+    public function setAgency(\DedexBundle\Entity\Ern42\RatingAgencyType $agency)
+    {
+        $this->agency = $agency;
+        return $this;
+    }
+
+    /**
+     * Gets as reason
+     *
+     * A Composite containing details of a Reason for a rating being applied.
+     *
+     * @return \DedexBundle\Entity\Ern42\RatingReasonType
+     */
+    public function getReason()
+    {
+        return $this->reason;
+    }
+
+    /**
+     * Sets a new reason
+     *
+     * A Composite containing details of a Reason for a rating being applied.
+     *
+     * @param \DedexBundle\Entity\Ern42\RatingReasonType $reason
+     * @return self
+     */
+    public function setReason(?\DedexBundle\Entity\Ern42\RatingReasonType $reason = null)
+    {
+        $this->reason = $reason;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/BitRateType.php
+++ b/src/Entity/Ern42/BitRateType.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing BitRateType
+ *
+ * A Composite containing a BitRate and a UnitOfMeasure.
+ * XSD Type: BitRate
+ */
+class BitRateType
+{
+    /**
+     * @var float $__value
+     */
+    private $__value = null;
+
+    /**
+     * The UnitOfMeasure of the BitRate. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $unitOfMeasure
+     */
+    private $unitOfMeasure = null;
+
+    /**
+     * Construct
+     *
+     * @param float $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param float $value
+     * @return float
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as unitOfMeasure
+     *
+     * The UnitOfMeasure of the BitRate. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUnitOfMeasure()
+    {
+        return $this->unitOfMeasure;
+    }
+
+    /**
+     * Sets a new unitOfMeasure
+     *
+     * The UnitOfMeasure of the BitRate. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $unitOfMeasure
+     * @return self
+     */
+    public function setUnitOfMeasure($unitOfMeasure)
+    {
+        $this->unitOfMeasure = $unitOfMeasure;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/CLineType.php
+++ b/src/Entity/Ern42/CLineType.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing CLineType
+ *
+ * A Composite containing details of a CLine.
+ * XSD Type: CLine
+ */
+class CLineType
+{
+    /**
+     * The Language and script of the CLineText as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * The Year of the CLine.
+     *
+     * @var int $year
+     */
+    private $year = null;
+
+    /**
+     * The Name of the company releasing the Creation. This may be an owner or a Licensee of the Creation.
+     *
+     * @var string $cLineCompany
+     */
+    private $cLineCompany = null;
+
+    /**
+     * The text of the CLine.
+     *
+     * @var string $cLineText
+     */
+    private $cLineText = null;
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script of the CLineText as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script of the CLineText as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as year
+     *
+     * The Year of the CLine.
+     *
+     * @return int
+     */
+    public function getYear()
+    {
+        return $this->year;
+    }
+
+    /**
+     * Sets a new year
+     *
+     * The Year of the CLine.
+     *
+     * @param int $year
+     * @return self
+     */
+    public function setYear($year)
+    {
+        $this->year = $year;
+        return $this;
+    }
+
+    /**
+     * Gets as cLineCompany
+     *
+     * The Name of the company releasing the Creation. This may be an owner or a Licensee of the Creation.
+     *
+     * @return string
+     */
+    public function getCLineCompany()
+    {
+        return $this->cLineCompany;
+    }
+
+    /**
+     * Sets a new cLineCompany
+     *
+     * The Name of the company releasing the Creation. This may be an owner or a Licensee of the Creation.
+     *
+     * @param string $cLineCompany
+     * @return self
+     */
+    public function setCLineCompany($cLineCompany)
+    {
+        $this->cLineCompany = $cLineCompany;
+        return $this;
+    }
+
+    /**
+     * Gets as cLineText
+     *
+     * The text of the CLine.
+     *
+     * @return string
+     */
+    public function getCLineText()
+    {
+        return $this->cLineText;
+    }
+
+    /**
+     * Sets a new cLineText
+     *
+     * The text of the CLine.
+     *
+     * @param string $cLineText
+     * @return self
+     */
+    public function setCLineText($cLineText)
+    {
+        $this->cLineText = $cLineText;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/CLineWithDefaultType.php
+++ b/src/Entity/Ern42/CLineWithDefaultType.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing CLineWithDefaultType
+ *
+ * A Composite containing details of a CLine.
+ * Explanatory Note: This Composite is named CLineWithDefault to disambiguate it from the basic CLine Composite.
+ * XSD Type: CLineWithDefault
+ */
+class CLineWithDefaultType
+{
+    /**
+     * A Territory to which the CLine applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * The Language and script of the CLineText as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * The Year of the CLine.
+     *
+     * @var int $year
+     */
+    private $year = null;
+
+    /**
+     * The Name of the company releasing the Creation. This may be an owner or a Licensee of the Creation.
+     *
+     * @var string $cLineCompany
+     */
+    private $cLineCompany = null;
+
+    /**
+     * The text of the CLine.
+     *
+     * @var string $cLineText
+     */
+    private $cLineText = null;
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the CLine applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the CLine applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script of the CLineText as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script of the CLineText as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as year
+     *
+     * The Year of the CLine.
+     *
+     * @return int
+     */
+    public function getYear()
+    {
+        return $this->year;
+    }
+
+    /**
+     * Sets a new year
+     *
+     * The Year of the CLine.
+     *
+     * @param int $year
+     * @return self
+     */
+    public function setYear($year)
+    {
+        $this->year = $year;
+        return $this;
+    }
+
+    /**
+     * Gets as cLineCompany
+     *
+     * The Name of the company releasing the Creation. This may be an owner or a Licensee of the Creation.
+     *
+     * @return string
+     */
+    public function getCLineCompany()
+    {
+        return $this->cLineCompany;
+    }
+
+    /**
+     * Sets a new cLineCompany
+     *
+     * The Name of the company releasing the Creation. This may be an owner or a Licensee of the Creation.
+     *
+     * @param string $cLineCompany
+     * @return self
+     */
+    public function setCLineCompany($cLineCompany)
+    {
+        $this->cLineCompany = $cLineCompany;
+        return $this;
+    }
+
+    /**
+     * Gets as cLineText
+     *
+     * The text of the CLine.
+     *
+     * @return string
+     */
+    public function getCLineText()
+    {
+        return $this->cLineText;
+    }
+
+    /**
+     * Sets a new cLineText
+     *
+     * The text of the CLine.
+     *
+     * @param string $cLineText
+     * @return self
+     */
+    public function setCLineText($cLineText)
+    {
+        $this->cLineText = $cLineText;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/CarrierTypeType.php
+++ b/src/Entity/Ern42/CarrierTypeType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing CarrierTypeType
+ *
+ * A Composite containing details of a CarrierType.
+ * XSD Type: CarrierType
+ */
+class CarrierTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the CarrierType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the CarrierType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the CarrierType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the CarrierType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the CarrierType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the CarrierType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/CatalogNumberType.php
+++ b/src/Entity/Ern42/CatalogNumberType.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing CatalogNumberType
+ *
+ * A Composite containing details of a CatalogNumber.
+ * XSD Type: CatalogNumber
+ */
+class CatalogNumberType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the CatalogNumber. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the CatalogNumber. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the CatalogNumber. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ChapterListType.php
+++ b/src/Entity/Ern42/ChapterListType.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ChapterListType
+ *
+ * A Composite containing details of one or more Chapters.
+ * XSD Type: ChapterList
+ */
+class ChapterListType
+{
+    /**
+     * The Language and script for the Elements of the ChapterList as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * A Composite containing details of a Chapter contained in a Resource.
+     *
+     * @var \DedexBundle\Entity\Ern42\ChapterType[] $chapter
+     */
+    private $chapter = [
+        
+    ];
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the Elements of the ChapterList as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the Elements of the ChapterList as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Adds as chapter
+     *
+     * A Composite containing details of a Chapter contained in a Resource.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ChapterType $chapter
+     */
+    public function addToChapter(\DedexBundle\Entity\Ern42\ChapterType $chapter)
+    {
+        $this->chapter[] = $chapter;
+        return $this;
+    }
+
+    /**
+     * isset chapter
+     *
+     * A Composite containing details of a Chapter contained in a Resource.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetChapter($index)
+    {
+        return isset($this->chapter[$index]);
+    }
+
+    /**
+     * unset chapter
+     *
+     * A Composite containing details of a Chapter contained in a Resource.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetChapter($index)
+    {
+        unset($this->chapter[$index]);
+    }
+
+    /**
+     * Gets as chapter
+     *
+     * A Composite containing details of a Chapter contained in a Resource.
+     *
+     * @return \DedexBundle\Entity\Ern42\ChapterType[]
+     */
+    public function getChapter()
+    {
+        return $this->chapter;
+    }
+
+    /**
+     * Sets a new chapter
+     *
+     * A Composite containing details of a Chapter contained in a Resource.
+     *
+     * @param \DedexBundle\Entity\Ern42\ChapterType[] $chapter
+     * @return self
+     */
+    public function setChapter(array $chapter)
+    {
+        $this->chapter = $chapter;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ChapterType.php
+++ b/src/Entity/Ern42/ChapterType.php
@@ -1,0 +1,700 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ChapterType
+ *
+ * A Composite containing details of a Chapter. Chapters referenced from Video Resources are of ChapterType VideoChapter. Chapters referenced from a Release composite are of ChapterType Series, Season or Episode.
+ * XSD Type: Chapter
+ */
+class ChapterType
+{
+    /**
+     * The Language and script for the Elements of the Collection as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * The Identifier (specific to the Message) of the Chapter within the Release which contains it. This is a LocalCollectionAnchor starting with the letter X.
+     *
+     * @var string $chapterReference
+     */
+    private $chapterReference = null;
+
+    /**
+     * A Composite containing details of an Identifier of the Chapter.
+     *
+     * @var \DedexBundle\Entity\Ern42\ProprietaryIdType[] $chapterId
+     */
+    private $chapterId = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Title of the Chapter as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayTitleTextType[] $displayTitleText
+     */
+    private $displayTitleText = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Title of the Chapter as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayTitleType[] $displayTitle
+     */
+    private $displayTitle = [
+        
+    ];
+
+    /**
+     * A Composite containing details of an AdditionalTitle of the Chapter. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @var \DedexBundle\Entity\Ern42\AdditionalTitleType[] $additionalTitle
+     */
+    private $additionalTitle = [
+        
+    ];
+
+    /**
+     * The number indicating the order of the Chapter within all Chapters at this level. The default value is 1, and the value must be incremented by 1 for each Chapter occurring at a particular level.
+     *
+     * @var int $sequenceNumber
+     */
+    private $sequenceNumber = null;
+
+    /**
+     * A Composite containing details of a Contributor to the Chapter. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @var \DedexBundle\Entity\Ern42\ContributorType[] $contributor
+     */
+    private $contributor = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Character in the Chapter. A Character may be described through Name, Identifier and Roles. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @var \DedexBundle\Entity\Ern42\CharacterType[] $character
+     */
+    private $character = [
+        
+    ];
+
+    /**
+     * A Reference for an Image (specific to this Message). This is a LocalResourceAnchorReference starting with the letter A.
+     *
+     * @var string $representativeImageReference
+     */
+    private $representativeImageReference = null;
+
+    /**
+     * The start time of the Chapter, measured from the start of the Resource that contains it (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @var \DateInterval $startTime
+     */
+    private $startTime = null;
+
+    /**
+     * The Duration of the use of the Chapter (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @var \DateInterval $duration
+     */
+    private $duration = null;
+
+    /**
+     * The end time of the Chapter, measured from the start of the Resource that contains it (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @var \DateInterval $endTime
+     */
+    private $endTime = null;
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the Elements of the Collection as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the Elements of the Collection as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as chapterReference
+     *
+     * The Identifier (specific to the Message) of the Chapter within the Release which contains it. This is a LocalCollectionAnchor starting with the letter X.
+     *
+     * @return string
+     */
+    public function getChapterReference()
+    {
+        return $this->chapterReference;
+    }
+
+    /**
+     * Sets a new chapterReference
+     *
+     * The Identifier (specific to the Message) of the Chapter within the Release which contains it. This is a LocalCollectionAnchor starting with the letter X.
+     *
+     * @param string $chapterReference
+     * @return self
+     */
+    public function setChapterReference($chapterReference)
+    {
+        $this->chapterReference = $chapterReference;
+        return $this;
+    }
+
+    /**
+     * Adds as chapterId
+     *
+     * A Composite containing details of an Identifier of the Chapter.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ProprietaryIdType $chapterId
+     */
+    public function addToChapterId(\DedexBundle\Entity\Ern42\ProprietaryIdType $chapterId)
+    {
+        $this->chapterId[] = $chapterId;
+        return $this;
+    }
+
+    /**
+     * isset chapterId
+     *
+     * A Composite containing details of an Identifier of the Chapter.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetChapterId($index)
+    {
+        return isset($this->chapterId[$index]);
+    }
+
+    /**
+     * unset chapterId
+     *
+     * A Composite containing details of an Identifier of the Chapter.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetChapterId($index)
+    {
+        unset($this->chapterId[$index]);
+    }
+
+    /**
+     * Gets as chapterId
+     *
+     * A Composite containing details of an Identifier of the Chapter.
+     *
+     * @return \DedexBundle\Entity\Ern42\ProprietaryIdType[]
+     */
+    public function getChapterId()
+    {
+        return $this->chapterId;
+    }
+
+    /**
+     * Sets a new chapterId
+     *
+     * A Composite containing details of an Identifier of the Chapter.
+     *
+     * @param \DedexBundle\Entity\Ern42\ProprietaryIdType[] $chapterId
+     * @return self
+     */
+    public function setChapterId(?array $chapterId = null)
+    {
+        $this->chapterId = $chapterId;
+        return $this;
+    }
+
+    /**
+     * Adds as displayTitleText
+     *
+     * A Composite containing details of a Title of the Chapter as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleTextType $displayTitleText
+     */
+    public function addToDisplayTitleText(\DedexBundle\Entity\Ern42\DisplayTitleTextType $displayTitleText)
+    {
+        $this->displayTitleText[] = $displayTitleText;
+        return $this;
+    }
+
+    /**
+     * isset displayTitleText
+     *
+     * A Composite containing details of a Title of the Chapter as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayTitleText($index)
+    {
+        return isset($this->displayTitleText[$index]);
+    }
+
+    /**
+     * unset displayTitleText
+     *
+     * A Composite containing details of a Title of the Chapter as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayTitleText($index)
+    {
+        unset($this->displayTitleText[$index]);
+    }
+
+    /**
+     * Gets as displayTitleText
+     *
+     * A Composite containing details of a Title of the Chapter as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayTitleTextType[]
+     */
+    public function getDisplayTitleText()
+    {
+        return $this->displayTitleText;
+    }
+
+    /**
+     * Sets a new displayTitleText
+     *
+     * A Composite containing details of a Title of the Chapter as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleTextType[] $displayTitleText
+     * @return self
+     */
+    public function setDisplayTitleText(?array $displayTitleText = null)
+    {
+        $this->displayTitleText = $displayTitleText;
+        return $this;
+    }
+
+    /**
+     * Adds as displayTitle
+     *
+     * A Composite containing details of a Title of the Chapter as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleType $displayTitle
+     */
+    public function addToDisplayTitle(\DedexBundle\Entity\Ern42\DisplayTitleType $displayTitle)
+    {
+        $this->displayTitle[] = $displayTitle;
+        return $this;
+    }
+
+    /**
+     * isset displayTitle
+     *
+     * A Composite containing details of a Title of the Chapter as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayTitle($index)
+    {
+        return isset($this->displayTitle[$index]);
+    }
+
+    /**
+     * unset displayTitle
+     *
+     * A Composite containing details of a Title of the Chapter as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayTitle($index)
+    {
+        unset($this->displayTitle[$index]);
+    }
+
+    /**
+     * Gets as displayTitle
+     *
+     * A Composite containing details of a Title of the Chapter as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayTitleType[]
+     */
+    public function getDisplayTitle()
+    {
+        return $this->displayTitle;
+    }
+
+    /**
+     * Sets a new displayTitle
+     *
+     * A Composite containing details of a Title of the Chapter as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleType[] $displayTitle
+     * @return self
+     */
+    public function setDisplayTitle(?array $displayTitle = null)
+    {
+        $this->displayTitle = $displayTitle;
+        return $this;
+    }
+
+    /**
+     * Adds as additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Chapter. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\AdditionalTitleType $additionalTitle
+     */
+    public function addToAdditionalTitle(\DedexBundle\Entity\Ern42\AdditionalTitleType $additionalTitle)
+    {
+        $this->additionalTitle[] = $additionalTitle;
+        return $this;
+    }
+
+    /**
+     * isset additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Chapter. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetAdditionalTitle($index)
+    {
+        return isset($this->additionalTitle[$index]);
+    }
+
+    /**
+     * unset additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Chapter. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetAdditionalTitle($index)
+    {
+        unset($this->additionalTitle[$index]);
+    }
+
+    /**
+     * Gets as additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Chapter. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return \DedexBundle\Entity\Ern42\AdditionalTitleType[]
+     */
+    public function getAdditionalTitle()
+    {
+        return $this->additionalTitle;
+    }
+
+    /**
+     * Sets a new additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Chapter. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param \DedexBundle\Entity\Ern42\AdditionalTitleType[] $additionalTitle
+     * @return self
+     */
+    public function setAdditionalTitle(?array $additionalTitle = null)
+    {
+        $this->additionalTitle = $additionalTitle;
+        return $this;
+    }
+
+    /**
+     * Gets as sequenceNumber
+     *
+     * The number indicating the order of the Chapter within all Chapters at this level. The default value is 1, and the value must be incremented by 1 for each Chapter occurring at a particular level.
+     *
+     * @return int
+     */
+    public function getSequenceNumber()
+    {
+        return $this->sequenceNumber;
+    }
+
+    /**
+     * Sets a new sequenceNumber
+     *
+     * The number indicating the order of the Chapter within all Chapters at this level. The default value is 1, and the value must be incremented by 1 for each Chapter occurring at a particular level.
+     *
+     * @param int $sequenceNumber
+     * @return self
+     */
+    public function setSequenceNumber($sequenceNumber)
+    {
+        $this->sequenceNumber = $sequenceNumber;
+        return $this;
+    }
+
+    /**
+     * Adds as contributor
+     *
+     * A Composite containing details of a Contributor to the Chapter. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ContributorType $contributor
+     */
+    public function addToContributor(\DedexBundle\Entity\Ern42\ContributorType $contributor)
+    {
+        $this->contributor[] = $contributor;
+        return $this;
+    }
+
+    /**
+     * isset contributor
+     *
+     * A Composite containing details of a Contributor to the Chapter. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetContributor($index)
+    {
+        return isset($this->contributor[$index]);
+    }
+
+    /**
+     * unset contributor
+     *
+     * A Composite containing details of a Contributor to the Chapter. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetContributor($index)
+    {
+        unset($this->contributor[$index]);
+    }
+
+    /**
+     * Gets as contributor
+     *
+     * A Composite containing details of a Contributor to the Chapter. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return \DedexBundle\Entity\Ern42\ContributorType[]
+     */
+    public function getContributor()
+    {
+        return $this->contributor;
+    }
+
+    /**
+     * Sets a new contributor
+     *
+     * A Composite containing details of a Contributor to the Chapter. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param \DedexBundle\Entity\Ern42\ContributorType[] $contributor
+     * @return self
+     */
+    public function setContributor(?array $contributor = null)
+    {
+        $this->contributor = $contributor;
+        return $this;
+    }
+
+    /**
+     * Adds as character
+     *
+     * A Composite containing details of a Character in the Chapter. A Character may be described through Name, Identifier and Roles. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\CharacterType $character
+     */
+    public function addToCharacter(\DedexBundle\Entity\Ern42\CharacterType $character)
+    {
+        $this->character[] = $character;
+        return $this;
+    }
+
+    /**
+     * isset character
+     *
+     * A Composite containing details of a Character in the Chapter. A Character may be described through Name, Identifier and Roles. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetCharacter($index)
+    {
+        return isset($this->character[$index]);
+    }
+
+    /**
+     * unset character
+     *
+     * A Composite containing details of a Character in the Chapter. A Character may be described through Name, Identifier and Roles. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetCharacter($index)
+    {
+        unset($this->character[$index]);
+    }
+
+    /**
+     * Gets as character
+     *
+     * A Composite containing details of a Character in the Chapter. A Character may be described through Name, Identifier and Roles. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return \DedexBundle\Entity\Ern42\CharacterType[]
+     */
+    public function getCharacter()
+    {
+        return $this->character;
+    }
+
+    /**
+     * Sets a new character
+     *
+     * A Composite containing details of a Character in the Chapter. A Character may be described through Name, Identifier and Roles. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param \DedexBundle\Entity\Ern42\CharacterType[] $character
+     * @return self
+     */
+    public function setCharacter(?array $character = null)
+    {
+        $this->character = $character;
+        return $this;
+    }
+
+    /**
+     * Gets as representativeImageReference
+     *
+     * A Reference for an Image (specific to this Message). This is a LocalResourceAnchorReference starting with the letter A.
+     *
+     * @return string
+     */
+    public function getRepresentativeImageReference()
+    {
+        return $this->representativeImageReference;
+    }
+
+    /**
+     * Sets a new representativeImageReference
+     *
+     * A Reference for an Image (specific to this Message). This is a LocalResourceAnchorReference starting with the letter A.
+     *
+     * @param string $representativeImageReference
+     * @return self
+     */
+    public function setRepresentativeImageReference($representativeImageReference)
+    {
+        $this->representativeImageReference = $representativeImageReference;
+        return $this;
+    }
+
+    /**
+     * Gets as startTime
+     *
+     * The start time of the Chapter, measured from the start of the Resource that contains it (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @return \DateInterval
+     */
+    public function getStartTime()
+    {
+        return $this->startTime;
+    }
+
+    /**
+     * Sets a new startTime
+     *
+     * The start time of the Chapter, measured from the start of the Resource that contains it (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @param \DateInterval $startTime
+     * @return self
+     */
+    public function setStartTime(?\DateInterval $startTime = null)
+    {
+        $this->startTime = $startTime;
+        return $this;
+    }
+
+    /**
+     * Gets as duration
+     *
+     * The Duration of the use of the Chapter (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @return \DateInterval
+     */
+    public function getDuration()
+    {
+        return $this->duration;
+    }
+
+    /**
+     * Sets a new duration
+     *
+     * The Duration of the use of the Chapter (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @param \DateInterval $duration
+     * @return self
+     */
+    public function setDuration(?\DateInterval $duration = null)
+    {
+        $this->duration = $duration;
+        return $this;
+    }
+
+    /**
+     * Gets as endTime
+     *
+     * The end time of the Chapter, measured from the start of the Resource that contains it (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @return \DateInterval
+     */
+    public function getEndTime()
+    {
+        return $this->endTime;
+    }
+
+    /**
+     * Sets a new endTime
+     *
+     * The end time of the Chapter, measured from the start of the Resource that contains it (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @param \DateInterval $endTime
+     * @return self
+     */
+    public function setEndTime(?\DateInterval $endTime = null)
+    {
+        $this->endTime = $endTime;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/CharacterType.php
+++ b/src/Entity/Ern42/CharacterType.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing CharacterType
+ *
+ * A Composite containing details of a Character. A Character may be described through Name, Identifier and Roles.
+ * XSD Type: Character
+ */
+class CharacterType
+{
+    /**
+     * The number indicating the order of the Character in a group of Characters. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var int $sequenceNumber
+     */
+    private $sequenceNumber = null;
+
+    /**
+     * A Reference for a Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @var string $characterPartyReference
+     */
+    private $characterPartyReference = null;
+
+    /**
+     * A Composite containing details of the Name, Identifier and Role(s) of a Performer.
+     *
+     * @var \DedexBundle\Entity\Ern42\ContributorType $performer
+     */
+    private $performer = null;
+
+    /**
+     * Gets as sequenceNumber
+     *
+     * The number indicating the order of the Character in a group of Characters. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return int
+     */
+    public function getSequenceNumber()
+    {
+        return $this->sequenceNumber;
+    }
+
+    /**
+     * Sets a new sequenceNumber
+     *
+     * The number indicating the order of the Character in a group of Characters. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param int $sequenceNumber
+     * @return self
+     */
+    public function setSequenceNumber($sequenceNumber)
+    {
+        $this->sequenceNumber = $sequenceNumber;
+        return $this;
+    }
+
+    /**
+     * Gets as characterPartyReference
+     *
+     * A Reference for a Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @return string
+     */
+    public function getCharacterPartyReference()
+    {
+        return $this->characterPartyReference;
+    }
+
+    /**
+     * Sets a new characterPartyReference
+     *
+     * A Reference for a Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @param string $characterPartyReference
+     * @return self
+     */
+    public function setCharacterPartyReference($characterPartyReference)
+    {
+        $this->characterPartyReference = $characterPartyReference;
+        return $this;
+    }
+
+    /**
+     * Gets as performer
+     *
+     * A Composite containing details of the Name, Identifier and Role(s) of a Performer.
+     *
+     * @return \DedexBundle\Entity\Ern42\ContributorType
+     */
+    public function getPerformer()
+    {
+        return $this->performer;
+    }
+
+    /**
+     * Sets a new performer
+     *
+     * A Composite containing details of the Name, Identifier and Role(s) of a Performer.
+     *
+     * @param \DedexBundle\Entity\Ern42\ContributorType $performer
+     * @return self
+     */
+    public function setPerformer(?\DedexBundle\Entity\Ern42\ContributorType $performer = null)
+    {
+        $this->performer = $performer;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/CommercialModelTypeType.php
+++ b/src/Entity/Ern42/CommercialModelTypeType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing CommercialModelTypeType
+ *
+ * A Composite containing details of a CommercialModelType.
+ * XSD Type: CommercialModelType
+ */
+class CommercialModelTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the CommercialModelType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the CommercialModelType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the CommercialModelType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the CommercialModelType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the CommercialModelType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the CommercialModelType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ConditionForRightsClaimPolicyType.php
+++ b/src/Entity/Ern42/ConditionForRightsClaimPolicyType.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ConditionForRightsClaimPolicyType
+ *
+ * A Composite containing details of a Condition.
+ * Explanatory Note: This Composite is named ConditionForRightsClaimPolicy to disambiguate it from the basic mwnl:Condition Composite.
+ * XSD Type: ConditionForRightsClaimPolicy
+ */
+class ConditionForRightsClaimPolicyType
+{
+    /**
+     * The numeric value of the Condition.
+     *
+     * @var float $value
+     */
+    private $value = null;
+
+    /**
+     * A UnitOfMeasure for the condition value.
+     *
+     * @var string $unit
+     */
+    private $unit = null;
+
+    /**
+     * A Creation that is used as a reference when the unit is Percent, so it can be expressed whether the value is a percentage of the reference Resource for which rights are claimed or of a consumer's UserGeneratedContent.
+     *
+     * @var string $referenceCreation
+     */
+    private $referenceCreation = null;
+
+    /**
+     * A Relator expressing the accuracy of the condition value.
+     *
+     * @var string $relationalRelator
+     */
+    private $relationalRelator = null;
+
+    /**
+     * A Type to signal whether the Measurement should be made on the audio, the video, either or both. The absence of this element means that the terms of the contract between MessageSender and MessageRecipient rule.
+     *
+     * @var string $measurementType
+     */
+    private $measurementType = null;
+
+    /**
+     * Gets as value
+     *
+     * The numeric value of the Condition.
+     *
+     * @return float
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Sets a new value
+     *
+     * The numeric value of the Condition.
+     *
+     * @param float $value
+     * @return self
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+        return $this;
+    }
+
+    /**
+     * Gets as unit
+     *
+     * A UnitOfMeasure for the condition value.
+     *
+     * @return string
+     */
+    public function getUnit()
+    {
+        return $this->unit;
+    }
+
+    /**
+     * Sets a new unit
+     *
+     * A UnitOfMeasure for the condition value.
+     *
+     * @param string $unit
+     * @return self
+     */
+    public function setUnit($unit)
+    {
+        $this->unit = $unit;
+        return $this;
+    }
+
+    /**
+     * Gets as referenceCreation
+     *
+     * A Creation that is used as a reference when the unit is Percent, so it can be expressed whether the value is a percentage of the reference Resource for which rights are claimed or of a consumer's UserGeneratedContent.
+     *
+     * @return string
+     */
+    public function getReferenceCreation()
+    {
+        return $this->referenceCreation;
+    }
+
+    /**
+     * Sets a new referenceCreation
+     *
+     * A Creation that is used as a reference when the unit is Percent, so it can be expressed whether the value is a percentage of the reference Resource for which rights are claimed or of a consumer's UserGeneratedContent.
+     *
+     * @param string $referenceCreation
+     * @return self
+     */
+    public function setReferenceCreation($referenceCreation)
+    {
+        $this->referenceCreation = $referenceCreation;
+        return $this;
+    }
+
+    /**
+     * Gets as relationalRelator
+     *
+     * A Relator expressing the accuracy of the condition value.
+     *
+     * @return string
+     */
+    public function getRelationalRelator()
+    {
+        return $this->relationalRelator;
+    }
+
+    /**
+     * Sets a new relationalRelator
+     *
+     * A Relator expressing the accuracy of the condition value.
+     *
+     * @param string $relationalRelator
+     * @return self
+     */
+    public function setRelationalRelator($relationalRelator)
+    {
+        $this->relationalRelator = $relationalRelator;
+        return $this;
+    }
+
+    /**
+     * Gets as measurementType
+     *
+     * A Type to signal whether the Measurement should be made on the audio, the video, either or both. The absence of this element means that the terms of the contract between MessageSender and MessageRecipient rule.
+     *
+     * @return string
+     */
+    public function getMeasurementType()
+    {
+        return $this->measurementType;
+    }
+
+    /**
+     * Sets a new measurementType
+     *
+     * A Type to signal whether the Measurement should be made on the audio, the video, either or both. The absence of this element means that the terms of the contract between MessageSender and MessageRecipient rule.
+     *
+     * @param string $measurementType
+     * @return self
+     */
+    public function setMeasurementType($measurementType)
+    {
+        $this->measurementType = $measurementType;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ContainerFormatType.php
+++ b/src/Entity/Ern42/ContainerFormatType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ContainerFormatType
+ *
+ * A Composite containing details of a ContainerFormat.
+ * XSD Type: ContainerFormat
+ */
+class ContainerFormatType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the ContainerFormat. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the ContainerFormat. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the ContainerFormat. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the ContainerFormat. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the ContainerFormat. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the ContainerFormat. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ContributorRoleType.php
+++ b/src/Entity/Ern42/ContributorRoleType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ContributorRoleType
+ *
+ * A Composite containing details of a ContributorRole. Note: this can be used in a DdexMessage in relation to any Work, Performance or Fixation any of which may form the whole or part of the Resource itself.
+ * XSD Type: ContributorRole
+ */
+class ContributorRoleType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the ContributorRole. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the ContributorRole. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the ContributorRole. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the ContributorRole. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the ContributorRole. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the ContributorRole. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ContributorType.php
+++ b/src/Entity/Ern42/ContributorType.php
@@ -1,0 +1,403 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ContributorType
+ *
+ * A Composite containing details of the Name, Identifier and Role(s) of a Contributor to a Resource.
+ * XSD Type: Contributor
+ */
+class ContributorType
+{
+    /**
+     * The number indicating the order of the ResourceContributor in a group of ResourceContributors that have contributed to a Resource. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var int $sequenceNumber
+     */
+    private $sequenceNumber = null;
+
+    /**
+     * A Reference for a Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @var string $contributorPartyReference
+     */
+    private $contributorPartyReference = null;
+
+    /**
+     * A Composite containing details of a Role played by the Contributor.
+     *
+     * @var \DedexBundle\Entity\Ern42\ContributorRoleType[] $role
+     */
+    private $role = [
+        
+    ];
+
+    /**
+     * A Type of musical Instrument played by the Contributor.
+     *
+     * @var \DedexBundle\Entity\Ern42\InstrumentTypeType[] $instrumentType
+     */
+    private $instrumentType = [
+        
+    ];
+
+    /**
+     * A Flag indicating whether the Party is a featured Artist (=true) or not (=false).
+     *
+     * @var bool $hasMadeFeaturedContribution
+     */
+    private $hasMadeFeaturedContribution = null;
+
+    /**
+     * A Flag indicating whether the Party is an Artist that has a contract for its part in creating the Resource (=true) or not (=false).
+     *
+     * @var bool $hasMadeContractedContribution
+     */
+    private $hasMadeContractedContribution = null;
+
+    /**
+     * A Flag indicating whether the Contributor is credited as having played a role in creating the Recording (=true) or not (=false).
+     *
+     * @var \DedexBundle\Entity\Ern42\IsCreditedType $isCredited
+     */
+    private $isCredited = null;
+
+    /**
+     * A Role for which the Party is credited.
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayCreditsType[] $displayCredits
+     */
+    private $displayCredits = [
+        
+    ];
+
+    /**
+     * Gets as sequenceNumber
+     *
+     * The number indicating the order of the ResourceContributor in a group of ResourceContributors that have contributed to a Resource. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return int
+     */
+    public function getSequenceNumber()
+    {
+        return $this->sequenceNumber;
+    }
+
+    /**
+     * Sets a new sequenceNumber
+     *
+     * The number indicating the order of the ResourceContributor in a group of ResourceContributors that have contributed to a Resource. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param int $sequenceNumber
+     * @return self
+     */
+    public function setSequenceNumber($sequenceNumber)
+    {
+        $this->sequenceNumber = $sequenceNumber;
+        return $this;
+    }
+
+    /**
+     * Gets as contributorPartyReference
+     *
+     * A Reference for a Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @return string
+     */
+    public function getContributorPartyReference()
+    {
+        return $this->contributorPartyReference;
+    }
+
+    /**
+     * Sets a new contributorPartyReference
+     *
+     * A Reference for a Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @param string $contributorPartyReference
+     * @return self
+     */
+    public function setContributorPartyReference($contributorPartyReference)
+    {
+        $this->contributorPartyReference = $contributorPartyReference;
+        return $this;
+    }
+
+    /**
+     * Adds as role
+     *
+     * A Composite containing details of a Role played by the Contributor.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ContributorRoleType $role
+     */
+    public function addToRole(\DedexBundle\Entity\Ern42\ContributorRoleType $role)
+    {
+        $this->role[] = $role;
+        return $this;
+    }
+
+    /**
+     * isset role
+     *
+     * A Composite containing details of a Role played by the Contributor.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRole($index)
+    {
+        return isset($this->role[$index]);
+    }
+
+    /**
+     * unset role
+     *
+     * A Composite containing details of a Role played by the Contributor.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRole($index)
+    {
+        unset($this->role[$index]);
+    }
+
+    /**
+     * Gets as role
+     *
+     * A Composite containing details of a Role played by the Contributor.
+     *
+     * @return \DedexBundle\Entity\Ern42\ContributorRoleType[]
+     */
+    public function getRole()
+    {
+        return $this->role;
+    }
+
+    /**
+     * Sets a new role
+     *
+     * A Composite containing details of a Role played by the Contributor.
+     *
+     * @param \DedexBundle\Entity\Ern42\ContributorRoleType[] $role
+     * @return self
+     */
+    public function setRole(?array $role = null)
+    {
+        $this->role = $role;
+        return $this;
+    }
+
+    /**
+     * Adds as instrumentType
+     *
+     * A Type of musical Instrument played by the Contributor.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\InstrumentTypeType $instrumentType
+     */
+    public function addToInstrumentType(\DedexBundle\Entity\Ern42\InstrumentTypeType $instrumentType)
+    {
+        $this->instrumentType[] = $instrumentType;
+        return $this;
+    }
+
+    /**
+     * isset instrumentType
+     *
+     * A Type of musical Instrument played by the Contributor.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetInstrumentType($index)
+    {
+        return isset($this->instrumentType[$index]);
+    }
+
+    /**
+     * unset instrumentType
+     *
+     * A Type of musical Instrument played by the Contributor.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetInstrumentType($index)
+    {
+        unset($this->instrumentType[$index]);
+    }
+
+    /**
+     * Gets as instrumentType
+     *
+     * A Type of musical Instrument played by the Contributor.
+     *
+     * @return \DedexBundle\Entity\Ern42\InstrumentTypeType[]
+     */
+    public function getInstrumentType()
+    {
+        return $this->instrumentType;
+    }
+
+    /**
+     * Sets a new instrumentType
+     *
+     * A Type of musical Instrument played by the Contributor.
+     *
+     * @param \DedexBundle\Entity\Ern42\InstrumentTypeType[] $instrumentType
+     * @return self
+     */
+    public function setInstrumentType(?array $instrumentType = null)
+    {
+        $this->instrumentType = $instrumentType;
+        return $this;
+    }
+
+    /**
+     * Gets as hasMadeFeaturedContribution
+     *
+     * A Flag indicating whether the Party is a featured Artist (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getHasMadeFeaturedContribution()
+    {
+        return $this->hasMadeFeaturedContribution;
+    }
+
+    /**
+     * Sets a new hasMadeFeaturedContribution
+     *
+     * A Flag indicating whether the Party is a featured Artist (=true) or not (=false).
+     *
+     * @param bool $hasMadeFeaturedContribution
+     * @return self
+     */
+    public function setHasMadeFeaturedContribution($hasMadeFeaturedContribution)
+    {
+        $this->hasMadeFeaturedContribution = $hasMadeFeaturedContribution;
+        return $this;
+    }
+
+    /**
+     * Gets as hasMadeContractedContribution
+     *
+     * A Flag indicating whether the Party is an Artist that has a contract for its part in creating the Resource (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getHasMadeContractedContribution()
+    {
+        return $this->hasMadeContractedContribution;
+    }
+
+    /**
+     * Sets a new hasMadeContractedContribution
+     *
+     * A Flag indicating whether the Party is an Artist that has a contract for its part in creating the Resource (=true) or not (=false).
+     *
+     * @param bool $hasMadeContractedContribution
+     * @return self
+     */
+    public function setHasMadeContractedContribution($hasMadeContractedContribution)
+    {
+        $this->hasMadeContractedContribution = $hasMadeContractedContribution;
+        return $this;
+    }
+
+    /**
+     * Gets as isCredited
+     *
+     * A Flag indicating whether the Contributor is credited as having played a role in creating the Recording (=true) or not (=false).
+     *
+     * @return \DedexBundle\Entity\Ern42\IsCreditedType
+     */
+    public function getIsCredited()
+    {
+        return $this->isCredited;
+    }
+
+    /**
+     * Sets a new isCredited
+     *
+     * A Flag indicating whether the Contributor is credited as having played a role in creating the Recording (=true) or not (=false).
+     *
+     * @param \DedexBundle\Entity\Ern42\IsCreditedType $isCredited
+     * @return self
+     */
+    public function setIsCredited(?\DedexBundle\Entity\Ern42\IsCreditedType $isCredited = null)
+    {
+        $this->isCredited = $isCredited;
+        return $this;
+    }
+
+    /**
+     * Adds as displayCredits
+     *
+     * A Role for which the Party is credited.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayCreditsType $displayCredits
+     */
+    public function addToDisplayCredits(\DedexBundle\Entity\Ern42\DisplayCreditsType $displayCredits)
+    {
+        $this->displayCredits[] = $displayCredits;
+        return $this;
+    }
+
+    /**
+     * isset displayCredits
+     *
+     * A Role for which the Party is credited.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayCredits($index)
+    {
+        return isset($this->displayCredits[$index]);
+    }
+
+    /**
+     * unset displayCredits
+     *
+     * A Role for which the Party is credited.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayCredits($index)
+    {
+        unset($this->displayCredits[$index]);
+    }
+
+    /**
+     * Gets as displayCredits
+     *
+     * A Role for which the Party is credited.
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayCreditsType[]
+     */
+    public function getDisplayCredits()
+    {
+        return $this->displayCredits;
+    }
+
+    /**
+     * Sets a new displayCredits
+     *
+     * A Role for which the Party is credited.
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayCreditsType[] $displayCredits
+     * @return self
+     */
+    public function setDisplayCredits(?array $displayCredits = null)
+    {
+        $this->displayCredits = $displayCredits;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/CoreAreaType.php
+++ b/src/Entity/Ern42/CoreAreaType.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing CoreAreaType
+ *
+ * A Composite containing details of the core part of a Video.
+ * XSD Type: CoreArea
+ */
+class CoreAreaType
+{
+    /**
+     * The position of the top left corner of the core area measured in Pixels. The position is given as two coordinate values separated by a comma, the top left pixel being 0,0.
+     *
+     * @var string $topLeftCorner
+     */
+    private $topLeftCorner = null;
+
+    /**
+     * The position of the bottom right corner of the core area measured in Pixels. The position is given as two coordinate values separated by a comma, the top left pixel being 0,0.
+     *
+     * @var string $bottomRightCorner
+     */
+    private $bottomRightCorner = null;
+
+    /**
+     * Gets as topLeftCorner
+     *
+     * The position of the top left corner of the core area measured in Pixels. The position is given as two coordinate values separated by a comma, the top left pixel being 0,0.
+     *
+     * @return string
+     */
+    public function getTopLeftCorner()
+    {
+        return $this->topLeftCorner;
+    }
+
+    /**
+     * Sets a new topLeftCorner
+     *
+     * The position of the top left corner of the core area measured in Pixels. The position is given as two coordinate values separated by a comma, the top left pixel being 0,0.
+     *
+     * @param string $topLeftCorner
+     * @return self
+     */
+    public function setTopLeftCorner($topLeftCorner)
+    {
+        $this->topLeftCorner = $topLeftCorner;
+        return $this;
+    }
+
+    /**
+     * Gets as bottomRightCorner
+     *
+     * The position of the bottom right corner of the core area measured in Pixels. The position is given as two coordinate values separated by a comma, the top left pixel being 0,0.
+     *
+     * @return string
+     */
+    public function getBottomRightCorner()
+    {
+        return $this->bottomRightCorner;
+    }
+
+    /**
+     * Sets a new bottomRightCorner
+     *
+     * The position of the bottom right corner of the core area measured in Pixels. The position is given as two coordinate values separated by a comma, the top left pixel being 0,0.
+     *
+     * @param string $bottomRightCorner
+     * @return self
+     */
+    public function setBottomRightCorner($bottomRightCorner)
+    {
+        $this->bottomRightCorner = $bottomRightCorner;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/CourtesyLineWithDefaultType.php
+++ b/src/Entity/Ern42/CourtesyLineWithDefaultType.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing CourtesyLineWithDefaultType
+ *
+ * A Composite containing details of a CourtesyLine.
+ * Explanatory Note: This Composite is named CourtesyLineWithDefault to disambiguate it from the basic CourtesyLine Composite.
+ * XSD Type: CourtesyLineWithDefault
+ */
+class CourtesyLineWithDefaultType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Language and script of the CourtesyLine as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * A Territory to which the CourtesyLine applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script of the CourtesyLine as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script of the CourtesyLine as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the CourtesyLine applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the CourtesyLine applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/CueOriginType.php
+++ b/src/Entity/Ern42/CueOriginType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing CueOriginType
+ *
+ * A Composite containing details of a CueOrigin.
+ * XSD Type: CueOrigin
+ */
+class CueOriginType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the CueOrigin. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the CueOrigin. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the CueOrigin. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the CueOrigin. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the CueOrigin. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the CueOrigin. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/CueSheetTypeType.php
+++ b/src/Entity/Ern42/CueSheetTypeType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing CueSheetTypeType
+ *
+ * A Composite containing details of a CueSheetType.
+ * XSD Type: CueSheetType
+ */
+class CueSheetTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the CueSheetType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the CueSheetType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the CueSheetType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the CueSheetType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the CueSheetType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the CueSheetType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/CueThemeTypeType.php
+++ b/src/Entity/Ern42/CueThemeTypeType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing CueThemeTypeType
+ *
+ * A Composite containing details of a ThemeType for a Creation referenced in a Cue.
+ * XSD Type: CueThemeType
+ */
+class CueThemeTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the ThemeType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the ThemeType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the ThemeType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the ThemeType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the ThemeType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the ThemeType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/CueUseTypeType.php
+++ b/src/Entity/Ern42/CueUseTypeType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing CueUseTypeType
+ *
+ * A Composite containing details of a CueUseType.
+ * XSD Type: CueUseType
+ */
+class CueUseTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the CueUseType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the CueUseType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the CueUseType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the CueUseType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the CueUseType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the CueUseType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/CueVisualPerceptionTypeType.php
+++ b/src/Entity/Ern42/CueVisualPerceptionTypeType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing CueVisualPerceptionTypeType
+ *
+ * A Composite containing details of a VisualPerceptionType for a Creation referenced in a Cue.
+ * XSD Type: CueVisualPerceptionType
+ */
+class CueVisualPerceptionTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the VisualPerceptionType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the VisualPerceptionType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the VisualPerceptionType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the VisualPerceptionType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the VisualPerceptionType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the VisualPerceptionType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/CueVocalTypeType.php
+++ b/src/Entity/Ern42/CueVocalTypeType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing CueVocalTypeType
+ *
+ * A Composite containing details of a VocalType for a Creation referenced in a Cue.
+ * XSD Type: CueVocalType
+ */
+class CueVocalTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the VocalType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the VocalType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the VocalType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the VocalType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the VocalType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the VocalType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/CurrentTerritoryCodeType.php
+++ b/src/Entity/Ern42/CurrentTerritoryCodeType.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing CurrentTerritoryCodeType
+ *
+ * A Composite containing details of a TerritoryCode.
+ * XSD Type: CurrentTerritoryCode
+ */
+class CurrentTerritoryCodeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * A standard used for the TerritoryCode. This is represented in an XML schema as an XML Attribute. If this Attribute is not provided, it is assumed that the code is a TerritoryCode in accordance with ISO 3166-1 or 3166-2 standard (or Worldwide).
+     *
+     * @var string $identifierType
+     */
+    private $identifierType = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as identifierType
+     *
+     * A standard used for the TerritoryCode. This is represented in an XML schema as an XML Attribute. If this Attribute is not provided, it is assumed that the code is a TerritoryCode in accordance with ISO 3166-1 or 3166-2 standard (or Worldwide).
+     *
+     * @return string
+     */
+    public function getIdentifierType()
+    {
+        return $this->identifierType;
+    }
+
+    /**
+     * Sets a new identifierType
+     *
+     * A standard used for the TerritoryCode. This is represented in an XML schema as an XML Attribute. If this Attribute is not provided, it is assumed that the code is a TerritoryCode in accordance with ISO 3166-1 or 3166-2 standard (or Worldwide).
+     *
+     * @param string $identifierType
+     * @return self
+     */
+    public function setIdentifierType($identifierType)
+    {
+        $this->identifierType = $identifierType;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/DSPType.php
+++ b/src/Entity/Ern42/DSPType.php
@@ -1,0 +1,286 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing DSPType
+ *
+ * A Composite containing details of a DSP acting as a Licensee in a commercial relationship.
+ * XSD Type: DSP
+ */
+class DSPType
+{
+    /**
+     * A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.
+     *
+     * @var \DedexBundle\Entity\Ern42\DetailedPartyIdType[] $partyId
+     */
+    private $partyId = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the PartyName(s).
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers
+     *
+     * @var \DedexBundle\Entity\Ern42\PartyNameType[] $partyName
+     */
+    private $partyName = [
+        
+    ];
+
+    /**
+     * A Composite containing a TradingName of the DSP.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @var \DedexBundle\Entity\Ern42\NameType $tradingName
+     */
+    private $tradingName = null;
+
+    /**
+     * A URL for the DSP's web site.
+     *
+     * @var string[] $uRL
+     */
+    private $uRL = [
+        
+    ];
+
+    /**
+     * Adds as partyId
+     *
+     * A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DetailedPartyIdType $partyId
+     */
+    public function addToPartyId(\DedexBundle\Entity\Ern42\DetailedPartyIdType $partyId)
+    {
+        $this->partyId[] = $partyId;
+        return $this;
+    }
+
+    /**
+     * isset partyId
+     *
+     * A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetPartyId($index)
+    {
+        return isset($this->partyId[$index]);
+    }
+
+    /**
+     * unset partyId
+     *
+     * A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetPartyId($index)
+    {
+        unset($this->partyId[$index]);
+    }
+
+    /**
+     * Gets as partyId
+     *
+     * A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.
+     *
+     * @return \DedexBundle\Entity\Ern42\DetailedPartyIdType[]
+     */
+    public function getPartyId()
+    {
+        return $this->partyId;
+    }
+
+    /**
+     * Sets a new partyId
+     *
+     * A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.
+     *
+     * @param \DedexBundle\Entity\Ern42\DetailedPartyIdType[] $partyId
+     * @return self
+     */
+    public function setPartyId(?array $partyId = null)
+    {
+        $this->partyId = $partyId;
+        return $this;
+    }
+
+    /**
+     * Adds as partyName
+     *
+     * A Composite containing details of the PartyName(s).
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\PartyNameType $partyName
+     */
+    public function addToPartyName(\DedexBundle\Entity\Ern42\PartyNameType $partyName)
+    {
+        $this->partyName[] = $partyName;
+        return $this;
+    }
+
+    /**
+     * isset partyName
+     *
+     * A Composite containing details of the PartyName(s).
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetPartyName($index)
+    {
+        return isset($this->partyName[$index]);
+    }
+
+    /**
+     * unset partyName
+     *
+     * A Composite containing details of the PartyName(s).
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetPartyName($index)
+    {
+        unset($this->partyName[$index]);
+    }
+
+    /**
+     * Gets as partyName
+     *
+     * A Composite containing details of the PartyName(s).
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers
+     *
+     * @return \DedexBundle\Entity\Ern42\PartyNameType[]
+     */
+    public function getPartyName()
+    {
+        return $this->partyName;
+    }
+
+    /**
+     * Sets a new partyName
+     *
+     * A Composite containing details of the PartyName(s).
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers
+     *
+     * @param \DedexBundle\Entity\Ern42\PartyNameType[] $partyName
+     * @return self
+     */
+    public function setPartyName(?array $partyName = null)
+    {
+        $this->partyName = $partyName;
+        return $this;
+    }
+
+    /**
+     * Gets as tradingName
+     *
+     * A Composite containing a TradingName of the DSP.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return \DedexBundle\Entity\Ern42\NameType
+     */
+    public function getTradingName()
+    {
+        return $this->tradingName;
+    }
+
+    /**
+     * Sets a new tradingName
+     *
+     * A Composite containing a TradingName of the DSP.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param \DedexBundle\Entity\Ern42\NameType $tradingName
+     * @return self
+     */
+    public function setTradingName(?\DedexBundle\Entity\Ern42\NameType $tradingName = null)
+    {
+        $this->tradingName = $tradingName;
+        return $this;
+    }
+
+    /**
+     * Adds as uRL
+     *
+     * A URL for the DSP's web site.
+     *
+     * @return self
+     * @param string $uRL
+     */
+    public function addToURL($uRL)
+    {
+        $this->uRL[] = $uRL;
+        return $this;
+    }
+
+    /**
+     * isset uRL
+     *
+     * A URL for the DSP's web site.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetURL($index)
+    {
+        return isset($this->uRL[$index]);
+    }
+
+    /**
+     * unset uRL
+     *
+     * A URL for the DSP's web site.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetURL($index)
+    {
+        unset($this->uRL[$index]);
+    }
+
+    /**
+     * Gets as uRL
+     *
+     * A URL for the DSP's web site.
+     *
+     * @return string[]
+     */
+    public function getURL()
+    {
+        return $this->uRL;
+    }
+
+    /**
+     * Sets a new uRL
+     *
+     * A URL for the DSP's web site.
+     *
+     * @param string[] $uRL
+     * @return self
+     */
+    public function setURL(?array $uRL = null)
+    {
+        $this->uRL = $uRL;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/DealListType.php
+++ b/src/Entity/Ern42/DealListType.php
@@ -1,0 +1,256 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing DealListType
+ *
+ * A Composite containing details of one or more Deals.
+ * XSD Type: DealList
+ */
+class DealListType
+{
+    /**
+     * A Composite containing details of one or more Deals pertaining to one or more Releases.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/multiple-deals-for-one-release
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/newreleasemessage-with-no-deal
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/complex-deals-can-be-dangerous
+     *
+     * @var \DedexBundle\Entity\Ern42\ReleaseDealType[] $releaseDeal
+     */
+    private $releaseDeal = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a set of Dates specifying when a Release can be shown to Consumers.
+     *
+     * @var \DedexBundle\Entity\Ern42\ReleaseVisibilityType[] $releaseVisibility
+     */
+    private $releaseVisibility = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a set of Dates specifying when a TrackRelease can be shown to Consumers.
+     *
+     * @var \DedexBundle\Entity\Ern42\TrackReleaseVisibilityType[] $trackReleaseVisibility
+     */
+    private $trackReleaseVisibility = [
+        
+    ];
+
+    /**
+     * Adds as releaseDeal
+     *
+     * A Composite containing details of one or more Deals pertaining to one or more Releases.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/multiple-deals-for-one-release
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/newreleasemessage-with-no-deal
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/complex-deals-can-be-dangerous
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ReleaseDealType $releaseDeal
+     */
+    public function addToReleaseDeal(\DedexBundle\Entity\Ern42\ReleaseDealType $releaseDeal)
+    {
+        $this->releaseDeal[] = $releaseDeal;
+        return $this;
+    }
+
+    /**
+     * isset releaseDeal
+     *
+     * A Composite containing details of one or more Deals pertaining to one or more Releases.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/multiple-deals-for-one-release
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/newreleasemessage-with-no-deal
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/complex-deals-can-be-dangerous
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetReleaseDeal($index)
+    {
+        return isset($this->releaseDeal[$index]);
+    }
+
+    /**
+     * unset releaseDeal
+     *
+     * A Composite containing details of one or more Deals pertaining to one or more Releases.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/multiple-deals-for-one-release
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/newreleasemessage-with-no-deal
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/complex-deals-can-be-dangerous
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetReleaseDeal($index)
+    {
+        unset($this->releaseDeal[$index]);
+    }
+
+    /**
+     * Gets as releaseDeal
+     *
+     * A Composite containing details of one or more Deals pertaining to one or more Releases.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/multiple-deals-for-one-release
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/newreleasemessage-with-no-deal
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/complex-deals-can-be-dangerous
+     *
+     * @return \DedexBundle\Entity\Ern42\ReleaseDealType[]
+     */
+    public function getReleaseDeal()
+    {
+        return $this->releaseDeal;
+    }
+
+    /**
+     * Sets a new releaseDeal
+     *
+     * A Composite containing details of one or more Deals pertaining to one or more Releases.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/multiple-deals-for-one-release
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/newreleasemessage-with-no-deal
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/complex-deals-can-be-dangerous
+     *
+     * @param \DedexBundle\Entity\Ern42\ReleaseDealType[] $releaseDeal
+     * @return self
+     */
+    public function setReleaseDeal(array $releaseDeal)
+    {
+        $this->releaseDeal = $releaseDeal;
+        return $this;
+    }
+
+    /**
+     * Adds as releaseVisibility
+     *
+     * A Composite containing details of a set of Dates specifying when a Release can be shown to Consumers.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ReleaseVisibilityType $releaseVisibility
+     */
+    public function addToReleaseVisibility(\DedexBundle\Entity\Ern42\ReleaseVisibilityType $releaseVisibility)
+    {
+        $this->releaseVisibility[] = $releaseVisibility;
+        return $this;
+    }
+
+    /**
+     * isset releaseVisibility
+     *
+     * A Composite containing details of a set of Dates specifying when a Release can be shown to Consumers.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetReleaseVisibility($index)
+    {
+        return isset($this->releaseVisibility[$index]);
+    }
+
+    /**
+     * unset releaseVisibility
+     *
+     * A Composite containing details of a set of Dates specifying when a Release can be shown to Consumers.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetReleaseVisibility($index)
+    {
+        unset($this->releaseVisibility[$index]);
+    }
+
+    /**
+     * Gets as releaseVisibility
+     *
+     * A Composite containing details of a set of Dates specifying when a Release can be shown to Consumers.
+     *
+     * @return \DedexBundle\Entity\Ern42\ReleaseVisibilityType[]
+     */
+    public function getReleaseVisibility()
+    {
+        return $this->releaseVisibility;
+    }
+
+    /**
+     * Sets a new releaseVisibility
+     *
+     * A Composite containing details of a set of Dates specifying when a Release can be shown to Consumers.
+     *
+     * @param \DedexBundle\Entity\Ern42\ReleaseVisibilityType[] $releaseVisibility
+     * @return self
+     */
+    public function setReleaseVisibility(?array $releaseVisibility = null)
+    {
+        $this->releaseVisibility = $releaseVisibility;
+        return $this;
+    }
+
+    /**
+     * Adds as trackReleaseVisibility
+     *
+     * A Composite containing details of a set of Dates specifying when a TrackRelease can be shown to Consumers.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\TrackReleaseVisibilityType $trackReleaseVisibility
+     */
+    public function addToTrackReleaseVisibility(\DedexBundle\Entity\Ern42\TrackReleaseVisibilityType $trackReleaseVisibility)
+    {
+        $this->trackReleaseVisibility[] = $trackReleaseVisibility;
+        return $this;
+    }
+
+    /**
+     * isset trackReleaseVisibility
+     *
+     * A Composite containing details of a set of Dates specifying when a TrackRelease can be shown to Consumers.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetTrackReleaseVisibility($index)
+    {
+        return isset($this->trackReleaseVisibility[$index]);
+    }
+
+    /**
+     * unset trackReleaseVisibility
+     *
+     * A Composite containing details of a set of Dates specifying when a TrackRelease can be shown to Consumers.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetTrackReleaseVisibility($index)
+    {
+        unset($this->trackReleaseVisibility[$index]);
+    }
+
+    /**
+     * Gets as trackReleaseVisibility
+     *
+     * A Composite containing details of a set of Dates specifying when a TrackRelease can be shown to Consumers.
+     *
+     * @return \DedexBundle\Entity\Ern42\TrackReleaseVisibilityType[]
+     */
+    public function getTrackReleaseVisibility()
+    {
+        return $this->trackReleaseVisibility;
+    }
+
+    /**
+     * Sets a new trackReleaseVisibility
+     *
+     * A Composite containing details of a set of Dates specifying when a TrackRelease can be shown to Consumers.
+     *
+     * @param \DedexBundle\Entity\Ern42\TrackReleaseVisibilityType[] $trackReleaseVisibility
+     * @return self
+     */
+    public function setTrackReleaseVisibility(?array $trackReleaseVisibility = null)
+    {
+        $this->trackReleaseVisibility = $trackReleaseVisibility;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/DealResourceReferenceListType.php
+++ b/src/Entity/Ern42/DealResourceReferenceListType.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing DealResourceReferenceListType
+ *
+ * A Composite containing details of one or more Resources relating to a Deal.
+ * XSD Type: DealResourceReferenceList
+ */
+class DealResourceReferenceListType
+{
+    /**
+     * A Reference for a Resource (specific to this Message). This is a LocalResourceAnchorReference starting with the letter A.
+     *
+     * @var string[] $dealResourceReference
+     */
+    private $dealResourceReference = [
+        
+    ];
+
+    /**
+     * Adds as dealResourceReference
+     *
+     * A Reference for a Resource (specific to this Message). This is a LocalResourceAnchorReference starting with the letter A.
+     *
+     * @return self
+     * @param string $dealResourceReference
+     */
+    public function addToDealResourceReference($dealResourceReference)
+    {
+        $this->dealResourceReference[] = $dealResourceReference;
+        return $this;
+    }
+
+    /**
+     * isset dealResourceReference
+     *
+     * A Reference for a Resource (specific to this Message). This is a LocalResourceAnchorReference starting with the letter A.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDealResourceReference($index)
+    {
+        return isset($this->dealResourceReference[$index]);
+    }
+
+    /**
+     * unset dealResourceReference
+     *
+     * A Reference for a Resource (specific to this Message). This is a LocalResourceAnchorReference starting with the letter A.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDealResourceReference($index)
+    {
+        unset($this->dealResourceReference[$index]);
+    }
+
+    /**
+     * Gets as dealResourceReference
+     *
+     * A Reference for a Resource (specific to this Message). This is a LocalResourceAnchorReference starting with the letter A.
+     *
+     * @return string[]
+     */
+    public function getDealResourceReference()
+    {
+        return $this->dealResourceReference;
+    }
+
+    /**
+     * Sets a new dealResourceReference
+     *
+     * A Reference for a Resource (specific to this Message). This is a LocalResourceAnchorReference starting with the letter A.
+     *
+     * @param string $dealResourceReference
+     * @return self
+     */
+    public function setDealResourceReference(array $dealResourceReference)
+    {
+        $this->dealResourceReference = $dealResourceReference;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/DealTechnicalResourceDetailsReferenceListType.php
+++ b/src/Entity/Ern42/DealTechnicalResourceDetailsReferenceListType.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing DealTechnicalResourceDetailsReferenceListType
+ *
+ * A Composite containing a list of DealTechnicalResourceDetailsReferences.
+ * XSD Type: DealTechnicalResourceDetailsReferenceList
+ */
+class DealTechnicalResourceDetailsReferenceListType
+{
+    /**
+     * A Reference for a Composite specifying technical details of a Resource (specific to this Message). This is a LocalTechnicalResourceDetailsAnchorReference starting with the letter T.
+     *
+     * @var string[] $dealTechnicalResourceDetailsReference
+     */
+    private $dealTechnicalResourceDetailsReference = [
+        
+    ];
+
+    /**
+     * Adds as dealTechnicalResourceDetailsReference
+     *
+     * A Reference for a Composite specifying technical details of a Resource (specific to this Message). This is a LocalTechnicalResourceDetailsAnchorReference starting with the letter T.
+     *
+     * @return self
+     * @param string $dealTechnicalResourceDetailsReference
+     */
+    public function addToDealTechnicalResourceDetailsReference($dealTechnicalResourceDetailsReference)
+    {
+        $this->dealTechnicalResourceDetailsReference[] = $dealTechnicalResourceDetailsReference;
+        return $this;
+    }
+
+    /**
+     * isset dealTechnicalResourceDetailsReference
+     *
+     * A Reference for a Composite specifying technical details of a Resource (specific to this Message). This is a LocalTechnicalResourceDetailsAnchorReference starting with the letter T.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDealTechnicalResourceDetailsReference($index)
+    {
+        return isset($this->dealTechnicalResourceDetailsReference[$index]);
+    }
+
+    /**
+     * unset dealTechnicalResourceDetailsReference
+     *
+     * A Reference for a Composite specifying technical details of a Resource (specific to this Message). This is a LocalTechnicalResourceDetailsAnchorReference starting with the letter T.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDealTechnicalResourceDetailsReference($index)
+    {
+        unset($this->dealTechnicalResourceDetailsReference[$index]);
+    }
+
+    /**
+     * Gets as dealTechnicalResourceDetailsReference
+     *
+     * A Reference for a Composite specifying technical details of a Resource (specific to this Message). This is a LocalTechnicalResourceDetailsAnchorReference starting with the letter T.
+     *
+     * @return string[]
+     */
+    public function getDealTechnicalResourceDetailsReference()
+    {
+        return $this->dealTechnicalResourceDetailsReference;
+    }
+
+    /**
+     * Sets a new dealTechnicalResourceDetailsReference
+     *
+     * A Reference for a Composite specifying technical details of a Resource (specific to this Message). This is a LocalTechnicalResourceDetailsAnchorReference starting with the letter T.
+     *
+     * @param string $dealTechnicalResourceDetailsReference
+     * @return self
+     */
+    public function setDealTechnicalResourceDetailsReference(array $dealTechnicalResourceDetailsReference)
+    {
+        $this->dealTechnicalResourceDetailsReference = $dealTechnicalResourceDetailsReference;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/DealTermsTechnicalInstantiationType.php
+++ b/src/Entity/Ern42/DealTermsTechnicalInstantiationType.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing DealTermsTechnicalInstantiationType
+ *
+ * A Composite containing technical details of a Release.
+ * XSD Type: DealTermsTechnicalInstantiation
+ */
+class DealTermsTechnicalInstantiationType
+{
+    /**
+     * A Type of resolution (or definition) in which a Video is provided.
+     *
+     * @var \DedexBundle\Entity\Ern42\VideoDefinitionTypeType $videoDefinitionType
+     */
+    private $videoDefinitionType = null;
+
+    /**
+     * A Type of coding used to encode a Resource.
+     *
+     * @var string $codingType
+     */
+    private $codingType = null;
+
+    /**
+     * A Composite containing the BitRate for the audio data and a UnitOfMeasure (the default is kbps).
+     *
+     * @var \DedexBundle\Entity\Ern42\BitRateType $bitRate
+     */
+    private $bitRate = null;
+
+    /**
+     * Gets as videoDefinitionType
+     *
+     * A Type of resolution (or definition) in which a Video is provided.
+     *
+     * @return \DedexBundle\Entity\Ern42\VideoDefinitionTypeType
+     */
+    public function getVideoDefinitionType()
+    {
+        return $this->videoDefinitionType;
+    }
+
+    /**
+     * Sets a new videoDefinitionType
+     *
+     * A Type of resolution (or definition) in which a Video is provided.
+     *
+     * @param \DedexBundle\Entity\Ern42\VideoDefinitionTypeType $videoDefinitionType
+     * @return self
+     */
+    public function setVideoDefinitionType(?\DedexBundle\Entity\Ern42\VideoDefinitionTypeType $videoDefinitionType = null)
+    {
+        $this->videoDefinitionType = $videoDefinitionType;
+        return $this;
+    }
+
+    /**
+     * Gets as codingType
+     *
+     * A Type of coding used to encode a Resource.
+     *
+     * @return string
+     */
+    public function getCodingType()
+    {
+        return $this->codingType;
+    }
+
+    /**
+     * Sets a new codingType
+     *
+     * A Type of coding used to encode a Resource.
+     *
+     * @param string $codingType
+     * @return self
+     */
+    public function setCodingType($codingType)
+    {
+        $this->codingType = $codingType;
+        return $this;
+    }
+
+    /**
+     * Gets as bitRate
+     *
+     * A Composite containing the BitRate for the audio data and a UnitOfMeasure (the default is kbps).
+     *
+     * @return \DedexBundle\Entity\Ern42\BitRateType
+     */
+    public function getBitRate()
+    {
+        return $this->bitRate;
+    }
+
+    /**
+     * Sets a new bitRate
+     *
+     * A Composite containing the BitRate for the audio data and a UnitOfMeasure (the default is kbps).
+     *
+     * @param \DedexBundle\Entity\Ern42\BitRateType $bitRate
+     * @return self
+     */
+    public function setBitRate(?\DedexBundle\Entity\Ern42\BitRateType $bitRate = null)
+    {
+        $this->bitRate = $bitRate;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/DealTermsType.php
+++ b/src/Entity/Ern42/DealTermsType.php
@@ -1,0 +1,1160 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing DealTermsType
+ *
+ * A Composite containing details of the terms of a Deal.
+ * XSD Type: DealTerms
+ */
+class DealTermsType
+{
+    /**
+     * A Territory in which the Deal applies. Either this Element or ExcludedTerritory must be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var \DedexBundle\Entity\Ern42\CurrentTerritoryCodeType[] $territoryCode
+     */
+    private $territoryCode = [
+        
+    ];
+
+    /**
+     * A Territory in which the Deal does not apply. Either this Element or Territory must be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var \DedexBundle\Entity\Ern42\CurrentTerritoryCodeType[] $excludedTerritoryCode
+     */
+    private $excludedTerritoryCode = [
+        
+    ];
+
+    /**
+     * A Composite containing details about a Period of Time during which the Deal is valid. To indicate a Deal that is valid at the time of sending of a NewReleaseMessage, the MessageSender should use a StartDate or StartDateTime set in the past. No EndDate in this Composite means that the Deal is valid until further notice. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.
+     * Further Reading: https://kb.ddex.net/general-implementation-guidance/licensing-the-standards/ddex-party-identifier-(dpid)
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/start-dates%2C-end-dates%2C-start-datetimes-and-end-datetimes
+     *
+     * @var \DedexBundle\Entity\Ern42\PeriodWithStartDateType[] $validityPeriod
+     */
+    private $validityPeriod = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the fundamental business model which applies to the Deal (e.g. SubscriptionModel and PayAsYouGoModel). The CommercialModelType indicates how the Consumer pays for the Service or Release.
+     *
+     * @var \DedexBundle\Entity\Ern42\CommercialModelTypeType[] $commercialModelType
+     */
+    private $commercialModelType = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a nature of a Service, or a Release, as used by a Consumer. The UseType is mandatory unless the terms of the Deal were communicated beforehand (possibly out of band) and then referenced using a DealReference.
+     *
+     * @var \DedexBundle\Entity\Ern42\DiscoverableUseTypeType[] $useType
+     */
+    private $useType = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a physical interface by which a Consumer uses a Service or Release.
+     *
+     * @var \DedexBundle\Entity\Ern42\UserInterfaceTypeType[] $userInterfaceType
+     */
+    private $userInterfaceType = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Carrier.
+     *
+     * @var \DedexBundle\Entity\Ern42\CarrierTypeType[] $carrierType
+     */
+    private $carrierType = [
+        
+    ];
+
+    /**
+     * A Composite containing technical details of the Release.
+     *
+     * @var \DedexBundle\Entity\Ern42\DealTermsTechnicalInstantiationType $technicalInstantiation
+     */
+    private $technicalInstantiation = null;
+
+    /**
+     * The number of times a Release can be used under the terms of the Deal.
+     *
+     * @var int $numberOfUsages
+     */
+    private $numberOfUsages = null;
+
+    /**
+     * A Composite containing details of the DSP through whose DistributionChannel the sales are permitted. If none are provided no limitations on the DistributionChannels are given.
+     *
+     * @var \DedexBundle\Entity\Ern42\DSPType[] $distributionChannel
+     */
+    private $distributionChannel = [
+        
+    ];
+
+    /**
+     * A Composite containing details of excluded DSP. This is used in an aggregator model where all agreed partners of the aggregators may use a ReleaseDeal, except those that are listed herein.
+     *
+     * @var \DedexBundle\Entity\Ern42\DSPType[] $excludedDistributionChannel
+     */
+    private $excludedDistributionChannel = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a rights claim policy.
+     *
+     * @var \DedexBundle\Entity\Ern42\RightsClaimPolicyType[] $rightsClaimPolicy
+     */
+    private $rightsClaimPolicy = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Price. Note that this Price applies to all UseTypes referenced in this Composite.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/price-information
+     *
+     * @var \DedexBundle\Entity\Ern42\PriceInformationWithTypeType[] $priceInformation
+     */
+    private $priceInformation = [
+        
+    ];
+
+    /**
+     * The Flag indicating whether a special Deal is made between the Licensor and the Licensee (=true) or not (=false) regarding the royalties or payments due to be paid for Releases distributed under this Deal.
+     *
+     * @var bool $isPromotional
+     */
+    private $isPromotional = null;
+
+    /**
+     * A Composite containing details of a PromotionalCode.
+     *
+     * @var \DedexBundle\Entity\Ern42\PromotionalCodeType $promotionalCode
+     */
+    private $promotionalCode = null;
+
+    /**
+     * A Flag indicating whether the Deal is covering only the period where the Release can be purchased by a consumer but not yet fulfilled (=true) or not (=false).
+     *
+     * @var bool $isPreOrderDeal
+     */
+    private $isPreOrderDeal = null;
+
+    /**
+     * A Composite containing details of one or more Resources that are only available for download as soon as the Release is purchased (i.e. before the ReleaseDate).
+     *
+     * @var string[] $instantGratificationResourceList
+     */
+    private $instantGratificationResourceList = null;
+
+    /**
+     * A Composite containing details of physical returns.
+     *
+     * @var \DedexBundle\Entity\Ern42\PhysicalReturnsType $physicalReturns
+     */
+    private $physicalReturns = null;
+
+    /**
+     * A number of Products per carton. This is the smallest number of Products that can be ordered.
+     *
+     * @var int $numberOfProductsPerCarton
+     */
+    private $numberOfProductsPerCarton = null;
+
+    /**
+     * Adds as territoryCode
+     *
+     * A Territory in which the Deal applies. Either this Element or ExcludedTerritory must be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\CurrentTerritoryCodeType $territoryCode
+     */
+    public function addToTerritoryCode(\DedexBundle\Entity\Ern42\CurrentTerritoryCodeType $territoryCode)
+    {
+        $this->territoryCode[] = $territoryCode;
+        return $this;
+    }
+
+    /**
+     * isset territoryCode
+     *
+     * A Territory in which the Deal applies. Either this Element or ExcludedTerritory must be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetTerritoryCode($index)
+    {
+        return isset($this->territoryCode[$index]);
+    }
+
+    /**
+     * unset territoryCode
+     *
+     * A Territory in which the Deal applies. Either this Element or ExcludedTerritory must be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetTerritoryCode($index)
+    {
+        unset($this->territoryCode[$index]);
+    }
+
+    /**
+     * Gets as territoryCode
+     *
+     * A Territory in which the Deal applies. Either this Element or ExcludedTerritory must be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return \DedexBundle\Entity\Ern42\CurrentTerritoryCodeType[]
+     */
+    public function getTerritoryCode()
+    {
+        return $this->territoryCode;
+    }
+
+    /**
+     * Sets a new territoryCode
+     *
+     * A Territory in which the Deal applies. Either this Element or ExcludedTerritory must be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param \DedexBundle\Entity\Ern42\CurrentTerritoryCodeType[] $territoryCode
+     * @return self
+     */
+    public function setTerritoryCode(?array $territoryCode = null)
+    {
+        $this->territoryCode = $territoryCode;
+        return $this;
+    }
+
+    /**
+     * Adds as excludedTerritoryCode
+     *
+     * A Territory in which the Deal does not apply. Either this Element or Territory must be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\CurrentTerritoryCodeType $excludedTerritoryCode
+     */
+    public function addToExcludedTerritoryCode(\DedexBundle\Entity\Ern42\CurrentTerritoryCodeType $excludedTerritoryCode)
+    {
+        $this->excludedTerritoryCode[] = $excludedTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * isset excludedTerritoryCode
+     *
+     * A Territory in which the Deal does not apply. Either this Element or Territory must be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetExcludedTerritoryCode($index)
+    {
+        return isset($this->excludedTerritoryCode[$index]);
+    }
+
+    /**
+     * unset excludedTerritoryCode
+     *
+     * A Territory in which the Deal does not apply. Either this Element or Territory must be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetExcludedTerritoryCode($index)
+    {
+        unset($this->excludedTerritoryCode[$index]);
+    }
+
+    /**
+     * Gets as excludedTerritoryCode
+     *
+     * A Territory in which the Deal does not apply. Either this Element or Territory must be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return \DedexBundle\Entity\Ern42\CurrentTerritoryCodeType[]
+     */
+    public function getExcludedTerritoryCode()
+    {
+        return $this->excludedTerritoryCode;
+    }
+
+    /**
+     * Sets a new excludedTerritoryCode
+     *
+     * A Territory in which the Deal does not apply. Either this Element or Territory must be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param \DedexBundle\Entity\Ern42\CurrentTerritoryCodeType[] $excludedTerritoryCode
+     * @return self
+     */
+    public function setExcludedTerritoryCode(?array $excludedTerritoryCode = null)
+    {
+        $this->excludedTerritoryCode = $excludedTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Adds as validityPeriod
+     *
+     * A Composite containing details about a Period of Time during which the Deal is valid. To indicate a Deal that is valid at the time of sending of a NewReleaseMessage, the MessageSender should use a StartDate or StartDateTime set in the past. No EndDate in this Composite means that the Deal is valid until further notice. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.
+     * Further Reading: https://kb.ddex.net/general-implementation-guidance/licensing-the-standards/ddex-party-identifier-(dpid)
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/start-dates%2C-end-dates%2C-start-datetimes-and-end-datetimes
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\PeriodWithStartDateType $validityPeriod
+     */
+    public function addToValidityPeriod(\DedexBundle\Entity\Ern42\PeriodWithStartDateType $validityPeriod)
+    {
+        $this->validityPeriod[] = $validityPeriod;
+        return $this;
+    }
+
+    /**
+     * isset validityPeriod
+     *
+     * A Composite containing details about a Period of Time during which the Deal is valid. To indicate a Deal that is valid at the time of sending of a NewReleaseMessage, the MessageSender should use a StartDate or StartDateTime set in the past. No EndDate in this Composite means that the Deal is valid until further notice. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.
+     * Further Reading: https://kb.ddex.net/general-implementation-guidance/licensing-the-standards/ddex-party-identifier-(dpid)
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/start-dates%2C-end-dates%2C-start-datetimes-and-end-datetimes
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetValidityPeriod($index)
+    {
+        return isset($this->validityPeriod[$index]);
+    }
+
+    /**
+     * unset validityPeriod
+     *
+     * A Composite containing details about a Period of Time during which the Deal is valid. To indicate a Deal that is valid at the time of sending of a NewReleaseMessage, the MessageSender should use a StartDate or StartDateTime set in the past. No EndDate in this Composite means that the Deal is valid until further notice. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.
+     * Further Reading: https://kb.ddex.net/general-implementation-guidance/licensing-the-standards/ddex-party-identifier-(dpid)
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/start-dates%2C-end-dates%2C-start-datetimes-and-end-datetimes
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetValidityPeriod($index)
+    {
+        unset($this->validityPeriod[$index]);
+    }
+
+    /**
+     * Gets as validityPeriod
+     *
+     * A Composite containing details about a Period of Time during which the Deal is valid. To indicate a Deal that is valid at the time of sending of a NewReleaseMessage, the MessageSender should use a StartDate or StartDateTime set in the past. No EndDate in this Composite means that the Deal is valid until further notice. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.
+     * Further Reading: https://kb.ddex.net/general-implementation-guidance/licensing-the-standards/ddex-party-identifier-(dpid)
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/start-dates%2C-end-dates%2C-start-datetimes-and-end-datetimes
+     *
+     * @return \DedexBundle\Entity\Ern42\PeriodWithStartDateType[]
+     */
+    public function getValidityPeriod()
+    {
+        return $this->validityPeriod;
+    }
+
+    /**
+     * Sets a new validityPeriod
+     *
+     * A Composite containing details about a Period of Time during which the Deal is valid. To indicate a Deal that is valid at the time of sending of a NewReleaseMessage, the MessageSender should use a StartDate or StartDateTime set in the past. No EndDate in this Composite means that the Deal is valid until further notice. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.
+     * Further Reading: https://kb.ddex.net/general-implementation-guidance/licensing-the-standards/ddex-party-identifier-(dpid)
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/start-dates%2C-end-dates%2C-start-datetimes-and-end-datetimes
+     *
+     * @param \DedexBundle\Entity\Ern42\PeriodWithStartDateType[] $validityPeriod
+     * @return self
+     */
+    public function setValidityPeriod(array $validityPeriod)
+    {
+        $this->validityPeriod = $validityPeriod;
+        return $this;
+    }
+
+    /**
+     * Adds as commercialModelType
+     *
+     * A Composite containing details of the fundamental business model which applies to the Deal (e.g. SubscriptionModel and PayAsYouGoModel). The CommercialModelType indicates how the Consumer pays for the Service or Release.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\CommercialModelTypeType $commercialModelType
+     */
+    public function addToCommercialModelType(\DedexBundle\Entity\Ern42\CommercialModelTypeType $commercialModelType)
+    {
+        $this->commercialModelType[] = $commercialModelType;
+        return $this;
+    }
+
+    /**
+     * isset commercialModelType
+     *
+     * A Composite containing details of the fundamental business model which applies to the Deal (e.g. SubscriptionModel and PayAsYouGoModel). The CommercialModelType indicates how the Consumer pays for the Service or Release.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetCommercialModelType($index)
+    {
+        return isset($this->commercialModelType[$index]);
+    }
+
+    /**
+     * unset commercialModelType
+     *
+     * A Composite containing details of the fundamental business model which applies to the Deal (e.g. SubscriptionModel and PayAsYouGoModel). The CommercialModelType indicates how the Consumer pays for the Service or Release.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetCommercialModelType($index)
+    {
+        unset($this->commercialModelType[$index]);
+    }
+
+    /**
+     * Gets as commercialModelType
+     *
+     * A Composite containing details of the fundamental business model which applies to the Deal (e.g. SubscriptionModel and PayAsYouGoModel). The CommercialModelType indicates how the Consumer pays for the Service or Release.
+     *
+     * @return \DedexBundle\Entity\Ern42\CommercialModelTypeType[]
+     */
+    public function getCommercialModelType()
+    {
+        return $this->commercialModelType;
+    }
+
+    /**
+     * Sets a new commercialModelType
+     *
+     * A Composite containing details of the fundamental business model which applies to the Deal (e.g. SubscriptionModel and PayAsYouGoModel). The CommercialModelType indicates how the Consumer pays for the Service or Release.
+     *
+     * @param \DedexBundle\Entity\Ern42\CommercialModelTypeType[] $commercialModelType
+     * @return self
+     */
+    public function setCommercialModelType(?array $commercialModelType = null)
+    {
+        $this->commercialModelType = $commercialModelType;
+        return $this;
+    }
+
+    /**
+     * Adds as useType
+     *
+     * A Composite containing details of a nature of a Service, or a Release, as used by a Consumer. The UseType is mandatory unless the terms of the Deal were communicated beforehand (possibly out of band) and then referenced using a DealReference.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DiscoverableUseTypeType $useType
+     */
+    public function addToUseType(\DedexBundle\Entity\Ern42\DiscoverableUseTypeType $useType)
+    {
+        $this->useType[] = $useType;
+        return $this;
+    }
+
+    /**
+     * isset useType
+     *
+     * A Composite containing details of a nature of a Service, or a Release, as used by a Consumer. The UseType is mandatory unless the terms of the Deal were communicated beforehand (possibly out of band) and then referenced using a DealReference.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetUseType($index)
+    {
+        return isset($this->useType[$index]);
+    }
+
+    /**
+     * unset useType
+     *
+     * A Composite containing details of a nature of a Service, or a Release, as used by a Consumer. The UseType is mandatory unless the terms of the Deal were communicated beforehand (possibly out of band) and then referenced using a DealReference.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetUseType($index)
+    {
+        unset($this->useType[$index]);
+    }
+
+    /**
+     * Gets as useType
+     *
+     * A Composite containing details of a nature of a Service, or a Release, as used by a Consumer. The UseType is mandatory unless the terms of the Deal were communicated beforehand (possibly out of band) and then referenced using a DealReference.
+     *
+     * @return \DedexBundle\Entity\Ern42\DiscoverableUseTypeType[]
+     */
+    public function getUseType()
+    {
+        return $this->useType;
+    }
+
+    /**
+     * Sets a new useType
+     *
+     * A Composite containing details of a nature of a Service, or a Release, as used by a Consumer. The UseType is mandatory unless the terms of the Deal were communicated beforehand (possibly out of band) and then referenced using a DealReference.
+     *
+     * @param \DedexBundle\Entity\Ern42\DiscoverableUseTypeType[] $useType
+     * @return self
+     */
+    public function setUseType(?array $useType = null)
+    {
+        $this->useType = $useType;
+        return $this;
+    }
+
+    /**
+     * Adds as userInterfaceType
+     *
+     * A Composite containing details of a physical interface by which a Consumer uses a Service or Release.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\UserInterfaceTypeType $userInterfaceType
+     */
+    public function addToUserInterfaceType(\DedexBundle\Entity\Ern42\UserInterfaceTypeType $userInterfaceType)
+    {
+        $this->userInterfaceType[] = $userInterfaceType;
+        return $this;
+    }
+
+    /**
+     * isset userInterfaceType
+     *
+     * A Composite containing details of a physical interface by which a Consumer uses a Service or Release.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetUserInterfaceType($index)
+    {
+        return isset($this->userInterfaceType[$index]);
+    }
+
+    /**
+     * unset userInterfaceType
+     *
+     * A Composite containing details of a physical interface by which a Consumer uses a Service or Release.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetUserInterfaceType($index)
+    {
+        unset($this->userInterfaceType[$index]);
+    }
+
+    /**
+     * Gets as userInterfaceType
+     *
+     * A Composite containing details of a physical interface by which a Consumer uses a Service or Release.
+     *
+     * @return \DedexBundle\Entity\Ern42\UserInterfaceTypeType[]
+     */
+    public function getUserInterfaceType()
+    {
+        return $this->userInterfaceType;
+    }
+
+    /**
+     * Sets a new userInterfaceType
+     *
+     * A Composite containing details of a physical interface by which a Consumer uses a Service or Release.
+     *
+     * @param \DedexBundle\Entity\Ern42\UserInterfaceTypeType[] $userInterfaceType
+     * @return self
+     */
+    public function setUserInterfaceType(?array $userInterfaceType = null)
+    {
+        $this->userInterfaceType = $userInterfaceType;
+        return $this;
+    }
+
+    /**
+     * Adds as carrierType
+     *
+     * A Composite containing details of a Carrier.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\CarrierTypeType $carrierType
+     */
+    public function addToCarrierType(\DedexBundle\Entity\Ern42\CarrierTypeType $carrierType)
+    {
+        $this->carrierType[] = $carrierType;
+        return $this;
+    }
+
+    /**
+     * isset carrierType
+     *
+     * A Composite containing details of a Carrier.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetCarrierType($index)
+    {
+        return isset($this->carrierType[$index]);
+    }
+
+    /**
+     * unset carrierType
+     *
+     * A Composite containing details of a Carrier.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetCarrierType($index)
+    {
+        unset($this->carrierType[$index]);
+    }
+
+    /**
+     * Gets as carrierType
+     *
+     * A Composite containing details of a Carrier.
+     *
+     * @return \DedexBundle\Entity\Ern42\CarrierTypeType[]
+     */
+    public function getCarrierType()
+    {
+        return $this->carrierType;
+    }
+
+    /**
+     * Sets a new carrierType
+     *
+     * A Composite containing details of a Carrier.
+     *
+     * @param \DedexBundle\Entity\Ern42\CarrierTypeType[] $carrierType
+     * @return self
+     */
+    public function setCarrierType(?array $carrierType = null)
+    {
+        $this->carrierType = $carrierType;
+        return $this;
+    }
+
+    /**
+     * Gets as technicalInstantiation
+     *
+     * A Composite containing technical details of the Release.
+     *
+     * @return \DedexBundle\Entity\Ern42\DealTermsTechnicalInstantiationType
+     */
+    public function getTechnicalInstantiation()
+    {
+        return $this->technicalInstantiation;
+    }
+
+    /**
+     * Sets a new technicalInstantiation
+     *
+     * A Composite containing technical details of the Release.
+     *
+     * @param \DedexBundle\Entity\Ern42\DealTermsTechnicalInstantiationType $technicalInstantiation
+     * @return self
+     */
+    public function setTechnicalInstantiation(?\DedexBundle\Entity\Ern42\DealTermsTechnicalInstantiationType $technicalInstantiation = null)
+    {
+        $this->technicalInstantiation = $technicalInstantiation;
+        return $this;
+    }
+
+    /**
+     * Gets as numberOfUsages
+     *
+     * The number of times a Release can be used under the terms of the Deal.
+     *
+     * @return int
+     */
+    public function getNumberOfUsages()
+    {
+        return $this->numberOfUsages;
+    }
+
+    /**
+     * Sets a new numberOfUsages
+     *
+     * The number of times a Release can be used under the terms of the Deal.
+     *
+     * @param int $numberOfUsages
+     * @return self
+     */
+    public function setNumberOfUsages($numberOfUsages)
+    {
+        $this->numberOfUsages = $numberOfUsages;
+        return $this;
+    }
+
+    /**
+     * Adds as distributionChannel
+     *
+     * A Composite containing details of the DSP through whose DistributionChannel the sales are permitted. If none are provided no limitations on the DistributionChannels are given.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DSPType $distributionChannel
+     */
+    public function addToDistributionChannel(\DedexBundle\Entity\Ern42\DSPType $distributionChannel)
+    {
+        $this->distributionChannel[] = $distributionChannel;
+        return $this;
+    }
+
+    /**
+     * isset distributionChannel
+     *
+     * A Composite containing details of the DSP through whose DistributionChannel the sales are permitted. If none are provided no limitations on the DistributionChannels are given.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDistributionChannel($index)
+    {
+        return isset($this->distributionChannel[$index]);
+    }
+
+    /**
+     * unset distributionChannel
+     *
+     * A Composite containing details of the DSP through whose DistributionChannel the sales are permitted. If none are provided no limitations on the DistributionChannels are given.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDistributionChannel($index)
+    {
+        unset($this->distributionChannel[$index]);
+    }
+
+    /**
+     * Gets as distributionChannel
+     *
+     * A Composite containing details of the DSP through whose DistributionChannel the sales are permitted. If none are provided no limitations on the DistributionChannels are given.
+     *
+     * @return \DedexBundle\Entity\Ern42\DSPType[]
+     */
+    public function getDistributionChannel()
+    {
+        return $this->distributionChannel;
+    }
+
+    /**
+     * Sets a new distributionChannel
+     *
+     * A Composite containing details of the DSP through whose DistributionChannel the sales are permitted. If none are provided no limitations on the DistributionChannels are given.
+     *
+     * @param \DedexBundle\Entity\Ern42\DSPType[] $distributionChannel
+     * @return self
+     */
+    public function setDistributionChannel(?array $distributionChannel = null)
+    {
+        $this->distributionChannel = $distributionChannel;
+        return $this;
+    }
+
+    /**
+     * Adds as excludedDistributionChannel
+     *
+     * A Composite containing details of excluded DSP. This is used in an aggregator model where all agreed partners of the aggregators may use a ReleaseDeal, except those that are listed herein.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DSPType $excludedDistributionChannel
+     */
+    public function addToExcludedDistributionChannel(\DedexBundle\Entity\Ern42\DSPType $excludedDistributionChannel)
+    {
+        $this->excludedDistributionChannel[] = $excludedDistributionChannel;
+        return $this;
+    }
+
+    /**
+     * isset excludedDistributionChannel
+     *
+     * A Composite containing details of excluded DSP. This is used in an aggregator model where all agreed partners of the aggregators may use a ReleaseDeal, except those that are listed herein.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetExcludedDistributionChannel($index)
+    {
+        return isset($this->excludedDistributionChannel[$index]);
+    }
+
+    /**
+     * unset excludedDistributionChannel
+     *
+     * A Composite containing details of excluded DSP. This is used in an aggregator model where all agreed partners of the aggregators may use a ReleaseDeal, except those that are listed herein.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetExcludedDistributionChannel($index)
+    {
+        unset($this->excludedDistributionChannel[$index]);
+    }
+
+    /**
+     * Gets as excludedDistributionChannel
+     *
+     * A Composite containing details of excluded DSP. This is used in an aggregator model where all agreed partners of the aggregators may use a ReleaseDeal, except those that are listed herein.
+     *
+     * @return \DedexBundle\Entity\Ern42\DSPType[]
+     */
+    public function getExcludedDistributionChannel()
+    {
+        return $this->excludedDistributionChannel;
+    }
+
+    /**
+     * Sets a new excludedDistributionChannel
+     *
+     * A Composite containing details of excluded DSP. This is used in an aggregator model where all agreed partners of the aggregators may use a ReleaseDeal, except those that are listed herein.
+     *
+     * @param \DedexBundle\Entity\Ern42\DSPType[] $excludedDistributionChannel
+     * @return self
+     */
+    public function setExcludedDistributionChannel(?array $excludedDistributionChannel = null)
+    {
+        $this->excludedDistributionChannel = $excludedDistributionChannel;
+        return $this;
+    }
+
+    /**
+     * Adds as rightsClaimPolicy
+     *
+     * A Composite containing details of a rights claim policy.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\RightsClaimPolicyType $rightsClaimPolicy
+     */
+    public function addToRightsClaimPolicy(\DedexBundle\Entity\Ern42\RightsClaimPolicyType $rightsClaimPolicy)
+    {
+        $this->rightsClaimPolicy[] = $rightsClaimPolicy;
+        return $this;
+    }
+
+    /**
+     * isset rightsClaimPolicy
+     *
+     * A Composite containing details of a rights claim policy.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRightsClaimPolicy($index)
+    {
+        return isset($this->rightsClaimPolicy[$index]);
+    }
+
+    /**
+     * unset rightsClaimPolicy
+     *
+     * A Composite containing details of a rights claim policy.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRightsClaimPolicy($index)
+    {
+        unset($this->rightsClaimPolicy[$index]);
+    }
+
+    /**
+     * Gets as rightsClaimPolicy
+     *
+     * A Composite containing details of a rights claim policy.
+     *
+     * @return \DedexBundle\Entity\Ern42\RightsClaimPolicyType[]
+     */
+    public function getRightsClaimPolicy()
+    {
+        return $this->rightsClaimPolicy;
+    }
+
+    /**
+     * Sets a new rightsClaimPolicy
+     *
+     * A Composite containing details of a rights claim policy.
+     *
+     * @param \DedexBundle\Entity\Ern42\RightsClaimPolicyType[] $rightsClaimPolicy
+     * @return self
+     */
+    public function setRightsClaimPolicy(?array $rightsClaimPolicy = null)
+    {
+        $this->rightsClaimPolicy = $rightsClaimPolicy;
+        return $this;
+    }
+
+    /**
+     * Adds as priceInformation
+     *
+     * A Composite containing details of a Price. Note that this Price applies to all UseTypes referenced in this Composite.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/price-information
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\PriceInformationWithTypeType $priceInformation
+     */
+    public function addToPriceInformation(\DedexBundle\Entity\Ern42\PriceInformationWithTypeType $priceInformation)
+    {
+        $this->priceInformation[] = $priceInformation;
+        return $this;
+    }
+
+    /**
+     * isset priceInformation
+     *
+     * A Composite containing details of a Price. Note that this Price applies to all UseTypes referenced in this Composite.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/price-information
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetPriceInformation($index)
+    {
+        return isset($this->priceInformation[$index]);
+    }
+
+    /**
+     * unset priceInformation
+     *
+     * A Composite containing details of a Price. Note that this Price applies to all UseTypes referenced in this Composite.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/price-information
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetPriceInformation($index)
+    {
+        unset($this->priceInformation[$index]);
+    }
+
+    /**
+     * Gets as priceInformation
+     *
+     * A Composite containing details of a Price. Note that this Price applies to all UseTypes referenced in this Composite.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/price-information
+     *
+     * @return \DedexBundle\Entity\Ern42\PriceInformationWithTypeType[]
+     */
+    public function getPriceInformation()
+    {
+        return $this->priceInformation;
+    }
+
+    /**
+     * Sets a new priceInformation
+     *
+     * A Composite containing details of a Price. Note that this Price applies to all UseTypes referenced in this Composite.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/price-information
+     *
+     * @param \DedexBundle\Entity\Ern42\PriceInformationWithTypeType[] $priceInformation
+     * @return self
+     */
+    public function setPriceInformation(?array $priceInformation = null)
+    {
+        $this->priceInformation = $priceInformation;
+        return $this;
+    }
+
+    /**
+     * Gets as isPromotional
+     *
+     * The Flag indicating whether a special Deal is made between the Licensor and the Licensee (=true) or not (=false) regarding the royalties or payments due to be paid for Releases distributed under this Deal.
+     *
+     * @return bool
+     */
+    public function getIsPromotional()
+    {
+        return $this->isPromotional;
+    }
+
+    /**
+     * Sets a new isPromotional
+     *
+     * The Flag indicating whether a special Deal is made between the Licensor and the Licensee (=true) or not (=false) regarding the royalties or payments due to be paid for Releases distributed under this Deal.
+     *
+     * @param bool $isPromotional
+     * @return self
+     */
+    public function setIsPromotional($isPromotional)
+    {
+        $this->isPromotional = $isPromotional;
+        return $this;
+    }
+
+    /**
+     * Gets as promotionalCode
+     *
+     * A Composite containing details of a PromotionalCode.
+     *
+     * @return \DedexBundle\Entity\Ern42\PromotionalCodeType
+     */
+    public function getPromotionalCode()
+    {
+        return $this->promotionalCode;
+    }
+
+    /**
+     * Sets a new promotionalCode
+     *
+     * A Composite containing details of a PromotionalCode.
+     *
+     * @param \DedexBundle\Entity\Ern42\PromotionalCodeType $promotionalCode
+     * @return self
+     */
+    public function setPromotionalCode(?\DedexBundle\Entity\Ern42\PromotionalCodeType $promotionalCode = null)
+    {
+        $this->promotionalCode = $promotionalCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isPreOrderDeal
+     *
+     * A Flag indicating whether the Deal is covering only the period where the Release can be purchased by a consumer but not yet fulfilled (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getIsPreOrderDeal()
+    {
+        return $this->isPreOrderDeal;
+    }
+
+    /**
+     * Sets a new isPreOrderDeal
+     *
+     * A Flag indicating whether the Deal is covering only the period where the Release can be purchased by a consumer but not yet fulfilled (=true) or not (=false).
+     *
+     * @param bool $isPreOrderDeal
+     * @return self
+     */
+    public function setIsPreOrderDeal($isPreOrderDeal)
+    {
+        $this->isPreOrderDeal = $isPreOrderDeal;
+        return $this;
+    }
+
+    /**
+     * Adds as dealResourceReference
+     *
+     * A Composite containing details of one or more Resources that are only available for download as soon as the Release is purchased (i.e. before the ReleaseDate).
+     *
+     * @return self
+     * @param string $dealResourceReference
+     */
+    public function addToInstantGratificationResourceList($dealResourceReference)
+    {
+        $this->instantGratificationResourceList[] = $dealResourceReference;
+        return $this;
+    }
+
+    /**
+     * isset instantGratificationResourceList
+     *
+     * A Composite containing details of one or more Resources that are only available for download as soon as the Release is purchased (i.e. before the ReleaseDate).
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetInstantGratificationResourceList($index)
+    {
+        return isset($this->instantGratificationResourceList[$index]);
+    }
+
+    /**
+     * unset instantGratificationResourceList
+     *
+     * A Composite containing details of one or more Resources that are only available for download as soon as the Release is purchased (i.e. before the ReleaseDate).
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetInstantGratificationResourceList($index)
+    {
+        unset($this->instantGratificationResourceList[$index]);
+    }
+
+    /**
+     * Gets as instantGratificationResourceList
+     *
+     * A Composite containing details of one or more Resources that are only available for download as soon as the Release is purchased (i.e. before the ReleaseDate).
+     *
+     * @return string[]
+     */
+    public function getInstantGratificationResourceList()
+    {
+        return $this->instantGratificationResourceList;
+    }
+
+    /**
+     * Sets a new instantGratificationResourceList
+     *
+     * A Composite containing details of one or more Resources that are only available for download as soon as the Release is purchased (i.e. before the ReleaseDate).
+     *
+     * @param string $instantGratificationResourceList
+     * @return self
+     */
+    public function setInstantGratificationResourceList(?array $instantGratificationResourceList = null)
+    {
+        $this->instantGratificationResourceList = $instantGratificationResourceList;
+        return $this;
+    }
+
+    /**
+     * Gets as physicalReturns
+     *
+     * A Composite containing details of physical returns.
+     *
+     * @return \DedexBundle\Entity\Ern42\PhysicalReturnsType
+     */
+    public function getPhysicalReturns()
+    {
+        return $this->physicalReturns;
+    }
+
+    /**
+     * Sets a new physicalReturns
+     *
+     * A Composite containing details of physical returns.
+     *
+     * @param \DedexBundle\Entity\Ern42\PhysicalReturnsType $physicalReturns
+     * @return self
+     */
+    public function setPhysicalReturns(?\DedexBundle\Entity\Ern42\PhysicalReturnsType $physicalReturns = null)
+    {
+        $this->physicalReturns = $physicalReturns;
+        return $this;
+    }
+
+    /**
+     * Gets as numberOfProductsPerCarton
+     *
+     * A number of Products per carton. This is the smallest number of Products that can be ordered.
+     *
+     * @return int
+     */
+    public function getNumberOfProductsPerCarton()
+    {
+        return $this->numberOfProductsPerCarton;
+    }
+
+    /**
+     * Sets a new numberOfProductsPerCarton
+     *
+     * A number of Products per carton. This is the smallest number of Products that can be ordered.
+     *
+     * @param int $numberOfProductsPerCarton
+     * @return self
+     */
+    public function setNumberOfProductsPerCarton($numberOfProductsPerCarton)
+    {
+        $this->numberOfProductsPerCarton = $numberOfProductsPerCarton;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/DealType.php
+++ b/src/Entity/Ern42/DealType.php
@@ -1,0 +1,305 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing DealType
+ *
+ * A Composite containing details (in full or in summary) of a Deal made between a DSP (as Licensee) and a Licensor of Works or Releases. When any new DealTerms are added or removed from an existing Deal (different UseTypes, Prices, Territories, DistributionChannels) then a new Deal is created, and (if appropriate) the ValidityPeriod of the existing Deal should be terminated. The only changes which should be made to the DealTerms of an existing Deal are corrections required because of an earlier error or omission, or the addition of an EndDate to the Deal's ValidityPeriod.
+ * XSD Type: Deal
+ */
+class DealType
+{
+    /**
+     * A Reference to a TextDocument containing details of the Deal (in the form of an Identifier, Name or Description).
+     *
+     * @var string[] $dealReference
+     */
+    private $dealReference = [
+        
+    ];
+
+    /**
+     * A Flag indicating whether the Deal is communicated outside the usual ERN delivery and identified by an Identifier in the DealReference element (=true) or not (=false). It would be up to the MessageSender and MessageRecipient to ensure that this Deal Identifier is unique.
+     *
+     * @var bool $isCommunicatedOutOfBand
+     */
+    private $isCommunicatedOutOfBand = null;
+
+    /**
+     * A Composite containing details of the terms of the Deal.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/cancelling-a-deal-before-street-date
+     *
+     * @var \DedexBundle\Entity\Ern42\DealTermsType $dealTerms
+     */
+    private $dealTerms = null;
+
+    /**
+     * A Composite containing a list of DealTechnicalResourceDetailsReferences for the Deal.
+     *
+     * @var string[] $dealTechnicalResourceDetailsReferenceList
+     */
+    private $dealTechnicalResourceDetailsReferenceList = null;
+
+    /**
+     * A Composite containing details of a WebPage for the DistributionChannel.
+     *
+     * @var \DedexBundle\Entity\Ern42\DistributionChannelPageType[] $distributionChannelPage
+     */
+    private $distributionChannelPage = [
+        
+    ];
+
+    /**
+     * Adds as dealReference
+     *
+     * A Reference to a TextDocument containing details of the Deal (in the form of an Identifier, Name or Description).
+     *
+     * @return self
+     * @param string $dealReference
+     */
+    public function addToDealReference($dealReference)
+    {
+        $this->dealReference[] = $dealReference;
+        return $this;
+    }
+
+    /**
+     * isset dealReference
+     *
+     * A Reference to a TextDocument containing details of the Deal (in the form of an Identifier, Name or Description).
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDealReference($index)
+    {
+        return isset($this->dealReference[$index]);
+    }
+
+    /**
+     * unset dealReference
+     *
+     * A Reference to a TextDocument containing details of the Deal (in the form of an Identifier, Name or Description).
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDealReference($index)
+    {
+        unset($this->dealReference[$index]);
+    }
+
+    /**
+     * Gets as dealReference
+     *
+     * A Reference to a TextDocument containing details of the Deal (in the form of an Identifier, Name or Description).
+     *
+     * @return string[]
+     */
+    public function getDealReference()
+    {
+        return $this->dealReference;
+    }
+
+    /**
+     * Sets a new dealReference
+     *
+     * A Reference to a TextDocument containing details of the Deal (in the form of an Identifier, Name or Description).
+     *
+     * @param string[] $dealReference
+     * @return self
+     */
+    public function setDealReference(?array $dealReference = null)
+    {
+        $this->dealReference = $dealReference;
+        return $this;
+    }
+
+    /**
+     * Gets as isCommunicatedOutOfBand
+     *
+     * A Flag indicating whether the Deal is communicated outside the usual ERN delivery and identified by an Identifier in the DealReference element (=true) or not (=false). It would be up to the MessageSender and MessageRecipient to ensure that this Deal Identifier is unique.
+     *
+     * @return bool
+     */
+    public function getIsCommunicatedOutOfBand()
+    {
+        return $this->isCommunicatedOutOfBand;
+    }
+
+    /**
+     * Sets a new isCommunicatedOutOfBand
+     *
+     * A Flag indicating whether the Deal is communicated outside the usual ERN delivery and identified by an Identifier in the DealReference element (=true) or not (=false). It would be up to the MessageSender and MessageRecipient to ensure that this Deal Identifier is unique.
+     *
+     * @param bool $isCommunicatedOutOfBand
+     * @return self
+     */
+    public function setIsCommunicatedOutOfBand($isCommunicatedOutOfBand)
+    {
+        $this->isCommunicatedOutOfBand = $isCommunicatedOutOfBand;
+        return $this;
+    }
+
+    /**
+     * Gets as dealTerms
+     *
+     * A Composite containing details of the terms of the Deal.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/cancelling-a-deal-before-street-date
+     *
+     * @return \DedexBundle\Entity\Ern42\DealTermsType
+     */
+    public function getDealTerms()
+    {
+        return $this->dealTerms;
+    }
+
+    /**
+     * Sets a new dealTerms
+     *
+     * A Composite containing details of the terms of the Deal.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/cancelling-a-deal-before-street-date
+     *
+     * @param \DedexBundle\Entity\Ern42\DealTermsType $dealTerms
+     * @return self
+     */
+    public function setDealTerms(?\DedexBundle\Entity\Ern42\DealTermsType $dealTerms = null)
+    {
+        $this->dealTerms = $dealTerms;
+        return $this;
+    }
+
+    /**
+     * Adds as dealTechnicalResourceDetailsReference
+     *
+     * A Composite containing a list of DealTechnicalResourceDetailsReferences for the Deal.
+     *
+     * @return self
+     * @param string $dealTechnicalResourceDetailsReference
+     */
+    public function addToDealTechnicalResourceDetailsReferenceList($dealTechnicalResourceDetailsReference)
+    {
+        $this->dealTechnicalResourceDetailsReferenceList[] = $dealTechnicalResourceDetailsReference;
+        return $this;
+    }
+
+    /**
+     * isset dealTechnicalResourceDetailsReferenceList
+     *
+     * A Composite containing a list of DealTechnicalResourceDetailsReferences for the Deal.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDealTechnicalResourceDetailsReferenceList($index)
+    {
+        return isset($this->dealTechnicalResourceDetailsReferenceList[$index]);
+    }
+
+    /**
+     * unset dealTechnicalResourceDetailsReferenceList
+     *
+     * A Composite containing a list of DealTechnicalResourceDetailsReferences for the Deal.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDealTechnicalResourceDetailsReferenceList($index)
+    {
+        unset($this->dealTechnicalResourceDetailsReferenceList[$index]);
+    }
+
+    /**
+     * Gets as dealTechnicalResourceDetailsReferenceList
+     *
+     * A Composite containing a list of DealTechnicalResourceDetailsReferences for the Deal.
+     *
+     * @return string[]
+     */
+    public function getDealTechnicalResourceDetailsReferenceList()
+    {
+        return $this->dealTechnicalResourceDetailsReferenceList;
+    }
+
+    /**
+     * Sets a new dealTechnicalResourceDetailsReferenceList
+     *
+     * A Composite containing a list of DealTechnicalResourceDetailsReferences for the Deal.
+     *
+     * @param string $dealTechnicalResourceDetailsReferenceList
+     * @return self
+     */
+    public function setDealTechnicalResourceDetailsReferenceList(?array $dealTechnicalResourceDetailsReferenceList = null)
+    {
+        $this->dealTechnicalResourceDetailsReferenceList = $dealTechnicalResourceDetailsReferenceList;
+        return $this;
+    }
+
+    /**
+     * Adds as distributionChannelPage
+     *
+     * A Composite containing details of a WebPage for the DistributionChannel.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DistributionChannelPageType $distributionChannelPage
+     */
+    public function addToDistributionChannelPage(\DedexBundle\Entity\Ern42\DistributionChannelPageType $distributionChannelPage)
+    {
+        $this->distributionChannelPage[] = $distributionChannelPage;
+        return $this;
+    }
+
+    /**
+     * isset distributionChannelPage
+     *
+     * A Composite containing details of a WebPage for the DistributionChannel.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDistributionChannelPage($index)
+    {
+        return isset($this->distributionChannelPage[$index]);
+    }
+
+    /**
+     * unset distributionChannelPage
+     *
+     * A Composite containing details of a WebPage for the DistributionChannel.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDistributionChannelPage($index)
+    {
+        unset($this->distributionChannelPage[$index]);
+    }
+
+    /**
+     * Gets as distributionChannelPage
+     *
+     * A Composite containing details of a WebPage for the DistributionChannel.
+     *
+     * @return \DedexBundle\Entity\Ern42\DistributionChannelPageType[]
+     */
+    public function getDistributionChannelPage()
+    {
+        return $this->distributionChannelPage;
+    }
+
+    /**
+     * Sets a new distributionChannelPage
+     *
+     * A Composite containing details of a WebPage for the DistributionChannel.
+     *
+     * @param \DedexBundle\Entity\Ern42\DistributionChannelPageType[] $distributionChannelPage
+     * @return self
+     */
+    public function setDistributionChannelPage(?array $distributionChannelPage = null)
+    {
+        $this->distributionChannelPage = $distributionChannelPage;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/DeityType.php
+++ b/src/Entity/Ern42/DeityType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing DeityType
+ *
+ * A Composite containing details of a Deity.
+ * XSD Type: Deity
+ */
+class DeityType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * A Territory to which the Deity applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the Deity applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the Deity applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/DelegatedUsageRightsType.php
+++ b/src/Entity/Ern42/DelegatedUsageRightsType.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing DelegatedUsageRightsType
+ *
+ * A Composite containing details of the kinds of usage for which Rights have been delegated.
+ * XSD Type: DelegatedUsageRights
+ */
+class DelegatedUsageRightsType
+{
+    /**
+     * A Composite containing details of the use for which Rights are delegated.
+     *
+     * @var \DedexBundle\Entity\Ern42\UseTypeType[] $useType
+     */
+    private $useType = [
+        
+    ];
+
+    /**
+     * A Composite containing details about a Period of Time for which the delegation of usage Rights applies. Periods are typically described by at least a StartDate or EndDate.
+     *
+     * @var \DedexBundle\Entity\Ern42\PeriodType $periodOfRightsDelegation
+     */
+    private $periodOfRightsDelegation = null;
+
+    /**
+     * A Territory for which the delegation of usage rights applies.
+     *
+     * @var \DedexBundle\Entity\Ern42\AllTerritoryCodeType[] $territoryOfRightsDelegation
+     */
+    private $territoryOfRightsDelegation = [
+        
+    ];
+
+    /**
+     * Adds as useType
+     *
+     * A Composite containing details of the use for which Rights are delegated.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\UseTypeType $useType
+     */
+    public function addToUseType(\DedexBundle\Entity\Ern42\UseTypeType $useType)
+    {
+        $this->useType[] = $useType;
+        return $this;
+    }
+
+    /**
+     * isset useType
+     *
+     * A Composite containing details of the use for which Rights are delegated.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetUseType($index)
+    {
+        return isset($this->useType[$index]);
+    }
+
+    /**
+     * unset useType
+     *
+     * A Composite containing details of the use for which Rights are delegated.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetUseType($index)
+    {
+        unset($this->useType[$index]);
+    }
+
+    /**
+     * Gets as useType
+     *
+     * A Composite containing details of the use for which Rights are delegated.
+     *
+     * @return \DedexBundle\Entity\Ern42\UseTypeType[]
+     */
+    public function getUseType()
+    {
+        return $this->useType;
+    }
+
+    /**
+     * Sets a new useType
+     *
+     * A Composite containing details of the use for which Rights are delegated.
+     *
+     * @param \DedexBundle\Entity\Ern42\UseTypeType[] $useType
+     * @return self
+     */
+    public function setUseType(array $useType)
+    {
+        $this->useType = $useType;
+        return $this;
+    }
+
+    /**
+     * Gets as periodOfRightsDelegation
+     *
+     * A Composite containing details about a Period of Time for which the delegation of usage Rights applies. Periods are typically described by at least a StartDate or EndDate.
+     *
+     * @return \DedexBundle\Entity\Ern42\PeriodType
+     */
+    public function getPeriodOfRightsDelegation()
+    {
+        return $this->periodOfRightsDelegation;
+    }
+
+    /**
+     * Sets a new periodOfRightsDelegation
+     *
+     * A Composite containing details about a Period of Time for which the delegation of usage Rights applies. Periods are typically described by at least a StartDate or EndDate.
+     *
+     * @param \DedexBundle\Entity\Ern42\PeriodType $periodOfRightsDelegation
+     * @return self
+     */
+    public function setPeriodOfRightsDelegation(?\DedexBundle\Entity\Ern42\PeriodType $periodOfRightsDelegation = null)
+    {
+        $this->periodOfRightsDelegation = $periodOfRightsDelegation;
+        return $this;
+    }
+
+    /**
+     * Adds as territoryOfRightsDelegation
+     *
+     * A Territory for which the delegation of usage rights applies.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\AllTerritoryCodeType $territoryOfRightsDelegation
+     */
+    public function addToTerritoryOfRightsDelegation(\DedexBundle\Entity\Ern42\AllTerritoryCodeType $territoryOfRightsDelegation)
+    {
+        $this->territoryOfRightsDelegation[] = $territoryOfRightsDelegation;
+        return $this;
+    }
+
+    /**
+     * isset territoryOfRightsDelegation
+     *
+     * A Territory for which the delegation of usage rights applies.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetTerritoryOfRightsDelegation($index)
+    {
+        return isset($this->territoryOfRightsDelegation[$index]);
+    }
+
+    /**
+     * unset territoryOfRightsDelegation
+     *
+     * A Territory for which the delegation of usage rights applies.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetTerritoryOfRightsDelegation($index)
+    {
+        unset($this->territoryOfRightsDelegation[$index]);
+    }
+
+    /**
+     * Gets as territoryOfRightsDelegation
+     *
+     * A Territory for which the delegation of usage rights applies.
+     *
+     * @return \DedexBundle\Entity\Ern42\AllTerritoryCodeType[]
+     */
+    public function getTerritoryOfRightsDelegation()
+    {
+        return $this->territoryOfRightsDelegation;
+    }
+
+    /**
+     * Sets a new territoryOfRightsDelegation
+     *
+     * A Territory for which the delegation of usage rights applies.
+     *
+     * @param \DedexBundle\Entity\Ern42\AllTerritoryCodeType[] $territoryOfRightsDelegation
+     * @return self
+     */
+    public function setTerritoryOfRightsDelegation(?array $territoryOfRightsDelegation = null)
+    {
+        $this->territoryOfRightsDelegation = $territoryOfRightsDelegation;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/DescriptionWithTerritoryType.php
+++ b/src/Entity/Ern42/DescriptionWithTerritoryType.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing DescriptionWithTerritoryType
+ *
+ * A Composite containing details of a Description.
+ * Explanatory Note: This Composite is named DescriptionWithTerritory to disambiguate it from the basic Description Composite.
+ * XSD Type: DescriptionWithTerritory
+ */
+class DescriptionWithTerritoryType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Language and script of the Description as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * A Territory to which the Description applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script of the Description as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script of the Description as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the Description applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the Description applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/DetailedCueSheetListType.php
+++ b/src/Entity/Ern42/DetailedCueSheetListType.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing DetailedCueSheetListType
+ *
+ * A Composite containing details of one or more CueSheets.
+ * XSD Type: DetailedCueSheetList
+ */
+class DetailedCueSheetListType
+{
+    /**
+     * A Composite containing details of a CueSheet contained in a Resource.
+     *
+     * @var \DedexBundle\Entity\Ern42\DetailedCueSheetType[] $cueSheet
+     */
+    private $cueSheet = [
+        
+    ];
+
+    /**
+     * Adds as cueSheet
+     *
+     * A Composite containing details of a CueSheet contained in a Resource.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DetailedCueSheetType $cueSheet
+     */
+    public function addToCueSheet(\DedexBundle\Entity\Ern42\DetailedCueSheetType $cueSheet)
+    {
+        $this->cueSheet[] = $cueSheet;
+        return $this;
+    }
+
+    /**
+     * isset cueSheet
+     *
+     * A Composite containing details of a CueSheet contained in a Resource.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetCueSheet($index)
+    {
+        return isset($this->cueSheet[$index]);
+    }
+
+    /**
+     * unset cueSheet
+     *
+     * A Composite containing details of a CueSheet contained in a Resource.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetCueSheet($index)
+    {
+        unset($this->cueSheet[$index]);
+    }
+
+    /**
+     * Gets as cueSheet
+     *
+     * A Composite containing details of a CueSheet contained in a Resource.
+     *
+     * @return \DedexBundle\Entity\Ern42\DetailedCueSheetType[]
+     */
+    public function getCueSheet()
+    {
+        return $this->cueSheet;
+    }
+
+    /**
+     * Sets a new cueSheet
+     *
+     * A Composite containing details of a CueSheet contained in a Resource.
+     *
+     * @param \DedexBundle\Entity\Ern42\DetailedCueSheetType[] $cueSheet
+     * @return self
+     */
+    public function setCueSheet(array $cueSheet)
+    {
+        $this->cueSheet = $cueSheet;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/DetailedCueSheetType.php
+++ b/src/Entity/Ern42/DetailedCueSheetType.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing DetailedCueSheetType
+ *
+ * A Composite containing details of a CueSheet.
+ * XSD Type: DetailedCueSheet
+ */
+class DetailedCueSheetType
+{
+    /**
+     * A Composite containing details of a CueSheetId of the CueSheet.
+     *
+     * @var \DedexBundle\Entity\Ern42\ProprietaryIdType[] $cueSheetId
+     */
+    private $cueSheetId = [
+        
+    ];
+
+    /**
+     * The Identifier (specific to the Message) of the CueSheet within the Release which contains it. This is a LocalCueSheetAnchor starting with the letter Q.
+     *
+     * @var string $cueSheetReference
+     */
+    private $cueSheetReference = null;
+
+    /**
+     * A Composite containing details of a Type of the CueSheet.
+     *
+     * @var \DedexBundle\Entity\Ern42\CueSheetTypeType $cueSheetType
+     */
+    private $cueSheetType = null;
+
+    /**
+     * A Composite containing details of a Cue.
+     *
+     * @var \DedexBundle\Entity\Ern42\DetailedCueType[] $cue
+     */
+    private $cue = [
+        
+    ];
+
+    /**
+     * Adds as cueSheetId
+     *
+     * A Composite containing details of a CueSheetId of the CueSheet.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ProprietaryIdType $cueSheetId
+     */
+    public function addToCueSheetId(\DedexBundle\Entity\Ern42\ProprietaryIdType $cueSheetId)
+    {
+        $this->cueSheetId[] = $cueSheetId;
+        return $this;
+    }
+
+    /**
+     * isset cueSheetId
+     *
+     * A Composite containing details of a CueSheetId of the CueSheet.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetCueSheetId($index)
+    {
+        return isset($this->cueSheetId[$index]);
+    }
+
+    /**
+     * unset cueSheetId
+     *
+     * A Composite containing details of a CueSheetId of the CueSheet.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetCueSheetId($index)
+    {
+        unset($this->cueSheetId[$index]);
+    }
+
+    /**
+     * Gets as cueSheetId
+     *
+     * A Composite containing details of a CueSheetId of the CueSheet.
+     *
+     * @return \DedexBundle\Entity\Ern42\ProprietaryIdType[]
+     */
+    public function getCueSheetId()
+    {
+        return $this->cueSheetId;
+    }
+
+    /**
+     * Sets a new cueSheetId
+     *
+     * A Composite containing details of a CueSheetId of the CueSheet.
+     *
+     * @param \DedexBundle\Entity\Ern42\ProprietaryIdType[] $cueSheetId
+     * @return self
+     */
+    public function setCueSheetId(?array $cueSheetId = null)
+    {
+        $this->cueSheetId = $cueSheetId;
+        return $this;
+    }
+
+    /**
+     * Gets as cueSheetReference
+     *
+     * The Identifier (specific to the Message) of the CueSheet within the Release which contains it. This is a LocalCueSheetAnchor starting with the letter Q.
+     *
+     * @return string
+     */
+    public function getCueSheetReference()
+    {
+        return $this->cueSheetReference;
+    }
+
+    /**
+     * Sets a new cueSheetReference
+     *
+     * The Identifier (specific to the Message) of the CueSheet within the Release which contains it. This is a LocalCueSheetAnchor starting with the letter Q.
+     *
+     * @param string $cueSheetReference
+     * @return self
+     */
+    public function setCueSheetReference($cueSheetReference)
+    {
+        $this->cueSheetReference = $cueSheetReference;
+        return $this;
+    }
+
+    /**
+     * Gets as cueSheetType
+     *
+     * A Composite containing details of a Type of the CueSheet.
+     *
+     * @return \DedexBundle\Entity\Ern42\CueSheetTypeType
+     */
+    public function getCueSheetType()
+    {
+        return $this->cueSheetType;
+    }
+
+    /**
+     * Sets a new cueSheetType
+     *
+     * A Composite containing details of a Type of the CueSheet.
+     *
+     * @param \DedexBundle\Entity\Ern42\CueSheetTypeType $cueSheetType
+     * @return self
+     */
+    public function setCueSheetType(\DedexBundle\Entity\Ern42\CueSheetTypeType $cueSheetType)
+    {
+        $this->cueSheetType = $cueSheetType;
+        return $this;
+    }
+
+    /**
+     * Adds as cue
+     *
+     * A Composite containing details of a Cue.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DetailedCueType $cue
+     */
+    public function addToCue(\DedexBundle\Entity\Ern42\DetailedCueType $cue)
+    {
+        $this->cue[] = $cue;
+        return $this;
+    }
+
+    /**
+     * isset cue
+     *
+     * A Composite containing details of a Cue.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetCue($index)
+    {
+        return isset($this->cue[$index]);
+    }
+
+    /**
+     * unset cue
+     *
+     * A Composite containing details of a Cue.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetCue($index)
+    {
+        unset($this->cue[$index]);
+    }
+
+    /**
+     * Gets as cue
+     *
+     * A Composite containing details of a Cue.
+     *
+     * @return \DedexBundle\Entity\Ern42\DetailedCueType[]
+     */
+    public function getCue()
+    {
+        return $this->cue;
+    }
+
+    /**
+     * Sets a new cue
+     *
+     * A Composite containing details of a Cue.
+     *
+     * @param \DedexBundle\Entity\Ern42\DetailedCueType[] $cue
+     * @return self
+     */
+    public function setCue(array $cue)
+    {
+        $this->cue = $cue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/DetailedCueType.php
+++ b/src/Entity/Ern42/DetailedCueType.php
@@ -1,0 +1,866 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing DetailedCueType
+ *
+ * A Composite containing details of a Cue.
+ * Explanatory Note: This Composite is named DetailedCue to disambiguate it from the basic Cue Composite.
+ * XSD Type: DetailedCue
+ */
+class DetailedCueType
+{
+    /**
+     * A Composite containing details of a UseType of the Cue. It can be expected that this element will be contractually mandatory in many communications of cue sheets to music rights societies.
+     *
+     * @var \DedexBundle\Entity\Ern42\CueUseTypeType $cueUseType
+     */
+    private $cueUseType = null;
+
+    /**
+     * A Composite containing details of a ThemeType for the Creation referenced in the Cue.
+     *
+     * @var \DedexBundle\Entity\Ern42\CueThemeTypeType $cueThemeType
+     */
+    private $cueThemeType = null;
+
+    /**
+     * A Composite containing details of a VocalType for the Creation referenced in the Cue.
+     *
+     * @var \DedexBundle\Entity\Ern42\CueVocalTypeType $cueVocalType
+     */
+    private $cueVocalType = null;
+
+    /**
+     * A Composite containing details of a VisualPerceptionType for the Creation referenced in the Cue.
+     *
+     * @var \DedexBundle\Entity\Ern42\CueVisualPerceptionTypeType $cueVisualPerceptionType
+     */
+    private $cueVisualPerceptionType = null;
+
+    /**
+     * A Composite containing details of a CueOrigin for the Cue. It can be expected that this element will be contractually mandatory in many communications of cue sheets to music rights societies.
+     *
+     * @var \DedexBundle\Entity\Ern42\CueOriginType $cueOrigin
+     */
+    private $cueOrigin = null;
+
+    /**
+     * A Composite containing details of a ResourceId.
+     *
+     * @var \DedexBundle\Entity\Ern42\ResourceIdType $resourceId
+     */
+    private $resourceId = null;
+
+    /**
+     * A Composite containing details of a WorkId.
+     *
+     * @var \DedexBundle\Entity\Ern42\MusicalWorkIdType $workId
+     */
+    private $workId = null;
+
+    /**
+     * A Composite containing details of a Title of the Work referenced in the Cue, as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayTitleTextType[] $displayTitleText
+     */
+    private $displayTitleText = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Title of the Work referenced in the Cue, as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayTitleType[] $displayTitle
+     */
+    private $displayTitle = [
+        
+    ];
+
+    /**
+     * A Composite containing details of an AdditionalTitle of the Work referenced in the Cue. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @var \DedexBundle\Entity\Ern42\AdditionalTitleType[] $additionalTitle
+     */
+    private $additionalTitle = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Contributor of the Work referenced in the Cue.
+     *
+     * @var \DedexBundle\Entity\Ern42\ContributorType[] $contributor
+     */
+    private $contributor = [
+        
+    ];
+
+    /**
+     * A Flag indicating whether a Creation contains dancing (=true) or not (=false).
+     *
+     * @var bool $isDance
+     */
+    private $isDance = null;
+
+    /**
+     * A Flag indicating whether whether the Creation referenced in the Cue contains musical content such as a SoundRecording or a MusicalWork (=true) or not (=false).
+     *
+     * @var bool $hasMusicalContent
+     */
+    private $hasMusicalContent = null;
+
+    /**
+     * A Composite containing details of the PLine for the Cue.
+     *
+     * @var \DedexBundle\Entity\Ern42\PLineType[] $pLine
+     */
+    private $pLine = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the CLine for the Cue.
+     *
+     * @var \DedexBundle\Entity\Ern42\CLineType[] $cLine
+     */
+    private $cLine = [
+        
+    ];
+
+    /**
+     * The start time of the Creation, measured from the start of the Resource from which the CueSheet is referenced (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @var \DateInterval $startTime
+     */
+    private $startTime = null;
+
+    /**
+     * The Duration of the use of the Creation that is referenced in the CueCreationReference (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @var \DateInterval $duration
+     */
+    private $duration = null;
+
+    /**
+     * The end time of the Creation, measured from the start of the Resource from which the CueSheet is referenced (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @var \DateInterval $endTime
+     */
+    private $endTime = null;
+
+    /**
+     * Gets as cueUseType
+     *
+     * A Composite containing details of a UseType of the Cue. It can be expected that this element will be contractually mandatory in many communications of cue sheets to music rights societies.
+     *
+     * @return \DedexBundle\Entity\Ern42\CueUseTypeType
+     */
+    public function getCueUseType()
+    {
+        return $this->cueUseType;
+    }
+
+    /**
+     * Sets a new cueUseType
+     *
+     * A Composite containing details of a UseType of the Cue. It can be expected that this element will be contractually mandatory in many communications of cue sheets to music rights societies.
+     *
+     * @param \DedexBundle\Entity\Ern42\CueUseTypeType $cueUseType
+     * @return self
+     */
+    public function setCueUseType(?\DedexBundle\Entity\Ern42\CueUseTypeType $cueUseType = null)
+    {
+        $this->cueUseType = $cueUseType;
+        return $this;
+    }
+
+    /**
+     * Gets as cueThemeType
+     *
+     * A Composite containing details of a ThemeType for the Creation referenced in the Cue.
+     *
+     * @return \DedexBundle\Entity\Ern42\CueThemeTypeType
+     */
+    public function getCueThemeType()
+    {
+        return $this->cueThemeType;
+    }
+
+    /**
+     * Sets a new cueThemeType
+     *
+     * A Composite containing details of a ThemeType for the Creation referenced in the Cue.
+     *
+     * @param \DedexBundle\Entity\Ern42\CueThemeTypeType $cueThemeType
+     * @return self
+     */
+    public function setCueThemeType(?\DedexBundle\Entity\Ern42\CueThemeTypeType $cueThemeType = null)
+    {
+        $this->cueThemeType = $cueThemeType;
+        return $this;
+    }
+
+    /**
+     * Gets as cueVocalType
+     *
+     * A Composite containing details of a VocalType for the Creation referenced in the Cue.
+     *
+     * @return \DedexBundle\Entity\Ern42\CueVocalTypeType
+     */
+    public function getCueVocalType()
+    {
+        return $this->cueVocalType;
+    }
+
+    /**
+     * Sets a new cueVocalType
+     *
+     * A Composite containing details of a VocalType for the Creation referenced in the Cue.
+     *
+     * @param \DedexBundle\Entity\Ern42\CueVocalTypeType $cueVocalType
+     * @return self
+     */
+    public function setCueVocalType(?\DedexBundle\Entity\Ern42\CueVocalTypeType $cueVocalType = null)
+    {
+        $this->cueVocalType = $cueVocalType;
+        return $this;
+    }
+
+    /**
+     * Gets as cueVisualPerceptionType
+     *
+     * A Composite containing details of a VisualPerceptionType for the Creation referenced in the Cue.
+     *
+     * @return \DedexBundle\Entity\Ern42\CueVisualPerceptionTypeType
+     */
+    public function getCueVisualPerceptionType()
+    {
+        return $this->cueVisualPerceptionType;
+    }
+
+    /**
+     * Sets a new cueVisualPerceptionType
+     *
+     * A Composite containing details of a VisualPerceptionType for the Creation referenced in the Cue.
+     *
+     * @param \DedexBundle\Entity\Ern42\CueVisualPerceptionTypeType $cueVisualPerceptionType
+     * @return self
+     */
+    public function setCueVisualPerceptionType(?\DedexBundle\Entity\Ern42\CueVisualPerceptionTypeType $cueVisualPerceptionType = null)
+    {
+        $this->cueVisualPerceptionType = $cueVisualPerceptionType;
+        return $this;
+    }
+
+    /**
+     * Gets as cueOrigin
+     *
+     * A Composite containing details of a CueOrigin for the Cue. It can be expected that this element will be contractually mandatory in many communications of cue sheets to music rights societies.
+     *
+     * @return \DedexBundle\Entity\Ern42\CueOriginType
+     */
+    public function getCueOrigin()
+    {
+        return $this->cueOrigin;
+    }
+
+    /**
+     * Sets a new cueOrigin
+     *
+     * A Composite containing details of a CueOrigin for the Cue. It can be expected that this element will be contractually mandatory in many communications of cue sheets to music rights societies.
+     *
+     * @param \DedexBundle\Entity\Ern42\CueOriginType $cueOrigin
+     * @return self
+     */
+    public function setCueOrigin(?\DedexBundle\Entity\Ern42\CueOriginType $cueOrigin = null)
+    {
+        $this->cueOrigin = $cueOrigin;
+        return $this;
+    }
+
+    /**
+     * Gets as resourceId
+     *
+     * A Composite containing details of a ResourceId.
+     *
+     * @return \DedexBundle\Entity\Ern42\ResourceIdType
+     */
+    public function getResourceId()
+    {
+        return $this->resourceId;
+    }
+
+    /**
+     * Sets a new resourceId
+     *
+     * A Composite containing details of a ResourceId.
+     *
+     * @param \DedexBundle\Entity\Ern42\ResourceIdType $resourceId
+     * @return self
+     */
+    public function setResourceId(?\DedexBundle\Entity\Ern42\ResourceIdType $resourceId = null)
+    {
+        $this->resourceId = $resourceId;
+        return $this;
+    }
+
+    /**
+     * Gets as workId
+     *
+     * A Composite containing details of a WorkId.
+     *
+     * @return \DedexBundle\Entity\Ern42\MusicalWorkIdType
+     */
+    public function getWorkId()
+    {
+        return $this->workId;
+    }
+
+    /**
+     * Sets a new workId
+     *
+     * A Composite containing details of a WorkId.
+     *
+     * @param \DedexBundle\Entity\Ern42\MusicalWorkIdType $workId
+     * @return self
+     */
+    public function setWorkId(?\DedexBundle\Entity\Ern42\MusicalWorkIdType $workId = null)
+    {
+        $this->workId = $workId;
+        return $this;
+    }
+
+    /**
+     * Adds as displayTitleText
+     *
+     * A Composite containing details of a Title of the Work referenced in the Cue, as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleTextType $displayTitleText
+     */
+    public function addToDisplayTitleText(\DedexBundle\Entity\Ern42\DisplayTitleTextType $displayTitleText)
+    {
+        $this->displayTitleText[] = $displayTitleText;
+        return $this;
+    }
+
+    /**
+     * isset displayTitleText
+     *
+     * A Composite containing details of a Title of the Work referenced in the Cue, as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayTitleText($index)
+    {
+        return isset($this->displayTitleText[$index]);
+    }
+
+    /**
+     * unset displayTitleText
+     *
+     * A Composite containing details of a Title of the Work referenced in the Cue, as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayTitleText($index)
+    {
+        unset($this->displayTitleText[$index]);
+    }
+
+    /**
+     * Gets as displayTitleText
+     *
+     * A Composite containing details of a Title of the Work referenced in the Cue, as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayTitleTextType[]
+     */
+    public function getDisplayTitleText()
+    {
+        return $this->displayTitleText;
+    }
+
+    /**
+     * Sets a new displayTitleText
+     *
+     * A Composite containing details of a Title of the Work referenced in the Cue, as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleTextType[] $displayTitleText
+     * @return self
+     */
+    public function setDisplayTitleText(?array $displayTitleText = null)
+    {
+        $this->displayTitleText = $displayTitleText;
+        return $this;
+    }
+
+    /**
+     * Adds as displayTitle
+     *
+     * A Composite containing details of a Title of the Work referenced in the Cue, as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleType $displayTitle
+     */
+    public function addToDisplayTitle(\DedexBundle\Entity\Ern42\DisplayTitleType $displayTitle)
+    {
+        $this->displayTitle[] = $displayTitle;
+        return $this;
+    }
+
+    /**
+     * isset displayTitle
+     *
+     * A Composite containing details of a Title of the Work referenced in the Cue, as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayTitle($index)
+    {
+        return isset($this->displayTitle[$index]);
+    }
+
+    /**
+     * unset displayTitle
+     *
+     * A Composite containing details of a Title of the Work referenced in the Cue, as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayTitle($index)
+    {
+        unset($this->displayTitle[$index]);
+    }
+
+    /**
+     * Gets as displayTitle
+     *
+     * A Composite containing details of a Title of the Work referenced in the Cue, as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayTitleType[]
+     */
+    public function getDisplayTitle()
+    {
+        return $this->displayTitle;
+    }
+
+    /**
+     * Sets a new displayTitle
+     *
+     * A Composite containing details of a Title of the Work referenced in the Cue, as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleType[] $displayTitle
+     * @return self
+     */
+    public function setDisplayTitle(?array $displayTitle = null)
+    {
+        $this->displayTitle = $displayTitle;
+        return $this;
+    }
+
+    /**
+     * Adds as additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Work referenced in the Cue. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\AdditionalTitleType $additionalTitle
+     */
+    public function addToAdditionalTitle(\DedexBundle\Entity\Ern42\AdditionalTitleType $additionalTitle)
+    {
+        $this->additionalTitle[] = $additionalTitle;
+        return $this;
+    }
+
+    /**
+     * isset additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Work referenced in the Cue. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetAdditionalTitle($index)
+    {
+        return isset($this->additionalTitle[$index]);
+    }
+
+    /**
+     * unset additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Work referenced in the Cue. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetAdditionalTitle($index)
+    {
+        unset($this->additionalTitle[$index]);
+    }
+
+    /**
+     * Gets as additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Work referenced in the Cue. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return \DedexBundle\Entity\Ern42\AdditionalTitleType[]
+     */
+    public function getAdditionalTitle()
+    {
+        return $this->additionalTitle;
+    }
+
+    /**
+     * Sets a new additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Work referenced in the Cue. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param \DedexBundle\Entity\Ern42\AdditionalTitleType[] $additionalTitle
+     * @return self
+     */
+    public function setAdditionalTitle(?array $additionalTitle = null)
+    {
+        $this->additionalTitle = $additionalTitle;
+        return $this;
+    }
+
+    /**
+     * Adds as contributor
+     *
+     * A Composite containing details of a Contributor of the Work referenced in the Cue.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ContributorType $contributor
+     */
+    public function addToContributor(\DedexBundle\Entity\Ern42\ContributorType $contributor)
+    {
+        $this->contributor[] = $contributor;
+        return $this;
+    }
+
+    /**
+     * isset contributor
+     *
+     * A Composite containing details of a Contributor of the Work referenced in the Cue.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetContributor($index)
+    {
+        return isset($this->contributor[$index]);
+    }
+
+    /**
+     * unset contributor
+     *
+     * A Composite containing details of a Contributor of the Work referenced in the Cue.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetContributor($index)
+    {
+        unset($this->contributor[$index]);
+    }
+
+    /**
+     * Gets as contributor
+     *
+     * A Composite containing details of a Contributor of the Work referenced in the Cue.
+     *
+     * @return \DedexBundle\Entity\Ern42\ContributorType[]
+     */
+    public function getContributor()
+    {
+        return $this->contributor;
+    }
+
+    /**
+     * Sets a new contributor
+     *
+     * A Composite containing details of a Contributor of the Work referenced in the Cue.
+     *
+     * @param \DedexBundle\Entity\Ern42\ContributorType[] $contributor
+     * @return self
+     */
+    public function setContributor(?array $contributor = null)
+    {
+        $this->contributor = $contributor;
+        return $this;
+    }
+
+    /**
+     * Gets as isDance
+     *
+     * A Flag indicating whether a Creation contains dancing (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getIsDance()
+    {
+        return $this->isDance;
+    }
+
+    /**
+     * Sets a new isDance
+     *
+     * A Flag indicating whether a Creation contains dancing (=true) or not (=false).
+     *
+     * @param bool $isDance
+     * @return self
+     */
+    public function setIsDance($isDance)
+    {
+        $this->isDance = $isDance;
+        return $this;
+    }
+
+    /**
+     * Gets as hasMusicalContent
+     *
+     * A Flag indicating whether whether the Creation referenced in the Cue contains musical content such as a SoundRecording or a MusicalWork (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getHasMusicalContent()
+    {
+        return $this->hasMusicalContent;
+    }
+
+    /**
+     * Sets a new hasMusicalContent
+     *
+     * A Flag indicating whether whether the Creation referenced in the Cue contains musical content such as a SoundRecording or a MusicalWork (=true) or not (=false).
+     *
+     * @param bool $hasMusicalContent
+     * @return self
+     */
+    public function setHasMusicalContent($hasMusicalContent)
+    {
+        $this->hasMusicalContent = $hasMusicalContent;
+        return $this;
+    }
+
+    /**
+     * Adds as pLine
+     *
+     * A Composite containing details of the PLine for the Cue.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\PLineType $pLine
+     */
+    public function addToPLine(\DedexBundle\Entity\Ern42\PLineType $pLine)
+    {
+        $this->pLine[] = $pLine;
+        return $this;
+    }
+
+    /**
+     * isset pLine
+     *
+     * A Composite containing details of the PLine for the Cue.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetPLine($index)
+    {
+        return isset($this->pLine[$index]);
+    }
+
+    /**
+     * unset pLine
+     *
+     * A Composite containing details of the PLine for the Cue.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetPLine($index)
+    {
+        unset($this->pLine[$index]);
+    }
+
+    /**
+     * Gets as pLine
+     *
+     * A Composite containing details of the PLine for the Cue.
+     *
+     * @return \DedexBundle\Entity\Ern42\PLineType[]
+     */
+    public function getPLine()
+    {
+        return $this->pLine;
+    }
+
+    /**
+     * Sets a new pLine
+     *
+     * A Composite containing details of the PLine for the Cue.
+     *
+     * @param \DedexBundle\Entity\Ern42\PLineType[] $pLine
+     * @return self
+     */
+    public function setPLine(?array $pLine = null)
+    {
+        $this->pLine = $pLine;
+        return $this;
+    }
+
+    /**
+     * Adds as cLine
+     *
+     * A Composite containing details of the CLine for the Cue.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\CLineType $cLine
+     */
+    public function addToCLine(\DedexBundle\Entity\Ern42\CLineType $cLine)
+    {
+        $this->cLine[] = $cLine;
+        return $this;
+    }
+
+    /**
+     * isset cLine
+     *
+     * A Composite containing details of the CLine for the Cue.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetCLine($index)
+    {
+        return isset($this->cLine[$index]);
+    }
+
+    /**
+     * unset cLine
+     *
+     * A Composite containing details of the CLine for the Cue.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetCLine($index)
+    {
+        unset($this->cLine[$index]);
+    }
+
+    /**
+     * Gets as cLine
+     *
+     * A Composite containing details of the CLine for the Cue.
+     *
+     * @return \DedexBundle\Entity\Ern42\CLineType[]
+     */
+    public function getCLine()
+    {
+        return $this->cLine;
+    }
+
+    /**
+     * Sets a new cLine
+     *
+     * A Composite containing details of the CLine for the Cue.
+     *
+     * @param \DedexBundle\Entity\Ern42\CLineType[] $cLine
+     * @return self
+     */
+    public function setCLine(?array $cLine = null)
+    {
+        $this->cLine = $cLine;
+        return $this;
+    }
+
+    /**
+     * Gets as startTime
+     *
+     * The start time of the Creation, measured from the start of the Resource from which the CueSheet is referenced (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @return \DateInterval
+     */
+    public function getStartTime()
+    {
+        return $this->startTime;
+    }
+
+    /**
+     * Sets a new startTime
+     *
+     * The start time of the Creation, measured from the start of the Resource from which the CueSheet is referenced (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @param \DateInterval $startTime
+     * @return self
+     */
+    public function setStartTime(?\DateInterval $startTime = null)
+    {
+        $this->startTime = $startTime;
+        return $this;
+    }
+
+    /**
+     * Gets as duration
+     *
+     * The Duration of the use of the Creation that is referenced in the CueCreationReference (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @return \DateInterval
+     */
+    public function getDuration()
+    {
+        return $this->duration;
+    }
+
+    /**
+     * Sets a new duration
+     *
+     * The Duration of the use of the Creation that is referenced in the CueCreationReference (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @param \DateInterval $duration
+     * @return self
+     */
+    public function setDuration(?\DateInterval $duration = null)
+    {
+        $this->duration = $duration;
+        return $this;
+    }
+
+    /**
+     * Gets as endTime
+     *
+     * The end time of the Creation, measured from the start of the Resource from which the CueSheet is referenced (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @return \DateInterval
+     */
+    public function getEndTime()
+    {
+        return $this->endTime;
+    }
+
+    /**
+     * Sets a new endTime
+     *
+     * The end time of the Creation, measured from the start of the Resource from which the CueSheet is referenced (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @param \DateInterval $endTime
+     * @return self
+     */
+    public function setEndTime(?\DateInterval $endTime = null)
+    {
+        $this->endTime = $endTime;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/DetailedHashSumType.php
+++ b/src/Entity/Ern42/DetailedHashSumType.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing DetailedHashSumType
+ *
+ * A Composite containing details of a HashSum and its governing algorithm.
+ * Explanatory Note: This Composite is named DetailedHashSum to disambiguate it from the basic HashSum Composite.
+ * XSD Type: DetailedHashSum
+ */
+class DetailedHashSumType
+{
+    /**
+     * A Composite containing details of the Type of HashSumAlgorithm governing the HashSum.
+     *
+     * @var \DedexBundle\Entity\Ern42\HashSumAlgorithmTypeType $algorithm
+     */
+    private $algorithm = null;
+
+    /**
+     * The Identifier of the Version of the HashSumAlgorithm.
+     *
+     * @var string $version
+     */
+    private $version = null;
+
+    /**
+     * A parameter of the HashSumAlgorithm.
+     *
+     * @var string $parameter
+     */
+    private $parameter = null;
+
+    /**
+     * The datatype of the HashSum.
+     *
+     * @var string $dataType
+     */
+    private $dataType = null;
+
+    /**
+     * The value of the HashSum.
+     *
+     * @var string $hashSumValue
+     */
+    private $hashSumValue = null;
+
+    /**
+     * Gets as algorithm
+     *
+     * A Composite containing details of the Type of HashSumAlgorithm governing the HashSum.
+     *
+     * @return \DedexBundle\Entity\Ern42\HashSumAlgorithmTypeType
+     */
+    public function getAlgorithm()
+    {
+        return $this->algorithm;
+    }
+
+    /**
+     * Sets a new algorithm
+     *
+     * A Composite containing details of the Type of HashSumAlgorithm governing the HashSum.
+     *
+     * @param \DedexBundle\Entity\Ern42\HashSumAlgorithmTypeType $algorithm
+     * @return self
+     */
+    public function setAlgorithm(\DedexBundle\Entity\Ern42\HashSumAlgorithmTypeType $algorithm)
+    {
+        $this->algorithm = $algorithm;
+        return $this;
+    }
+
+    /**
+     * Gets as version
+     *
+     * The Identifier of the Version of the HashSumAlgorithm.
+     *
+     * @return string
+     */
+    public function getVersion()
+    {
+        return $this->version;
+    }
+
+    /**
+     * Sets a new version
+     *
+     * The Identifier of the Version of the HashSumAlgorithm.
+     *
+     * @param string $version
+     * @return self
+     */
+    public function setVersion($version)
+    {
+        $this->version = $version;
+        return $this;
+    }
+
+    /**
+     * Gets as parameter
+     *
+     * A parameter of the HashSumAlgorithm.
+     *
+     * @return string
+     */
+    public function getParameter()
+    {
+        return $this->parameter;
+    }
+
+    /**
+     * Sets a new parameter
+     *
+     * A parameter of the HashSumAlgorithm.
+     *
+     * @param string $parameter
+     * @return self
+     */
+    public function setParameter($parameter)
+    {
+        $this->parameter = $parameter;
+        return $this;
+    }
+
+    /**
+     * Gets as dataType
+     *
+     * The datatype of the HashSum.
+     *
+     * @return string
+     */
+    public function getDataType()
+    {
+        return $this->dataType;
+    }
+
+    /**
+     * Sets a new dataType
+     *
+     * The datatype of the HashSum.
+     *
+     * @param string $dataType
+     * @return self
+     */
+    public function setDataType($dataType)
+    {
+        $this->dataType = $dataType;
+        return $this;
+    }
+
+    /**
+     * Gets as hashSumValue
+     *
+     * The value of the HashSum.
+     *
+     * @return string
+     */
+    public function getHashSumValue()
+    {
+        return $this->hashSumValue;
+    }
+
+    /**
+     * Sets a new hashSumValue
+     *
+     * The value of the HashSum.
+     *
+     * @param string $hashSumValue
+     * @return self
+     */
+    public function setHashSumValue($hashSumValue)
+    {
+        $this->hashSumValue = $hashSumValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/DetailedPartyIdType.php
+++ b/src/Entity/Ern42/DetailedPartyIdType.php
@@ -1,0 +1,254 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing DetailedPartyIdType
+ *
+ * A Composite containing details of a PartyId.
+ * Explanatory Note: This Composite is named DetailedPartyId to disambiguate it from the basic PartyId Composite.
+ * XSD Type: DetailedPartyId
+ */
+class DetailedPartyIdType
+{
+    /**
+     * An International Standard Name Identifier, the ISO 27729 Standard Identifier for names. DDEX will enforce the syntax [0-9]{15}[X0-9] using XML Schema in the future.
+     *
+     * @var string $iSNI
+     */
+    private $iSNI = null;
+
+    /**
+     * An Identifier of a Party according to the DdexPartyId standard DDEX-DPID.
+     *
+     * @var string $dPID
+     */
+    private $dPID = null;
+
+    /**
+     * An Interested Party Identifier, a CISAC standard Identifier. An IpiNameNumber comprises 11 digits.
+     *
+     * @var string $ipiNameNumber
+     */
+    private $ipiNameNumber = null;
+
+    /**
+     * An International Performer Number, an IPDA Identifier.
+     *
+     * @var string $iPN
+     */
+    private $iPN = null;
+
+    /**
+     * A CISAC Society Identifier, a CISAC standard Identifier for music rights societies.
+     *
+     * @var string $cisacSocietyId
+     */
+    private $cisacSocietyId = null;
+
+    /**
+     * A Composite containing details of a ProprietaryIdentifier of the Party.
+     *
+     * @var \DedexBundle\Entity\Ern42\ProprietaryIdType[] $proprietaryId
+     */
+    private $proprietaryId = [
+        
+    ];
+
+    /**
+     * Gets as iSNI
+     *
+     * An International Standard Name Identifier, the ISO 27729 Standard Identifier for names. DDEX will enforce the syntax [0-9]{15}[X0-9] using XML Schema in the future.
+     *
+     * @return string
+     */
+    public function getISNI()
+    {
+        return $this->iSNI;
+    }
+
+    /**
+     * Sets a new iSNI
+     *
+     * An International Standard Name Identifier, the ISO 27729 Standard Identifier for names. DDEX will enforce the syntax [0-9]{15}[X0-9] using XML Schema in the future.
+     *
+     * @param string $iSNI
+     * @return self
+     */
+    public function setISNI($iSNI)
+    {
+        $this->iSNI = $iSNI;
+        return $this;
+    }
+
+    /**
+     * Gets as dPID
+     *
+     * An Identifier of a Party according to the DdexPartyId standard DDEX-DPID.
+     *
+     * @return string
+     */
+    public function getDPID()
+    {
+        return $this->dPID;
+    }
+
+    /**
+     * Sets a new dPID
+     *
+     * An Identifier of a Party according to the DdexPartyId standard DDEX-DPID.
+     *
+     * @param string $dPID
+     * @return self
+     */
+    public function setDPID($dPID)
+    {
+        $this->dPID = $dPID;
+        return $this;
+    }
+
+    /**
+     * Gets as ipiNameNumber
+     *
+     * An Interested Party Identifier, a CISAC standard Identifier. An IpiNameNumber comprises 11 digits.
+     *
+     * @return string
+     */
+    public function getIpiNameNumber()
+    {
+        return $this->ipiNameNumber;
+    }
+
+    /**
+     * Sets a new ipiNameNumber
+     *
+     * An Interested Party Identifier, a CISAC standard Identifier. An IpiNameNumber comprises 11 digits.
+     *
+     * @param string $ipiNameNumber
+     * @return self
+     */
+    public function setIpiNameNumber($ipiNameNumber)
+    {
+        $this->ipiNameNumber = $ipiNameNumber;
+        return $this;
+    }
+
+    /**
+     * Gets as iPN
+     *
+     * An International Performer Number, an IPDA Identifier.
+     *
+     * @return string
+     */
+    public function getIPN()
+    {
+        return $this->iPN;
+    }
+
+    /**
+     * Sets a new iPN
+     *
+     * An International Performer Number, an IPDA Identifier.
+     *
+     * @param string $iPN
+     * @return self
+     */
+    public function setIPN($iPN)
+    {
+        $this->iPN = $iPN;
+        return $this;
+    }
+
+    /**
+     * Gets as cisacSocietyId
+     *
+     * A CISAC Society Identifier, a CISAC standard Identifier for music rights societies.
+     *
+     * @return string
+     */
+    public function getCisacSocietyId()
+    {
+        return $this->cisacSocietyId;
+    }
+
+    /**
+     * Sets a new cisacSocietyId
+     *
+     * A CISAC Society Identifier, a CISAC standard Identifier for music rights societies.
+     *
+     * @param string $cisacSocietyId
+     * @return self
+     */
+    public function setCisacSocietyId($cisacSocietyId)
+    {
+        $this->cisacSocietyId = $cisacSocietyId;
+        return $this;
+    }
+
+    /**
+     * Adds as proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Party.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ProprietaryIdType $proprietaryId
+     */
+    public function addToProprietaryId(\DedexBundle\Entity\Ern42\ProprietaryIdType $proprietaryId)
+    {
+        $this->proprietaryId[] = $proprietaryId;
+        return $this;
+    }
+
+    /**
+     * isset proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Party.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetProprietaryId($index)
+    {
+        return isset($this->proprietaryId[$index]);
+    }
+
+    /**
+     * unset proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Party.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetProprietaryId($index)
+    {
+        unset($this->proprietaryId[$index]);
+    }
+
+    /**
+     * Gets as proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Party.
+     *
+     * @return \DedexBundle\Entity\Ern42\ProprietaryIdType[]
+     */
+    public function getProprietaryId()
+    {
+        return $this->proprietaryId;
+    }
+
+    /**
+     * Sets a new proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Party.
+     *
+     * @param \DedexBundle\Entity\Ern42\ProprietaryIdType[] $proprietaryId
+     * @return self
+     */
+    public function setProprietaryId(?array $proprietaryId = null)
+    {
+        $this->proprietaryId = $proprietaryId;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/DetailedResourceContributorType.php
+++ b/src/Entity/Ern42/DetailedResourceContributorType.php
@@ -1,0 +1,503 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing DetailedResourceContributorType
+ *
+ * A Composite containing details of the Name, Identifier and Role(s) of a Contributor to a Resource.
+ * Explanatory Note: This Composite is named DetailedResourceContributor to disambiguate it from the basic ResourceContributor Composite.
+ * XSD Type: DetailedResourceContributor
+ */
+class DetailedResourceContributorType
+{
+    /**
+     * The number indicating the order of the ResourceContributor in a group of ResourceContributors that have contributed to a Resource. This is represented in an XML schema as an XML Attribute. 
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/sequencing-recording-artists-and-writers
+     *
+     * @var int $sequenceNumber
+     */
+    private $sequenceNumber = null;
+
+    /**
+     * A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.
+     *
+     * @var \DedexBundle\Entity\Ern42\DetailedPartyIdType[] $partyId
+     */
+    private $partyId = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the PartyName(s).
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers
+     *
+     * @var \DedexBundle\Entity\Ern42\PartyNameType[] $partyName
+     */
+    private $partyName = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Role played by the Contributor.
+     *
+     * @var \DedexBundle\Entity\Ern42\ContributorRoleType[] $role
+     */
+    private $role = [
+        
+    ];
+
+    /**
+     * A Type of musical Instrument played by the Artist.
+     *
+     * @var \DedexBundle\Entity\Ern42\InstrumentTypeType[] $instrumentType
+     */
+    private $instrumentType = [
+        
+    ];
+
+    /**
+     * A Flag indicating whether the Contributor is a featured Artist (=true) or not (=false).
+     *
+     * @var bool $hasMadeFeaturedContribution
+     */
+    private $hasMadeFeaturedContribution = null;
+
+    /**
+     * A Flag indicating whether the Contributor is an Artist that has a contract for its part in creating the Resource (=true) or not (=false).
+     *
+     * @var bool $hasMadeContractedContribution
+     */
+    private $hasMadeContractedContribution = null;
+
+    /**
+     * A Role for which the Party is credited.
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayCreditsType[] $displayCredits
+     */
+    private $displayCredits = [
+        
+    ];
+
+    /**
+     * Gets as sequenceNumber
+     *
+     * The number indicating the order of the ResourceContributor in a group of ResourceContributors that have contributed to a Resource. This is represented in an XML schema as an XML Attribute. 
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/sequencing-recording-artists-and-writers
+     *
+     * @return int
+     */
+    public function getSequenceNumber()
+    {
+        return $this->sequenceNumber;
+    }
+
+    /**
+     * Sets a new sequenceNumber
+     *
+     * The number indicating the order of the ResourceContributor in a group of ResourceContributors that have contributed to a Resource. This is represented in an XML schema as an XML Attribute. 
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/sequencing-recording-artists-and-writers
+     *
+     * @param int $sequenceNumber
+     * @return self
+     */
+    public function setSequenceNumber($sequenceNumber)
+    {
+        $this->sequenceNumber = $sequenceNumber;
+        return $this;
+    }
+
+    /**
+     * Adds as partyId
+     *
+     * A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DetailedPartyIdType $partyId
+     */
+    public function addToPartyId(\DedexBundle\Entity\Ern42\DetailedPartyIdType $partyId)
+    {
+        $this->partyId[] = $partyId;
+        return $this;
+    }
+
+    /**
+     * isset partyId
+     *
+     * A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetPartyId($index)
+    {
+        return isset($this->partyId[$index]);
+    }
+
+    /**
+     * unset partyId
+     *
+     * A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetPartyId($index)
+    {
+        unset($this->partyId[$index]);
+    }
+
+    /**
+     * Gets as partyId
+     *
+     * A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.
+     *
+     * @return \DedexBundle\Entity\Ern42\DetailedPartyIdType[]
+     */
+    public function getPartyId()
+    {
+        return $this->partyId;
+    }
+
+    /**
+     * Sets a new partyId
+     *
+     * A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.
+     *
+     * @param \DedexBundle\Entity\Ern42\DetailedPartyIdType[] $partyId
+     * @return self
+     */
+    public function setPartyId(?array $partyId = null)
+    {
+        $this->partyId = $partyId;
+        return $this;
+    }
+
+    /**
+     * Adds as partyName
+     *
+     * A Composite containing details of the PartyName(s).
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\PartyNameType $partyName
+     */
+    public function addToPartyName(\DedexBundle\Entity\Ern42\PartyNameType $partyName)
+    {
+        $this->partyName[] = $partyName;
+        return $this;
+    }
+
+    /**
+     * isset partyName
+     *
+     * A Composite containing details of the PartyName(s).
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetPartyName($index)
+    {
+        return isset($this->partyName[$index]);
+    }
+
+    /**
+     * unset partyName
+     *
+     * A Composite containing details of the PartyName(s).
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetPartyName($index)
+    {
+        unset($this->partyName[$index]);
+    }
+
+    /**
+     * Gets as partyName
+     *
+     * A Composite containing details of the PartyName(s).
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers
+     *
+     * @return \DedexBundle\Entity\Ern42\PartyNameType[]
+     */
+    public function getPartyName()
+    {
+        return $this->partyName;
+    }
+
+    /**
+     * Sets a new partyName
+     *
+     * A Composite containing details of the PartyName(s).
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers
+     *
+     * @param \DedexBundle\Entity\Ern42\PartyNameType[] $partyName
+     * @return self
+     */
+    public function setPartyName(?array $partyName = null)
+    {
+        $this->partyName = $partyName;
+        return $this;
+    }
+
+    /**
+     * Adds as role
+     *
+     * A Composite containing details of a Role played by the Contributor.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ContributorRoleType $role
+     */
+    public function addToRole(\DedexBundle\Entity\Ern42\ContributorRoleType $role)
+    {
+        $this->role[] = $role;
+        return $this;
+    }
+
+    /**
+     * isset role
+     *
+     * A Composite containing details of a Role played by the Contributor.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRole($index)
+    {
+        return isset($this->role[$index]);
+    }
+
+    /**
+     * unset role
+     *
+     * A Composite containing details of a Role played by the Contributor.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRole($index)
+    {
+        unset($this->role[$index]);
+    }
+
+    /**
+     * Gets as role
+     *
+     * A Composite containing details of a Role played by the Contributor.
+     *
+     * @return \DedexBundle\Entity\Ern42\ContributorRoleType[]
+     */
+    public function getRole()
+    {
+        return $this->role;
+    }
+
+    /**
+     * Sets a new role
+     *
+     * A Composite containing details of a Role played by the Contributor.
+     *
+     * @param \DedexBundle\Entity\Ern42\ContributorRoleType[] $role
+     * @return self
+     */
+    public function setRole(?array $role = null)
+    {
+        $this->role = $role;
+        return $this;
+    }
+
+    /**
+     * Adds as instrumentType
+     *
+     * A Type of musical Instrument played by the Artist.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\InstrumentTypeType $instrumentType
+     */
+    public function addToInstrumentType(\DedexBundle\Entity\Ern42\InstrumentTypeType $instrumentType)
+    {
+        $this->instrumentType[] = $instrumentType;
+        return $this;
+    }
+
+    /**
+     * isset instrumentType
+     *
+     * A Type of musical Instrument played by the Artist.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetInstrumentType($index)
+    {
+        return isset($this->instrumentType[$index]);
+    }
+
+    /**
+     * unset instrumentType
+     *
+     * A Type of musical Instrument played by the Artist.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetInstrumentType($index)
+    {
+        unset($this->instrumentType[$index]);
+    }
+
+    /**
+     * Gets as instrumentType
+     *
+     * A Type of musical Instrument played by the Artist.
+     *
+     * @return \DedexBundle\Entity\Ern42\InstrumentTypeType[]
+     */
+    public function getInstrumentType()
+    {
+        return $this->instrumentType;
+    }
+
+    /**
+     * Sets a new instrumentType
+     *
+     * A Type of musical Instrument played by the Artist.
+     *
+     * @param \DedexBundle\Entity\Ern42\InstrumentTypeType[] $instrumentType
+     * @return self
+     */
+    public function setInstrumentType(?array $instrumentType = null)
+    {
+        $this->instrumentType = $instrumentType;
+        return $this;
+    }
+
+    /**
+     * Gets as hasMadeFeaturedContribution
+     *
+     * A Flag indicating whether the Contributor is a featured Artist (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getHasMadeFeaturedContribution()
+    {
+        return $this->hasMadeFeaturedContribution;
+    }
+
+    /**
+     * Sets a new hasMadeFeaturedContribution
+     *
+     * A Flag indicating whether the Contributor is a featured Artist (=true) or not (=false).
+     *
+     * @param bool $hasMadeFeaturedContribution
+     * @return self
+     */
+    public function setHasMadeFeaturedContribution($hasMadeFeaturedContribution)
+    {
+        $this->hasMadeFeaturedContribution = $hasMadeFeaturedContribution;
+        return $this;
+    }
+
+    /**
+     * Gets as hasMadeContractedContribution
+     *
+     * A Flag indicating whether the Contributor is an Artist that has a contract for its part in creating the Resource (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getHasMadeContractedContribution()
+    {
+        return $this->hasMadeContractedContribution;
+    }
+
+    /**
+     * Sets a new hasMadeContractedContribution
+     *
+     * A Flag indicating whether the Contributor is an Artist that has a contract for its part in creating the Resource (=true) or not (=false).
+     *
+     * @param bool $hasMadeContractedContribution
+     * @return self
+     */
+    public function setHasMadeContractedContribution($hasMadeContractedContribution)
+    {
+        $this->hasMadeContractedContribution = $hasMadeContractedContribution;
+        return $this;
+    }
+
+    /**
+     * Adds as displayCredits
+     *
+     * A Role for which the Party is credited.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayCreditsType $displayCredits
+     */
+    public function addToDisplayCredits(\DedexBundle\Entity\Ern42\DisplayCreditsType $displayCredits)
+    {
+        $this->displayCredits[] = $displayCredits;
+        return $this;
+    }
+
+    /**
+     * isset displayCredits
+     *
+     * A Role for which the Party is credited.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayCredits($index)
+    {
+        return isset($this->displayCredits[$index]);
+    }
+
+    /**
+     * unset displayCredits
+     *
+     * A Role for which the Party is credited.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayCredits($index)
+    {
+        unset($this->displayCredits[$index]);
+    }
+
+    /**
+     * Gets as displayCredits
+     *
+     * A Role for which the Party is credited.
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayCreditsType[]
+     */
+    public function getDisplayCredits()
+    {
+        return $this->displayCredits;
+    }
+
+    /**
+     * Sets a new displayCredits
+     *
+     * A Role for which the Party is credited.
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayCreditsType[] $displayCredits
+     * @return self
+     */
+    public function setDisplayCredits(?array $displayCredits = null)
+    {
+        $this->displayCredits = $displayCredits;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/DiscoverableUseTypeType.php
+++ b/src/Entity/Ern42/DiscoverableUseTypeType.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing DiscoverableUseTypeType
+ *
+ * A Composite containing details of a UseType.
+ * XSD Type: DiscoverableUseType
+ */
+class DiscoverableUseTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the UseType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A Flag indicating whether the Deal allows the ReleaseDistributor to include the release(s) referenced in the Deal to be indexed and searchable by Consumers on the ReleaseDistributor’s platform (=true) or not (=false). If this Attribute is not provided, it is assumed that this is True.
+     *
+     * @var bool $isDiscoverable
+     */
+    private $isDiscoverable = null;
+
+    /**
+     * A UserDefined value of the UseType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the UseType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the UseType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as isDiscoverable
+     *
+     * A Flag indicating whether the Deal allows the ReleaseDistributor to include the release(s) referenced in the Deal to be indexed and searchable by Consumers on the ReleaseDistributor’s platform (=true) or not (=false). If this Attribute is not provided, it is assumed that this is True.
+     *
+     * @return bool
+     */
+    public function getIsDiscoverable()
+    {
+        return $this->isDiscoverable;
+    }
+
+    /**
+     * Sets a new isDiscoverable
+     *
+     * A Flag indicating whether the Deal allows the ReleaseDistributor to include the release(s) referenced in the Deal to be indexed and searchable by Consumers on the ReleaseDistributor’s platform (=true) or not (=false). If this Attribute is not provided, it is assumed that this is True.
+     *
+     * @param bool $isDiscoverable
+     * @return self
+     */
+    public function setIsDiscoverable($isDiscoverable)
+    {
+        $this->isDiscoverable = $isDiscoverable;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the UseType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the UseType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/DisplayArtistNameWithDefaultType.php
+++ b/src/Entity/Ern42/DisplayArtistNameWithDefaultType.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing DisplayArtistNameWithDefaultType
+ *
+ * A Composite containing details of a DisplayArtistName.
+ * Explanatory Note: This Composite is named DisplayArtistNameWithDefault to disambiguate it from the basic DisplayArtistName Composite.
+ * XSD Type: DisplayArtistNameWithDefault
+ */
+class DisplayArtistNameWithDefaultType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Language and script of the Name as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * A Territory to which the Name applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script of the Name as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script of the Name as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the Name applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the Name applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/DisplayArtistRoleType.php
+++ b/src/Entity/Ern42/DisplayArtistRoleType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing DisplayArtistRoleType
+ *
+ * A Composite containing details of a DisplayArtistRole.
+ * XSD Type: DisplayArtistRole
+ */
+class DisplayArtistRoleType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the DisplayArtistRole. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the DisplayArtistRole. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the DisplayArtistRole. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the DisplayArtistRole. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the DisplayArtistRole. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the DisplayArtistRole. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/DisplayArtistType.php
+++ b/src/Entity/Ern42/DisplayArtistType.php
@@ -1,0 +1,265 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing DisplayArtistType
+ *
+ * A Composite containing details of the Name, Identifier and Role(s) of a DisplayArtist of a Resource.
+ * XSD Type: DisplayArtist
+ */
+class DisplayArtistType
+{
+    /**
+     * The number indicating the order of the Resource DisplayArtist in a group of Artists that have contributed to a Resource. This is represented in an XML schema as an XML Attribute. 
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/sequencing-recording-artists-and-writers
+     *
+     * @var int $sequenceNumber
+     */
+    private $sequenceNumber = null;
+
+    /**
+     * A Reference for a Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @var string $artistPartyReference
+     */
+    private $artistPartyReference = null;
+
+    /**
+     * A Composite containing details of a Role played by the DisplayArtist.
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayArtistRoleType $displayArtistRole
+     */
+    private $displayArtistRole = null;
+
+    /**
+     * A Composite containing details of a ContributorRole played by the DisplayArtist.
+     *
+     * @var \DedexBundle\Entity\Ern42\ContributorRoleType[] $artisticRole
+     */
+    private $artisticRole = [
+        
+    ];
+
+    /**
+     * A Composite containing information on how a RecordCompany wishes Artist information to be presented to Consumers as part of the Title (and in addition to displaying the DisplayArtist information).
+     *
+     * @var \DedexBundle\Entity\Ern42\TitleDisplayInformationType[] $titleDisplayInformation
+     */
+    private $titleDisplayInformation = [
+        
+    ];
+
+    /**
+     * Gets as sequenceNumber
+     *
+     * The number indicating the order of the Resource DisplayArtist in a group of Artists that have contributed to a Resource. This is represented in an XML schema as an XML Attribute. 
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/sequencing-recording-artists-and-writers
+     *
+     * @return int
+     */
+    public function getSequenceNumber()
+    {
+        return $this->sequenceNumber;
+    }
+
+    /**
+     * Sets a new sequenceNumber
+     *
+     * The number indicating the order of the Resource DisplayArtist in a group of Artists that have contributed to a Resource. This is represented in an XML schema as an XML Attribute. 
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/sequencing-recording-artists-and-writers
+     *
+     * @param int $sequenceNumber
+     * @return self
+     */
+    public function setSequenceNumber($sequenceNumber)
+    {
+        $this->sequenceNumber = $sequenceNumber;
+        return $this;
+    }
+
+    /**
+     * Gets as artistPartyReference
+     *
+     * A Reference for a Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @return string
+     */
+    public function getArtistPartyReference()
+    {
+        return $this->artistPartyReference;
+    }
+
+    /**
+     * Sets a new artistPartyReference
+     *
+     * A Reference for a Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @param string $artistPartyReference
+     * @return self
+     */
+    public function setArtistPartyReference($artistPartyReference)
+    {
+        $this->artistPartyReference = $artistPartyReference;
+        return $this;
+    }
+
+    /**
+     * Gets as displayArtistRole
+     *
+     * A Composite containing details of a Role played by the DisplayArtist.
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayArtistRoleType
+     */
+    public function getDisplayArtistRole()
+    {
+        return $this->displayArtistRole;
+    }
+
+    /**
+     * Sets a new displayArtistRole
+     *
+     * A Composite containing details of a Role played by the DisplayArtist.
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistRoleType $displayArtistRole
+     * @return self
+     */
+    public function setDisplayArtistRole(\DedexBundle\Entity\Ern42\DisplayArtistRoleType $displayArtistRole)
+    {
+        $this->displayArtistRole = $displayArtistRole;
+        return $this;
+    }
+
+    /**
+     * Adds as artisticRole
+     *
+     * A Composite containing details of a ContributorRole played by the DisplayArtist.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ContributorRoleType $artisticRole
+     */
+    public function addToArtisticRole(\DedexBundle\Entity\Ern42\ContributorRoleType $artisticRole)
+    {
+        $this->artisticRole[] = $artisticRole;
+        return $this;
+    }
+
+    /**
+     * isset artisticRole
+     *
+     * A Composite containing details of a ContributorRole played by the DisplayArtist.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetArtisticRole($index)
+    {
+        return isset($this->artisticRole[$index]);
+    }
+
+    /**
+     * unset artisticRole
+     *
+     * A Composite containing details of a ContributorRole played by the DisplayArtist.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetArtisticRole($index)
+    {
+        unset($this->artisticRole[$index]);
+    }
+
+    /**
+     * Gets as artisticRole
+     *
+     * A Composite containing details of a ContributorRole played by the DisplayArtist.
+     *
+     * @return \DedexBundle\Entity\Ern42\ContributorRoleType[]
+     */
+    public function getArtisticRole()
+    {
+        return $this->artisticRole;
+    }
+
+    /**
+     * Sets a new artisticRole
+     *
+     * A Composite containing details of a ContributorRole played by the DisplayArtist.
+     *
+     * @param \DedexBundle\Entity\Ern42\ContributorRoleType[] $artisticRole
+     * @return self
+     */
+    public function setArtisticRole(?array $artisticRole = null)
+    {
+        $this->artisticRole = $artisticRole;
+        return $this;
+    }
+
+    /**
+     * Adds as titleDisplayInformation
+     *
+     * A Composite containing information on how a RecordCompany wishes Artist information to be presented to Consumers as part of the Title (and in addition to displaying the DisplayArtist information).
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\TitleDisplayInformationType $titleDisplayInformation
+     */
+    public function addToTitleDisplayInformation(\DedexBundle\Entity\Ern42\TitleDisplayInformationType $titleDisplayInformation)
+    {
+        $this->titleDisplayInformation[] = $titleDisplayInformation;
+        return $this;
+    }
+
+    /**
+     * isset titleDisplayInformation
+     *
+     * A Composite containing information on how a RecordCompany wishes Artist information to be presented to Consumers as part of the Title (and in addition to displaying the DisplayArtist information).
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetTitleDisplayInformation($index)
+    {
+        return isset($this->titleDisplayInformation[$index]);
+    }
+
+    /**
+     * unset titleDisplayInformation
+     *
+     * A Composite containing information on how a RecordCompany wishes Artist information to be presented to Consumers as part of the Title (and in addition to displaying the DisplayArtist information).
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetTitleDisplayInformation($index)
+    {
+        unset($this->titleDisplayInformation[$index]);
+    }
+
+    /**
+     * Gets as titleDisplayInformation
+     *
+     * A Composite containing information on how a RecordCompany wishes Artist information to be presented to Consumers as part of the Title (and in addition to displaying the DisplayArtist information).
+     *
+     * @return \DedexBundle\Entity\Ern42\TitleDisplayInformationType[]
+     */
+    public function getTitleDisplayInformation()
+    {
+        return $this->titleDisplayInformation;
+    }
+
+    /**
+     * Sets a new titleDisplayInformation
+     *
+     * A Composite containing information on how a RecordCompany wishes Artist information to be presented to Consumers as part of the Title (and in addition to displaying the DisplayArtist information).
+     *
+     * @param \DedexBundle\Entity\Ern42\TitleDisplayInformationType[] $titleDisplayInformation
+     * @return self
+     */
+    public function setTitleDisplayInformation(?array $titleDisplayInformation = null)
+    {
+        $this->titleDisplayInformation = $titleDisplayInformation;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/DisplayCreditsType.php
+++ b/src/Entity/Ern42/DisplayCreditsType.php
@@ -1,0 +1,295 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing DisplayCreditsType
+ *
+ * A Composite containing details of a Role and instrumentation for which a Party is credited.
+ * XSD Type: DisplayCredits
+ */
+class DisplayCreditsType
+{
+    /**
+     * The Language and script of this Element as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * A Territory to which this Element applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Element provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * The textual portion of the display credit.
+     *
+     * @var string $displayCreditText
+     */
+    private $displayCreditText = null;
+
+    /**
+     * A Reference for a Party credited with the display credit.
+     *
+     * @var string[] $displayCreditParty
+     */
+    private $displayCreditParty = [
+        
+    ];
+
+    /**
+     * The Name for the Party as used in the DisplayCreditText. If no such element is present, the DisplayCreditText contains the Name of the credited Party as specified in the PartyName of the Party composite.
+     *
+     * @var string[] $nameUsedInDisplayCredit
+     */
+    private $nameUsedInDisplayCredit = [
+        
+    ];
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script of this Element as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script of this Element as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which this Element applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which this Element applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Element provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Element provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+
+    /**
+     * Gets as displayCreditText
+     *
+     * The textual portion of the display credit.
+     *
+     * @return string
+     */
+    public function getDisplayCreditText()
+    {
+        return $this->displayCreditText;
+    }
+
+    /**
+     * Sets a new displayCreditText
+     *
+     * The textual portion of the display credit.
+     *
+     * @param string $displayCreditText
+     * @return self
+     */
+    public function setDisplayCreditText($displayCreditText)
+    {
+        $this->displayCreditText = $displayCreditText;
+        return $this;
+    }
+
+    /**
+     * Adds as displayCreditParty
+     *
+     * A Reference for a Party credited with the display credit.
+     *
+     * @return self
+     * @param string $displayCreditParty
+     */
+    public function addToDisplayCreditParty($displayCreditParty)
+    {
+        $this->displayCreditParty[] = $displayCreditParty;
+        return $this;
+    }
+
+    /**
+     * isset displayCreditParty
+     *
+     * A Reference for a Party credited with the display credit.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayCreditParty($index)
+    {
+        return isset($this->displayCreditParty[$index]);
+    }
+
+    /**
+     * unset displayCreditParty
+     *
+     * A Reference for a Party credited with the display credit.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayCreditParty($index)
+    {
+        unset($this->displayCreditParty[$index]);
+    }
+
+    /**
+     * Gets as displayCreditParty
+     *
+     * A Reference for a Party credited with the display credit.
+     *
+     * @return string[]
+     */
+    public function getDisplayCreditParty()
+    {
+        return $this->displayCreditParty;
+    }
+
+    /**
+     * Sets a new displayCreditParty
+     *
+     * A Reference for a Party credited with the display credit.
+     *
+     * @param string $displayCreditParty
+     * @return self
+     */
+    public function setDisplayCreditParty(?array $displayCreditParty = null)
+    {
+        $this->displayCreditParty = $displayCreditParty;
+        return $this;
+    }
+
+    /**
+     * Adds as nameUsedInDisplayCredit
+     *
+     * The Name for the Party as used in the DisplayCreditText. If no such element is present, the DisplayCreditText contains the Name of the credited Party as specified in the PartyName of the Party composite.
+     *
+     * @return self
+     * @param string $nameUsedInDisplayCredit
+     */
+    public function addToNameUsedInDisplayCredit($nameUsedInDisplayCredit)
+    {
+        $this->nameUsedInDisplayCredit[] = $nameUsedInDisplayCredit;
+        return $this;
+    }
+
+    /**
+     * isset nameUsedInDisplayCredit
+     *
+     * The Name for the Party as used in the DisplayCreditText. If no such element is present, the DisplayCreditText contains the Name of the credited Party as specified in the PartyName of the Party composite.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetNameUsedInDisplayCredit($index)
+    {
+        return isset($this->nameUsedInDisplayCredit[$index]);
+    }
+
+    /**
+     * unset nameUsedInDisplayCredit
+     *
+     * The Name for the Party as used in the DisplayCreditText. If no such element is present, the DisplayCreditText contains the Name of the credited Party as specified in the PartyName of the Party composite.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetNameUsedInDisplayCredit($index)
+    {
+        unset($this->nameUsedInDisplayCredit[$index]);
+    }
+
+    /**
+     * Gets as nameUsedInDisplayCredit
+     *
+     * The Name for the Party as used in the DisplayCreditText. If no such element is present, the DisplayCreditText contains the Name of the credited Party as specified in the PartyName of the Party composite.
+     *
+     * @return string[]
+     */
+    public function getNameUsedInDisplayCredit()
+    {
+        return $this->nameUsedInDisplayCredit;
+    }
+
+    /**
+     * Sets a new nameUsedInDisplayCredit
+     *
+     * The Name for the Party as used in the DisplayCreditText. If no such element is present, the DisplayCreditText contains the Name of the credited Party as specified in the PartyName of the Party composite.
+     *
+     * @param string[] $nameUsedInDisplayCredit
+     * @return self
+     */
+    public function setNameUsedInDisplayCredit(?array $nameUsedInDisplayCredit = null)
+    {
+        $this->nameUsedInDisplayCredit = $nameUsedInDisplayCredit;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/DisplaySubTitleType.php
+++ b/src/Entity/Ern42/DisplaySubTitleType.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing DisplaySubTitleType
+ *
+ * A Composite containing details of a SubTitle.
+ * Explanatory Note: This Composite is named DisplaySubTitle to disambiguate it from the basic SubTitle Composite.
+ * XSD Type: DisplaySubTitle
+ */
+class DisplaySubTitleType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The number indicating the order of the SubTitle in a group of SubTitles. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var int $sequenceNumber
+     */
+    private $sequenceNumber = null;
+
+    /**
+     * A Flag indicating whether the SubTitle is displayed in the Title (=true) or not (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDisplayedInTitle
+     */
+    private $isDisplayedInTitle = null;
+
+    /**
+     * A Type of the SubTitle which defines its origin or the function it fulfils. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $subTitleType
+     */
+    private $subTitleType = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as sequenceNumber
+     *
+     * The number indicating the order of the SubTitle in a group of SubTitles. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return int
+     */
+    public function getSequenceNumber()
+    {
+        return $this->sequenceNumber;
+    }
+
+    /**
+     * Sets a new sequenceNumber
+     *
+     * The number indicating the order of the SubTitle in a group of SubTitles. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param int $sequenceNumber
+     * @return self
+     */
+    public function setSequenceNumber($sequenceNumber)
+    {
+        $this->sequenceNumber = $sequenceNumber;
+        return $this;
+    }
+
+    /**
+     * Gets as isDisplayedInTitle
+     *
+     * A Flag indicating whether the SubTitle is displayed in the Title (=true) or not (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDisplayedInTitle()
+    {
+        return $this->isDisplayedInTitle;
+    }
+
+    /**
+     * Sets a new isDisplayedInTitle
+     *
+     * A Flag indicating whether the SubTitle is displayed in the Title (=true) or not (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDisplayedInTitle
+     * @return self
+     */
+    public function setIsDisplayedInTitle($isDisplayedInTitle)
+    {
+        $this->isDisplayedInTitle = $isDisplayedInTitle;
+        return $this;
+    }
+
+    /**
+     * Gets as subTitleType
+     *
+     * A Type of the SubTitle which defines its origin or the function it fulfils. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getSubTitleType()
+    {
+        return $this->subTitleType;
+    }
+
+    /**
+     * Sets a new subTitleType
+     *
+     * A Type of the SubTitle which defines its origin or the function it fulfils. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $subTitleType
+     * @return self
+     */
+    public function setSubTitleType($subTitleType)
+    {
+        $this->subTitleType = $subTitleType;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/DisplayTitleTextType.php
+++ b/src/Entity/Ern42/DisplayTitleTextType.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing DisplayTitleTextType
+ *
+ * A Composite containing details of a Title as the MessageSender suggests it should be shown to the Consumer.
+ * XSD Type: DisplayTitleText
+ */
+class DisplayTitleTextType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Language and script for the Elements of the Title as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * A Territory to which the Title applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the Elements of the Title as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the Elements of the Title as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the Title applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the Title applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/DisplayTitleType.php
+++ b/src/Entity/Ern42/DisplayTitleType.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing DisplayTitleType
+ *
+ * A Composite containing details of a Title as the MessageSender suggests it should be shown to the Consumer.
+ * XSD Type: DisplayTitle
+ */
+class DisplayTitleType
+{
+    /**
+     * The Language and script for the Elements of the Title as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * A Territory to which the Title applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * The text of the Title.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @var string $titleText
+     */
+    private $titleText = null;
+
+    /**
+     * A Composite containing details of a SubTitle of the Title, including Titles of Versions used to differentiate different versions of the same Title, as required by the GRid and ISRC ReferenceDescriptiveMetadataSets.
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplaySubTitleType[] $subTitle
+     */
+    private $subTitle = [
+        
+    ];
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the Elements of the Title as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the Elements of the Title as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the Title applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the Title applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+
+    /**
+     * Gets as titleText
+     *
+     * The text of the Title.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return string
+     */
+    public function getTitleText()
+    {
+        return $this->titleText;
+    }
+
+    /**
+     * Sets a new titleText
+     *
+     * The text of the Title.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param string $titleText
+     * @return self
+     */
+    public function setTitleText($titleText)
+    {
+        $this->titleText = $titleText;
+        return $this;
+    }
+
+    /**
+     * Adds as subTitle
+     *
+     * A Composite containing details of a SubTitle of the Title, including Titles of Versions used to differentiate different versions of the same Title, as required by the GRid and ISRC ReferenceDescriptiveMetadataSets.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplaySubTitleType $subTitle
+     */
+    public function addToSubTitle(\DedexBundle\Entity\Ern42\DisplaySubTitleType $subTitle)
+    {
+        $this->subTitle[] = $subTitle;
+        return $this;
+    }
+
+    /**
+     * isset subTitle
+     *
+     * A Composite containing details of a SubTitle of the Title, including Titles of Versions used to differentiate different versions of the same Title, as required by the GRid and ISRC ReferenceDescriptiveMetadataSets.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetSubTitle($index)
+    {
+        return isset($this->subTitle[$index]);
+    }
+
+    /**
+     * unset subTitle
+     *
+     * A Composite containing details of a SubTitle of the Title, including Titles of Versions used to differentiate different versions of the same Title, as required by the GRid and ISRC ReferenceDescriptiveMetadataSets.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetSubTitle($index)
+    {
+        unset($this->subTitle[$index]);
+    }
+
+    /**
+     * Gets as subTitle
+     *
+     * A Composite containing details of a SubTitle of the Title, including Titles of Versions used to differentiate different versions of the same Title, as required by the GRid and ISRC ReferenceDescriptiveMetadataSets.
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplaySubTitleType[]
+     */
+    public function getSubTitle()
+    {
+        return $this->subTitle;
+    }
+
+    /**
+     * Sets a new subTitle
+     *
+     * A Composite containing details of a SubTitle of the Title, including Titles of Versions used to differentiate different versions of the same Title, as required by the GRid and ISRC ReferenceDescriptiveMetadataSets.
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplaySubTitleType[] $subTitle
+     * @return self
+     */
+    public function setSubTitle(?array $subTitle = null)
+    {
+        $this->subTitle = $subTitle;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/DistributionChannelPageType.php
+++ b/src/Entity/Ern42/DistributionChannelPageType.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing DistributionChannelPageType
+ *
+ * A Composite containing details of a WebPage for a DistributionChannel.
+ * XSD Type: DistributionChannelPage
+ */
+class DistributionChannelPageType
+{
+    /**
+     * A Composite containing details of the PartyId for a Party owning the WebPage. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.
+     *
+     * @var \DedexBundle\Entity\Ern42\DetailedPartyIdType[] $partyId
+     */
+    private $partyId = [
+        
+    ];
+
+    /**
+     * A Composite containing the Name of the WebPage.
+     *
+     * @var \DedexBundle\Entity\Ern42\NameType $pageName
+     */
+    private $pageName = null;
+
+    /**
+     * A URL of the WebPage.
+     *
+     * @var string $uRL
+     */
+    private $uRL = null;
+
+    /**
+     * An Identifier of a computer user who is granted maintenance access to the WebPage.
+     *
+     * @var string $userName
+     */
+    private $userName = null;
+
+    /**
+     * Adds as partyId
+     *
+     * A Composite containing details of the PartyId for a Party owning the WebPage. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DetailedPartyIdType $partyId
+     */
+    public function addToPartyId(\DedexBundle\Entity\Ern42\DetailedPartyIdType $partyId)
+    {
+        $this->partyId[] = $partyId;
+        return $this;
+    }
+
+    /**
+     * isset partyId
+     *
+     * A Composite containing details of the PartyId for a Party owning the WebPage. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetPartyId($index)
+    {
+        return isset($this->partyId[$index]);
+    }
+
+    /**
+     * unset partyId
+     *
+     * A Composite containing details of the PartyId for a Party owning the WebPage. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetPartyId($index)
+    {
+        unset($this->partyId[$index]);
+    }
+
+    /**
+     * Gets as partyId
+     *
+     * A Composite containing details of the PartyId for a Party owning the WebPage. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.
+     *
+     * @return \DedexBundle\Entity\Ern42\DetailedPartyIdType[]
+     */
+    public function getPartyId()
+    {
+        return $this->partyId;
+    }
+
+    /**
+     * Sets a new partyId
+     *
+     * A Composite containing details of the PartyId for a Party owning the WebPage. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.
+     *
+     * @param \DedexBundle\Entity\Ern42\DetailedPartyIdType[] $partyId
+     * @return self
+     */
+    public function setPartyId(?array $partyId = null)
+    {
+        $this->partyId = $partyId;
+        return $this;
+    }
+
+    /**
+     * Gets as pageName
+     *
+     * A Composite containing the Name of the WebPage.
+     *
+     * @return \DedexBundle\Entity\Ern42\NameType
+     */
+    public function getPageName()
+    {
+        return $this->pageName;
+    }
+
+    /**
+     * Sets a new pageName
+     *
+     * A Composite containing the Name of the WebPage.
+     *
+     * @param \DedexBundle\Entity\Ern42\NameType $pageName
+     * @return self
+     */
+    public function setPageName(?\DedexBundle\Entity\Ern42\NameType $pageName = null)
+    {
+        $this->pageName = $pageName;
+        return $this;
+    }
+
+    /**
+     * Gets as uRL
+     *
+     * A URL of the WebPage.
+     *
+     * @return string
+     */
+    public function getURL()
+    {
+        return $this->uRL;
+    }
+
+    /**
+     * Sets a new uRL
+     *
+     * A URL of the WebPage.
+     *
+     * @param string $uRL
+     * @return self
+     */
+    public function setURL($uRL)
+    {
+        $this->uRL = $uRL;
+        return $this;
+    }
+
+    /**
+     * Gets as userName
+     *
+     * An Identifier of a computer user who is granted maintenance access to the WebPage.
+     *
+     * @return string
+     */
+    public function getUserName()
+    {
+        return $this->userName;
+    }
+
+    /**
+     * Sets a new userName
+     *
+     * An Identifier of a computer user who is granted maintenance access to the WebPage.
+     *
+     * @param string $userName
+     * @return self
+     */
+    public function setUserName($userName)
+    {
+        $this->userName = $userName;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/EventDateTimeType.php
+++ b/src/Entity/Ern42/EventDateTimeType.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing EventDateTimeType
+ *
+ * A Composite containing details of the DateTime and Place of an Event.
+ * XSD Type: EventDateTime
+ */
+class EventDateTimeType
+{
+    /**
+     * @var \DateTime $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Flag indicating whether the reported DateTime is approximate (=true) or exact (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isApproximate
+     */
+    private $isApproximate = null;
+
+    /**
+     * The Flag indicating whether the Event being described occurred sometime before the reported DateTime (=true) or not (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isBefore
+     */
+    private $isBefore = null;
+
+    /**
+     * The Flag indicating whether the Event being described occurred sometime after the reported DateTime (=true) or not (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isAfter
+     */
+    private $isAfter = null;
+
+    /**
+     * The Territory in which the Event occurred. This is represented in an XML schema as an XML Attribute. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $territoryCode
+     */
+    private $territoryCode = null;
+
+    /**
+     * A Description of the location in which the Event occurred. It offers the opportunity to describe a place more precisely than using the TerritoryCode. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $locationDescription
+     */
+    private $locationDescription = null;
+
+    /**
+     * The Language and script for the LocationDescription as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * Construct
+     *
+     * @param \DateTime $value
+     */
+    public function __construct(\DateTime $value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param \DateTime $value
+     * @return \DateTime
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as isApproximate
+     *
+     * The Flag indicating whether the reported DateTime is approximate (=true) or exact (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsApproximate()
+    {
+        return $this->isApproximate;
+    }
+
+    /**
+     * Sets a new isApproximate
+     *
+     * The Flag indicating whether the reported DateTime is approximate (=true) or exact (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isApproximate
+     * @return self
+     */
+    public function setIsApproximate($isApproximate)
+    {
+        $this->isApproximate = $isApproximate;
+        return $this;
+    }
+
+    /**
+     * Gets as isBefore
+     *
+     * The Flag indicating whether the Event being described occurred sometime before the reported DateTime (=true) or not (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsBefore()
+    {
+        return $this->isBefore;
+    }
+
+    /**
+     * Sets a new isBefore
+     *
+     * The Flag indicating whether the Event being described occurred sometime before the reported DateTime (=true) or not (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isBefore
+     * @return self
+     */
+    public function setIsBefore($isBefore)
+    {
+        $this->isBefore = $isBefore;
+        return $this;
+    }
+
+    /**
+     * Gets as isAfter
+     *
+     * The Flag indicating whether the Event being described occurred sometime after the reported DateTime (=true) or not (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsAfter()
+    {
+        return $this->isAfter;
+    }
+
+    /**
+     * Sets a new isAfter
+     *
+     * The Flag indicating whether the Event being described occurred sometime after the reported DateTime (=true) or not (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isAfter
+     * @return self
+     */
+    public function setIsAfter($isAfter)
+    {
+        $this->isAfter = $isAfter;
+        return $this;
+    }
+
+    /**
+     * Gets as territoryCode
+     *
+     * The Territory in which the Event occurred. This is represented in an XML schema as an XML Attribute. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getTerritoryCode()
+    {
+        return $this->territoryCode;
+    }
+
+    /**
+     * Sets a new territoryCode
+     *
+     * The Territory in which the Event occurred. This is represented in an XML schema as an XML Attribute. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $territoryCode
+     * @return self
+     */
+    public function setTerritoryCode($territoryCode)
+    {
+        $this->territoryCode = $territoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as locationDescription
+     *
+     * A Description of the location in which the Event occurred. It offers the opportunity to describe a place more precisely than using the TerritoryCode. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLocationDescription()
+    {
+        return $this->locationDescription;
+    }
+
+    /**
+     * Sets a new locationDescription
+     *
+     * A Description of the location in which the Event occurred. It offers the opportunity to describe a place more precisely than using the TerritoryCode. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $locationDescription
+     * @return self
+     */
+    public function setLocationDescription($locationDescription)
+    {
+        $this->locationDescription = $locationDescription;
+        return $this;
+    }
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the LocationDescription as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the LocationDescription as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/EventDateTimeWithoutFlagsType.php
+++ b/src/Entity/Ern42/EventDateTimeWithoutFlagsType.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing EventDateTimeWithoutFlagsType
+ *
+ * A Composite containing details of the DateTime and Place of an Event.
+ * Explanatory Note: This Composite is named EventDateTimeWithoutFlags to disambiguate it from the basic EventDateTime Composite.
+ * XSD Type: EventDateTimeWithoutFlags
+ */
+class EventDateTimeWithoutFlagsType
+{
+    /**
+     * @var \DateTime $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Flag indicating whether the reported DateTime is approximate (=true) or exact (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isApproximate
+     */
+    private $isApproximate = null;
+
+    /**
+     * The Territory in which the Event occurred. This is represented in an XML schema as an XML Attribute. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * A Description of the location in which the Event occurred. It offers the opportunity to describe a place more precisely than using the TerritoryCode. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $locationDescription
+     */
+    private $locationDescription = null;
+
+    /**
+     * The Language and script for the LocationDescription as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * Construct
+     *
+     * @param \DateTime $value
+     */
+    public function __construct(\DateTime $value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param \DateTime $value
+     * @return \DateTime
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as isApproximate
+     *
+     * The Flag indicating whether the reported DateTime is approximate (=true) or exact (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsApproximate()
+    {
+        return $this->isApproximate;
+    }
+
+    /**
+     * Sets a new isApproximate
+     *
+     * The Flag indicating whether the reported DateTime is approximate (=true) or exact (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isApproximate
+     * @return self
+     */
+    public function setIsApproximate($isApproximate)
+    {
+        $this->isApproximate = $isApproximate;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * The Territory in which the Event occurred. This is represented in an XML schema as an XML Attribute. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * The Territory in which the Event occurred. This is represented in an XML schema as an XML Attribute. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as locationDescription
+     *
+     * A Description of the location in which the Event occurred. It offers the opportunity to describe a place more precisely than using the TerritoryCode. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLocationDescription()
+    {
+        return $this->locationDescription;
+    }
+
+    /**
+     * Sets a new locationDescription
+     *
+     * A Description of the location in which the Event occurred. It offers the opportunity to describe a place more precisely than using the TerritoryCode. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $locationDescription
+     * @return self
+     */
+    public function setLocationDescription($locationDescription)
+    {
+        $this->locationDescription = $locationDescription;
+        return $this;
+    }
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the LocationDescription as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the LocationDescription as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/EventDateType.php
+++ b/src/Entity/Ern42/EventDateType.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing EventDateType
+ *
+ * A Composite containing details of the Date and Place of an Event.
+ * XSD Type: EventDate
+ */
+class EventDateType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Flag indicating whether the reported Date is approximate (=true) or exact (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isApproximate
+     */
+    private $isApproximate = null;
+
+    /**
+     * The Flag indicating whether the Event being described occurred sometime before the reported Date (=true) or not (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isBefore
+     */
+    private $isBefore = null;
+
+    /**
+     * The Flag indicating whether the Event being described occurred sometime after the reported Date (=true) or not (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isAfter
+     */
+    private $isAfter = null;
+
+    /**
+     * The Territory in which the Event occurred. This is represented in an XML schema as an XML Attribute. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * A Description of the location in which the Event occurred. It offers the opportunity to describe a place more precisely than using the TerritoryCode. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $locationDescription
+     */
+    private $locationDescription = null;
+
+    /**
+     * The Language and script for the LocationDescription as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as isApproximate
+     *
+     * The Flag indicating whether the reported Date is approximate (=true) or exact (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsApproximate()
+    {
+        return $this->isApproximate;
+    }
+
+    /**
+     * Sets a new isApproximate
+     *
+     * The Flag indicating whether the reported Date is approximate (=true) or exact (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isApproximate
+     * @return self
+     */
+    public function setIsApproximate($isApproximate)
+    {
+        $this->isApproximate = $isApproximate;
+        return $this;
+    }
+
+    /**
+     * Gets as isBefore
+     *
+     * The Flag indicating whether the Event being described occurred sometime before the reported Date (=true) or not (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsBefore()
+    {
+        return $this->isBefore;
+    }
+
+    /**
+     * Sets a new isBefore
+     *
+     * The Flag indicating whether the Event being described occurred sometime before the reported Date (=true) or not (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isBefore
+     * @return self
+     */
+    public function setIsBefore($isBefore)
+    {
+        $this->isBefore = $isBefore;
+        return $this;
+    }
+
+    /**
+     * Gets as isAfter
+     *
+     * The Flag indicating whether the Event being described occurred sometime after the reported Date (=true) or not (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsAfter()
+    {
+        return $this->isAfter;
+    }
+
+    /**
+     * Sets a new isAfter
+     *
+     * The Flag indicating whether the Event being described occurred sometime after the reported Date (=true) or not (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isAfter
+     * @return self
+     */
+    public function setIsAfter($isAfter)
+    {
+        $this->isAfter = $isAfter;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * The Territory in which the Event occurred. This is represented in an XML schema as an XML Attribute. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * The Territory in which the Event occurred. This is represented in an XML schema as an XML Attribute. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as locationDescription
+     *
+     * A Description of the location in which the Event occurred. It offers the opportunity to describe a place more precisely than using the TerritoryCode. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLocationDescription()
+    {
+        return $this->locationDescription;
+    }
+
+    /**
+     * Sets a new locationDescription
+     *
+     * A Description of the location in which the Event occurred. It offers the opportunity to describe a place more precisely than using the TerritoryCode. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $locationDescription
+     * @return self
+     */
+    public function setLocationDescription($locationDescription)
+    {
+        $this->locationDescription = $locationDescription;
+        return $this;
+    }
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the LocationDescription as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the LocationDescription as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/EventDateWithCurrentTerritoryType.php
+++ b/src/Entity/Ern42/EventDateWithCurrentTerritoryType.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing EventDateWithCurrentTerritoryType
+ *
+ * A Composite containing details of the Date and Place of an Event.
+ * Explanatory Note: This Composite is named EventDateWithCurrentTerritory to disambiguate it from the basic EventDate Composite.
+ * XSD Type: EventDateWithCurrentTerritory
+ */
+class EventDateWithCurrentTerritoryType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Flag indicating whether the reported Date is approximate (=true) or exact (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isApproximate
+     */
+    private $isApproximate = null;
+
+    /**
+     * The main Territory in which the Event occurred. This is represented in an XML schema as an XML Attribute. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * A Description of the location in which the Event occurred. It offers the opportunity to describe a place more precisely than using the TerritoryCode. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $locationDescription
+     */
+    private $locationDescription = null;
+
+    /**
+     * The Language and script for the LocationDescription as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as isApproximate
+     *
+     * The Flag indicating whether the reported Date is approximate (=true) or exact (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsApproximate()
+    {
+        return $this->isApproximate;
+    }
+
+    /**
+     * Sets a new isApproximate
+     *
+     * The Flag indicating whether the reported Date is approximate (=true) or exact (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isApproximate
+     * @return self
+     */
+    public function setIsApproximate($isApproximate)
+    {
+        $this->isApproximate = $isApproximate;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * The main Territory in which the Event occurred. This is represented in an XML schema as an XML Attribute. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * The main Territory in which the Event occurred. This is represented in an XML schema as an XML Attribute. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as locationDescription
+     *
+     * A Description of the location in which the Event occurred. It offers the opportunity to describe a place more precisely than using the TerritoryCode. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLocationDescription()
+    {
+        return $this->locationDescription;
+    }
+
+    /**
+     * Sets a new locationDescription
+     *
+     * A Description of the location in which the Event occurred. It offers the opportunity to describe a place more precisely than using the TerritoryCode. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $locationDescription
+     * @return self
+     */
+    public function setLocationDescription($locationDescription)
+    {
+        $this->locationDescription = $locationDescription;
+        return $this;
+    }
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the LocationDescription as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the LocationDescription as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/EventDateWithDefaultType.php
+++ b/src/Entity/Ern42/EventDateWithDefaultType.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing EventDateWithDefaultType
+ *
+ * A Composite containing details of the Date and Place of an Event.
+ * Explanatory Note: This Composite is named EventDateWithDefault to disambiguate it from the basic EventDate Composite.
+ * XSD Type: EventDateWithDefault
+ */
+class EventDateWithDefaultType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Flag indicating whether the reported Date is approximate (=true) or exact (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isApproximate
+     */
+    private $isApproximate = null;
+
+    /**
+     * The Territory in which the Event occurred. This is represented in an XML schema as an XML Attribute. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as isApproximate
+     *
+     * The Flag indicating whether the reported Date is approximate (=true) or exact (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsApproximate()
+    {
+        return $this->isApproximate;
+    }
+
+    /**
+     * Sets a new isApproximate
+     *
+     * The Flag indicating whether the reported Date is approximate (=true) or exact (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isApproximate
+     * @return self
+     */
+    public function setIsApproximate($isApproximate)
+    {
+        $this->isApproximate = $isApproximate;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * The Territory in which the Event occurred. This is represented in an XML schema as an XML Attribute. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * The Territory in which the Event occurred. This is represented in an XML schema as an XML Attribute. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/EventDateWithoutFlagsType.php
+++ b/src/Entity/Ern42/EventDateWithoutFlagsType.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing EventDateWithoutFlagsType
+ *
+ * A Composite containing details of the Date and Place of an Event.
+ * Explanatory Note: This Composite is named EventDateWithoutFlags to disambiguate it from the basic EventDate Composite.
+ * XSD Type: EventDateWithoutFlags
+ */
+class EventDateWithoutFlagsType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Flag indicating whether the reported Date is approximate (=true) or exact (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isApproximate
+     */
+    private $isApproximate = null;
+
+    /**
+     * The main Territory in which the Event occurred. This is represented in an XML schema as an XML Attribute. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * A Description of the location in which the Event occurred. It offers the opportunity to describe a place more precisely than using the TerritoryCode. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $locationDescription
+     */
+    private $locationDescription = null;
+
+    /**
+     * The Language and script for the LocationDescription as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as isApproximate
+     *
+     * The Flag indicating whether the reported Date is approximate (=true) or exact (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsApproximate()
+    {
+        return $this->isApproximate;
+    }
+
+    /**
+     * Sets a new isApproximate
+     *
+     * The Flag indicating whether the reported Date is approximate (=true) or exact (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isApproximate
+     * @return self
+     */
+    public function setIsApproximate($isApproximate)
+    {
+        $this->isApproximate = $isApproximate;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * The main Territory in which the Event occurred. This is represented in an XML schema as an XML Attribute. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * The main Territory in which the Event occurred. This is represented in an XML schema as an XML Attribute. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as locationDescription
+     *
+     * A Description of the location in which the Event occurred. It offers the opportunity to describe a place more precisely than using the TerritoryCode. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLocationDescription()
+    {
+        return $this->locationDescription;
+    }
+
+    /**
+     * Sets a new locationDescription
+     *
+     * A Description of the location in which the Event occurred. It offers the opportunity to describe a place more precisely than using the TerritoryCode. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $locationDescription
+     * @return self
+     */
+    public function setLocationDescription($locationDescription)
+    {
+        $this->locationDescription = $locationDescription;
+        return $this;
+    }
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the LocationDescription as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the LocationDescription as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ExtentType.php
+++ b/src/Entity/Ern42/ExtentType.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ExtentType
+ *
+ * A Composite containing an Extent and a UnitOfMeasure.
+ * XSD Type: Extent
+ */
+class ExtentType
+{
+    /**
+     * @var float $__value
+     */
+    private $__value = null;
+
+    /**
+     * The UnitOfMeasure of the Extent. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $unitOfMeasure
+     */
+    private $unitOfMeasure = null;
+
+    /**
+     * Construct
+     *
+     * @param float $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param float $value
+     * @return float
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as unitOfMeasure
+     *
+     * The UnitOfMeasure of the Extent. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUnitOfMeasure()
+    {
+        return $this->unitOfMeasure;
+    }
+
+    /**
+     * Sets a new unitOfMeasure
+     *
+     * The UnitOfMeasure of the Extent. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $unitOfMeasure
+     * @return self
+     */
+    public function setUnitOfMeasure($unitOfMeasure)
+    {
+        $this->unitOfMeasure = $unitOfMeasure;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ExternalResourceLinkType.php
+++ b/src/Entity/Ern42/ExternalResourceLinkType.php
@@ -1,0 +1,265 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ExternalResourceLinkType
+ *
+ * A Composite containing details of promotional or other material in digital form related to a Release.
+ * XSD Type: ExternalResourceLink
+ */
+class ExternalResourceLinkType
+{
+    /**
+     * A URL of the linked external Resource.
+     *
+     * @var string[] $uRL
+     */
+    private $uRL = [
+        
+    ];
+
+    /**
+     * A Composite containing details about the Period of Time during which the ExternalResourceLink is active. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.
+     * Further Reading: https://kb.ddex.net/general-implementation-guidance/licensing-the-standards/ddex-party-identifier-(dpid)
+     *
+     * @var \DedexBundle\Entity\Ern42\PeriodWithoutFlagsType $validityPeriod
+     */
+    private $validityPeriod = null;
+
+    /**
+     * The Identifier which provides a communication link to the related external Resource.
+     *
+     * @var string $externalLink
+     */
+    private $externalLink = null;
+
+    /**
+     * A Composite containing details of the Type of a Resource pointed to by the ExternalResourceLink.
+     *
+     * @var \DedexBundle\Entity\Ern42\ExternallyLinkedResourceTypeType[] $externallyLinkedResourceType
+     */
+    private $externallyLinkedResourceType = [
+        
+    ];
+
+    /**
+     * The FileFormat of the external Resource.
+     *
+     * @var string $fileFormat
+     */
+    private $fileFormat = null;
+
+    /**
+     * Adds as uRL
+     *
+     * A URL of the linked external Resource.
+     *
+     * @return self
+     * @param string $uRL
+     */
+    public function addToURL($uRL)
+    {
+        $this->uRL[] = $uRL;
+        return $this;
+    }
+
+    /**
+     * isset uRL
+     *
+     * A URL of the linked external Resource.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetURL($index)
+    {
+        return isset($this->uRL[$index]);
+    }
+
+    /**
+     * unset uRL
+     *
+     * A URL of the linked external Resource.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetURL($index)
+    {
+        unset($this->uRL[$index]);
+    }
+
+    /**
+     * Gets as uRL
+     *
+     * A URL of the linked external Resource.
+     *
+     * @return string[]
+     */
+    public function getURL()
+    {
+        return $this->uRL;
+    }
+
+    /**
+     * Sets a new uRL
+     *
+     * A URL of the linked external Resource.
+     *
+     * @param string[] $uRL
+     * @return self
+     */
+    public function setURL(array $uRL)
+    {
+        $this->uRL = $uRL;
+        return $this;
+    }
+
+    /**
+     * Gets as validityPeriod
+     *
+     * A Composite containing details about the Period of Time during which the ExternalResourceLink is active. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.
+     * Further Reading: https://kb.ddex.net/general-implementation-guidance/licensing-the-standards/ddex-party-identifier-(dpid)
+     *
+     * @return \DedexBundle\Entity\Ern42\PeriodWithoutFlagsType
+     */
+    public function getValidityPeriod()
+    {
+        return $this->validityPeriod;
+    }
+
+    /**
+     * Sets a new validityPeriod
+     *
+     * A Composite containing details about the Period of Time during which the ExternalResourceLink is active. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.
+     * Further Reading: https://kb.ddex.net/general-implementation-guidance/licensing-the-standards/ddex-party-identifier-(dpid)
+     *
+     * @param \DedexBundle\Entity\Ern42\PeriodWithoutFlagsType $validityPeriod
+     * @return self
+     */
+    public function setValidityPeriod(?\DedexBundle\Entity\Ern42\PeriodWithoutFlagsType $validityPeriod = null)
+    {
+        $this->validityPeriod = $validityPeriod;
+        return $this;
+    }
+
+    /**
+     * Gets as externalLink
+     *
+     * The Identifier which provides a communication link to the related external Resource.
+     *
+     * @return string
+     */
+    public function getExternalLink()
+    {
+        return $this->externalLink;
+    }
+
+    /**
+     * Sets a new externalLink
+     *
+     * The Identifier which provides a communication link to the related external Resource.
+     *
+     * @param string $externalLink
+     * @return self
+     */
+    public function setExternalLink($externalLink)
+    {
+        $this->externalLink = $externalLink;
+        return $this;
+    }
+
+    /**
+     * Adds as externallyLinkedResourceType
+     *
+     * A Composite containing details of the Type of a Resource pointed to by the ExternalResourceLink.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ExternallyLinkedResourceTypeType $externallyLinkedResourceType
+     */
+    public function addToExternallyLinkedResourceType(\DedexBundle\Entity\Ern42\ExternallyLinkedResourceTypeType $externallyLinkedResourceType)
+    {
+        $this->externallyLinkedResourceType[] = $externallyLinkedResourceType;
+        return $this;
+    }
+
+    /**
+     * isset externallyLinkedResourceType
+     *
+     * A Composite containing details of the Type of a Resource pointed to by the ExternalResourceLink.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetExternallyLinkedResourceType($index)
+    {
+        return isset($this->externallyLinkedResourceType[$index]);
+    }
+
+    /**
+     * unset externallyLinkedResourceType
+     *
+     * A Composite containing details of the Type of a Resource pointed to by the ExternalResourceLink.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetExternallyLinkedResourceType($index)
+    {
+        unset($this->externallyLinkedResourceType[$index]);
+    }
+
+    /**
+     * Gets as externallyLinkedResourceType
+     *
+     * A Composite containing details of the Type of a Resource pointed to by the ExternalResourceLink.
+     *
+     * @return \DedexBundle\Entity\Ern42\ExternallyLinkedResourceTypeType[]
+     */
+    public function getExternallyLinkedResourceType()
+    {
+        return $this->externallyLinkedResourceType;
+    }
+
+    /**
+     * Sets a new externallyLinkedResourceType
+     *
+     * A Composite containing details of the Type of a Resource pointed to by the ExternalResourceLink.
+     *
+     * @param \DedexBundle\Entity\Ern42\ExternallyLinkedResourceTypeType[] $externallyLinkedResourceType
+     * @return self
+     */
+    public function setExternallyLinkedResourceType(?array $externallyLinkedResourceType = null)
+    {
+        $this->externallyLinkedResourceType = $externallyLinkedResourceType;
+        return $this;
+    }
+
+    /**
+     * Gets as fileFormat
+     *
+     * The FileFormat of the external Resource.
+     *
+     * @return string
+     */
+    public function getFileFormat()
+    {
+        return $this->fileFormat;
+    }
+
+    /**
+     * Sets a new fileFormat
+     *
+     * The FileFormat of the external Resource.
+     *
+     * @param string $fileFormat
+     * @return self
+     */
+    public function setFileFormat($fileFormat)
+    {
+        $this->fileFormat = $fileFormat;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ExternallyLinkedResourceTypeType.php
+++ b/src/Entity/Ern42/ExternallyLinkedResourceTypeType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ExternallyLinkedResourceTypeType
+ *
+ * A Composite containing details of an ExternallyLinkedResourceType.
+ * XSD Type: ExternallyLinkedResourceType
+ */
+class ExternallyLinkedResourceTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the ExternallyLinkedResourceType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the ExternallyLinkedResourceType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the ExternallyLinkedResourceType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the ExternallyLinkedResourceType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the ExternallyLinkedResourceType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the ExternallyLinkedResourceType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/FileType.php
+++ b/src/Entity/Ern42/FileType.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing FileType
+ *
+ * A Composite containing details of a File.
+ * XSD Type: File
+ */
+class FileType
+{
+    /**
+     * A URI of the File (this can be a URL or another type of Identifier using a scheme identifier, e.g. http or ftp, as defined in RFC 3986).
+     *
+     * @var string $uRI
+     */
+    private $uRI = null;
+
+    /**
+     * A Composite containing a HashSum of the File and information about the algorithm with which it has been generated.
+     *
+     * @var \DedexBundle\Entity\Ern42\DetailedHashSumType $hashSum
+     */
+    private $hashSum = null;
+
+    /**
+     * The size of the File in kilobytes.
+     *
+     * @var float $fileSize
+     */
+    private $fileSize = null;
+
+    /**
+     * Gets as uRI
+     *
+     * A URI of the File (this can be a URL or another type of Identifier using a scheme identifier, e.g. http or ftp, as defined in RFC 3986).
+     *
+     * @return string
+     */
+    public function getURI()
+    {
+        return $this->uRI;
+    }
+
+    /**
+     * Sets a new uRI
+     *
+     * A URI of the File (this can be a URL or another type of Identifier using a scheme identifier, e.g. http or ftp, as defined in RFC 3986).
+     *
+     * @param string $uRI
+     * @return self
+     */
+    public function setURI($uRI)
+    {
+        $this->uRI = $uRI;
+        return $this;
+    }
+
+    /**
+     * Gets as hashSum
+     *
+     * A Composite containing a HashSum of the File and information about the algorithm with which it has been generated.
+     *
+     * @return \DedexBundle\Entity\Ern42\DetailedHashSumType
+     */
+    public function getHashSum()
+    {
+        return $this->hashSum;
+    }
+
+    /**
+     * Sets a new hashSum
+     *
+     * A Composite containing a HashSum of the File and information about the algorithm with which it has been generated.
+     *
+     * @param \DedexBundle\Entity\Ern42\DetailedHashSumType $hashSum
+     * @return self
+     */
+    public function setHashSum(?\DedexBundle\Entity\Ern42\DetailedHashSumType $hashSum = null)
+    {
+        $this->hashSum = $hashSum;
+        return $this;
+    }
+
+    /**
+     * Gets as fileSize
+     *
+     * The size of the File in kilobytes.
+     *
+     * @return float
+     */
+    public function getFileSize()
+    {
+        return $this->fileSize;
+    }
+
+    /**
+     * Sets a new fileSize
+     *
+     * The size of the File in kilobytes.
+     *
+     * @param float $fileSize
+     * @return self
+     */
+    public function setFileSize($fileSize)
+    {
+        $this->fileSize = $fileSize;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/FingerprintAlgorithmTypeType.php
+++ b/src/Entity/Ern42/FingerprintAlgorithmTypeType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing FingerprintAlgorithmTypeType
+ *
+ * A Composite containing details of a FingerprintAlgorithmType.
+ * XSD Type: FingerprintAlgorithmType
+ */
+class FingerprintAlgorithmTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the FingerprintAlgorithmType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the FingerprintAlgorithmType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the FingerprintAlgorithmType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the FingerprintAlgorithmType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the FingerprintAlgorithmType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the FingerprintAlgorithmType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/FingerprintType.php
+++ b/src/Entity/Ern42/FingerprintType.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing FingerprintType
+ *
+ * A Composite containing details of a Fingerprint and its governing algorithm.
+ * XSD Type: Fingerprint
+ */
+class FingerprintType
+{
+    /**
+     * A Composite containing details of the Type of Algorithm governing the Fingerprint.
+     *
+     * @var \DedexBundle\Entity\Ern42\FingerprintAlgorithmTypeType $algorithm
+     */
+    private $algorithm = null;
+
+    /**
+     * The Identifier of the Version of the FingerprintAlgorithm.
+     *
+     * @var string $version
+     */
+    private $version = null;
+
+    /**
+     * A parameter of the FingerprintAlgorithm.
+     *
+     * @var string $parameter
+     */
+    private $parameter = null;
+
+    /**
+     * A Composite containing details of a File containing the Fingerprint.
+     *
+     * @var \DedexBundle\Entity\Ern42\FileType $file
+     */
+    private $file = null;
+
+    /**
+     * The datatype of the Fingerprint.
+     *
+     * @var string $dataType
+     */
+    private $dataType = null;
+
+    /**
+     * The value of the Fingerprint.
+     *
+     * @var string $fingerprintValue
+     */
+    private $fingerprintValue = null;
+
+    /**
+     * Gets as algorithm
+     *
+     * A Composite containing details of the Type of Algorithm governing the Fingerprint.
+     *
+     * @return \DedexBundle\Entity\Ern42\FingerprintAlgorithmTypeType
+     */
+    public function getAlgorithm()
+    {
+        return $this->algorithm;
+    }
+
+    /**
+     * Sets a new algorithm
+     *
+     * A Composite containing details of the Type of Algorithm governing the Fingerprint.
+     *
+     * @param \DedexBundle\Entity\Ern42\FingerprintAlgorithmTypeType $algorithm
+     * @return self
+     */
+    public function setAlgorithm(\DedexBundle\Entity\Ern42\FingerprintAlgorithmTypeType $algorithm)
+    {
+        $this->algorithm = $algorithm;
+        return $this;
+    }
+
+    /**
+     * Gets as version
+     *
+     * The Identifier of the Version of the FingerprintAlgorithm.
+     *
+     * @return string
+     */
+    public function getVersion()
+    {
+        return $this->version;
+    }
+
+    /**
+     * Sets a new version
+     *
+     * The Identifier of the Version of the FingerprintAlgorithm.
+     *
+     * @param string $version
+     * @return self
+     */
+    public function setVersion($version)
+    {
+        $this->version = $version;
+        return $this;
+    }
+
+    /**
+     * Gets as parameter
+     *
+     * A parameter of the FingerprintAlgorithm.
+     *
+     * @return string
+     */
+    public function getParameter()
+    {
+        return $this->parameter;
+    }
+
+    /**
+     * Sets a new parameter
+     *
+     * A parameter of the FingerprintAlgorithm.
+     *
+     * @param string $parameter
+     * @return self
+     */
+    public function setParameter($parameter)
+    {
+        $this->parameter = $parameter;
+        return $this;
+    }
+
+    /**
+     * Gets as file
+     *
+     * A Composite containing details of a File containing the Fingerprint.
+     *
+     * @return \DedexBundle\Entity\Ern42\FileType
+     */
+    public function getFile()
+    {
+        return $this->file;
+    }
+
+    /**
+     * Sets a new file
+     *
+     * A Composite containing details of a File containing the Fingerprint.
+     *
+     * @param \DedexBundle\Entity\Ern42\FileType $file
+     * @return self
+     */
+    public function setFile(?\DedexBundle\Entity\Ern42\FileType $file = null)
+    {
+        $this->file = $file;
+        return $this;
+    }
+
+    /**
+     * Gets as dataType
+     *
+     * The datatype of the Fingerprint.
+     *
+     * @return string
+     */
+    public function getDataType()
+    {
+        return $this->dataType;
+    }
+
+    /**
+     * Sets a new dataType
+     *
+     * The datatype of the Fingerprint.
+     *
+     * @param string $dataType
+     * @return self
+     */
+    public function setDataType($dataType)
+    {
+        $this->dataType = $dataType;
+        return $this;
+    }
+
+    /**
+     * Gets as fingerprintValue
+     *
+     * The value of the Fingerprint.
+     *
+     * @return string
+     */
+    public function getFingerprintValue()
+    {
+        return $this->fingerprintValue;
+    }
+
+    /**
+     * Sets a new fingerprintValue
+     *
+     * The value of the Fingerprint.
+     *
+     * @param string $fingerprintValue
+     * @return self
+     */
+    public function setFingerprintValue($fingerprintValue)
+    {
+        $this->fingerprintValue = $fingerprintValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/FirstPublicationDateType.php
+++ b/src/Entity/Ern42/FirstPublicationDateType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing FirstPublicationDateType
+ *
+ * A Composite containing details of a FirstPublicationDate.
+ * XSD Type: FirstPublicationDate
+ */
+class FirstPublicationDateType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * A Territory to which the FirstPublicationDate applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the FirstPublicationDate applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the FirstPublicationDate applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/FrameRateType.php
+++ b/src/Entity/Ern42/FrameRateType.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing FrameRateType
+ *
+ * A Composite containing a FrameRate and a UnitOfMeasure.
+ * XSD Type: FrameRate
+ */
+class FrameRateType
+{
+    /**
+     * @var float $__value
+     */
+    private $__value = null;
+
+    /**
+     * The UnitOfMeasure of the FrameRate. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $unitOfMeasure
+     */
+    private $unitOfMeasure = null;
+
+    /**
+     * Construct
+     *
+     * @param float $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param float $value
+     * @return float
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as unitOfMeasure
+     *
+     * The UnitOfMeasure of the FrameRate. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUnitOfMeasure()
+    {
+        return $this->unitOfMeasure;
+    }
+
+    /**
+     * Sets a new unitOfMeasure
+     *
+     * The UnitOfMeasure of the FrameRate. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $unitOfMeasure
+     * @return self
+     */
+    public function setUnitOfMeasure($unitOfMeasure)
+    {
+        $this->unitOfMeasure = $unitOfMeasure;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/FulfillmentDateWithTerritoryType.php
+++ b/src/Entity/Ern42/FulfillmentDateWithTerritoryType.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing FulfillmentDateWithTerritoryType
+ *
+ * A Composite containing details of a FulfillmentDate.
+ * Explanatory Note: This Composite is named FulfillmentDateWithTerritory to disambiguate it from the basic FulfillmentDate Composite.
+ * XSD Type: FulfillmentDateWithTerritory
+ */
+class FulfillmentDateWithTerritoryType
+{
+    /**
+     * A Territory to which the FulfillmentDate applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * A Date after which an end user can receive the Resource (in ISO 8601 format: YYYY-MM-DD). If no FulfillmentDate is provided the FulfillmentDate is the StartDate of the respective Deal.
+     *
+     * @var string $fulfillmentDate
+     */
+    private $fulfillmentDate = null;
+
+    /**
+     * The Identifier (specific to the Message) of a Release for a Resource. This is a LocalReleaseAnchorReference starting with the letter R.
+     *
+     * @var string[] $resourceReleaseReference
+     */
+    private $resourceReleaseReference = [
+        
+    ];
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the FulfillmentDate applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the FulfillmentDate applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+
+    /**
+     * Gets as fulfillmentDate
+     *
+     * A Date after which an end user can receive the Resource (in ISO 8601 format: YYYY-MM-DD). If no FulfillmentDate is provided the FulfillmentDate is the StartDate of the respective Deal.
+     *
+     * @return string
+     */
+    public function getFulfillmentDate()
+    {
+        return $this->fulfillmentDate;
+    }
+
+    /**
+     * Sets a new fulfillmentDate
+     *
+     * A Date after which an end user can receive the Resource (in ISO 8601 format: YYYY-MM-DD). If no FulfillmentDate is provided the FulfillmentDate is the StartDate of the respective Deal.
+     *
+     * @param string $fulfillmentDate
+     * @return self
+     */
+    public function setFulfillmentDate($fulfillmentDate)
+    {
+        $this->fulfillmentDate = $fulfillmentDate;
+        return $this;
+    }
+
+    /**
+     * Adds as resourceReleaseReference
+     *
+     * The Identifier (specific to the Message) of a Release for a Resource. This is a LocalReleaseAnchorReference starting with the letter R.
+     *
+     * @return self
+     * @param string $resourceReleaseReference
+     */
+    public function addToResourceReleaseReference($resourceReleaseReference)
+    {
+        $this->resourceReleaseReference[] = $resourceReleaseReference;
+        return $this;
+    }
+
+    /**
+     * isset resourceReleaseReference
+     *
+     * The Identifier (specific to the Message) of a Release for a Resource. This is a LocalReleaseAnchorReference starting with the letter R.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetResourceReleaseReference($index)
+    {
+        return isset($this->resourceReleaseReference[$index]);
+    }
+
+    /**
+     * unset resourceReleaseReference
+     *
+     * The Identifier (specific to the Message) of a Release for a Resource. This is a LocalReleaseAnchorReference starting with the letter R.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetResourceReleaseReference($index)
+    {
+        unset($this->resourceReleaseReference[$index]);
+    }
+
+    /**
+     * Gets as resourceReleaseReference
+     *
+     * The Identifier (specific to the Message) of a Release for a Resource. This is a LocalReleaseAnchorReference starting with the letter R.
+     *
+     * @return string[]
+     */
+    public function getResourceReleaseReference()
+    {
+        return $this->resourceReleaseReference;
+    }
+
+    /**
+     * Sets a new resourceReleaseReference
+     *
+     * The Identifier (specific to the Message) of a Release for a Resource. This is a LocalReleaseAnchorReference starting with the letter R.
+     *
+     * @param string $resourceReleaseReference
+     * @return self
+     */
+    public function setResourceReleaseReference(?array $resourceReleaseReference = null)
+    {
+        $this->resourceReleaseReference = $resourceReleaseReference;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/GenreCategoryType.php
+++ b/src/Entity/Ern42/GenreCategoryType.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing GenreCategoryType
+ *
+ * A Composite containing details of a Genre Category.
+ * XSD Type: GenreCategory
+ */
+class GenreCategoryType
+{
+    /**
+     * A Territory to which the Genre Category applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * A Composite containing details of a Genre Category value.
+     *
+     * @var \DedexBundle\Entity\Ern42\GenreCategoryValueType $value
+     */
+    private $value = null;
+
+    /**
+     * A Composite containing a Description of the Genre Category.
+     *
+     * @var \DedexBundle\Entity\Ern42\TextWithoutTerritoryType[] $description
+     */
+    private $description = [
+        
+    ];
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the Genre Category applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the Genre Category applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as value
+     *
+     * A Composite containing details of a Genre Category value.
+     *
+     * @return \DedexBundle\Entity\Ern42\GenreCategoryValueType
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Sets a new value
+     *
+     * A Composite containing details of a Genre Category value.
+     *
+     * @param \DedexBundle\Entity\Ern42\GenreCategoryValueType $value
+     * @return self
+     */
+    public function setValue(\DedexBundle\Entity\Ern42\GenreCategoryValueType $value)
+    {
+        $this->value = $value;
+        return $this;
+    }
+
+    /**
+     * Adds as description
+     *
+     * A Composite containing a Description of the Genre Category.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\TextWithoutTerritoryType $description
+     */
+    public function addToDescription(\DedexBundle\Entity\Ern42\TextWithoutTerritoryType $description)
+    {
+        $this->description[] = $description;
+        return $this;
+    }
+
+    /**
+     * isset description
+     *
+     * A Composite containing a Description of the Genre Category.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDescription($index)
+    {
+        return isset($this->description[$index]);
+    }
+
+    /**
+     * unset description
+     *
+     * A Composite containing a Description of the Genre Category.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDescription($index)
+    {
+        unset($this->description[$index]);
+    }
+
+    /**
+     * Gets as description
+     *
+     * A Composite containing a Description of the Genre Category.
+     *
+     * @return \DedexBundle\Entity\Ern42\TextWithoutTerritoryType[]
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * Sets a new description
+     *
+     * A Composite containing a Description of the Genre Category.
+     *
+     * @param \DedexBundle\Entity\Ern42\TextWithoutTerritoryType[] $description
+     * @return self
+     */
+    public function setDescription(?array $description = null)
+    {
+        $this->description = $description;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/GenreCategoryValueType.php
+++ b/src/Entity/Ern42/GenreCategoryValueType.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing GenreCategoryValueType
+ *
+ * A Composite containing details of a Genre Category value.
+ * XSD Type: GenreCategoryValue
+ */
+class GenreCategoryValueType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Language and script of this Element as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * The Namespace of the element. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the element. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script of this Element as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script of this Element as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the element. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the element. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the element. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the element. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/GenreWithTerritoryType.php
+++ b/src/Entity/Ern42/GenreWithTerritoryType.php
@@ -1,0 +1,327 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing GenreWithTerritoryType
+ *
+ * A Composite containing details of a Genre.
+ * Explanatory Note: This Composite is named GenreWithTerritory to disambiguate it from the basic Genre Composite.
+ * XSD Type: GenreWithTerritory
+ */
+class GenreWithTerritoryType
+{
+    /**
+     * The Language and script for the Elements of the Genre as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * A Territory to which the Genre applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * A Description of a genre or style (such as Musical, literary or audio-visual) with which a Creation is associated.
+     *
+     * @var string $genreText
+     */
+    private $genreText = null;
+
+    /**
+     * A Description of a secondary genre or style with which a Creation is associated.
+     *
+     * @var string $subGenre
+     */
+    private $subGenre = null;
+
+    /**
+     * A Composite containing details of a Genre Category to which the Release belongs.
+     *
+     * @var \DedexBundle\Entity\Ern42\GenreCategoryType[] $genreCategory
+     */
+    private $genreCategory = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a sub-genre of the Release.
+     *
+     * @var \DedexBundle\Entity\Ern42\SubGenreCategoryValueType[] $subGenreCategory
+     */
+    private $subGenreCategory = null;
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the Elements of the Genre as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the Elements of the Genre as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the Genre applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the Genre applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+
+    /**
+     * Gets as genreText
+     *
+     * A Description of a genre or style (such as Musical, literary or audio-visual) with which a Creation is associated.
+     *
+     * @return string
+     */
+    public function getGenreText()
+    {
+        return $this->genreText;
+    }
+
+    /**
+     * Sets a new genreText
+     *
+     * A Description of a genre or style (such as Musical, literary or audio-visual) with which a Creation is associated.
+     *
+     * @param string $genreText
+     * @return self
+     */
+    public function setGenreText($genreText)
+    {
+        $this->genreText = $genreText;
+        return $this;
+    }
+
+    /**
+     * Gets as subGenre
+     *
+     * A Description of a secondary genre or style with which a Creation is associated.
+     *
+     * @return string
+     */
+    public function getSubGenre()
+    {
+        return $this->subGenre;
+    }
+
+    /**
+     * Sets a new subGenre
+     *
+     * A Description of a secondary genre or style with which a Creation is associated.
+     *
+     * @param string $subGenre
+     * @return self
+     */
+    public function setSubGenre($subGenre)
+    {
+        $this->subGenre = $subGenre;
+        return $this;
+    }
+
+    /**
+     * Adds as genreCategory
+     *
+     * A Composite containing details of a Genre Category to which the Release belongs.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\GenreCategoryType $genreCategory
+     */
+    public function addToGenreCategory(\DedexBundle\Entity\Ern42\GenreCategoryType $genreCategory)
+    {
+        $this->genreCategory[] = $genreCategory;
+        return $this;
+    }
+
+    /**
+     * isset genreCategory
+     *
+     * A Composite containing details of a Genre Category to which the Release belongs.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetGenreCategory($index)
+    {
+        return isset($this->genreCategory[$index]);
+    }
+
+    /**
+     * unset genreCategory
+     *
+     * A Composite containing details of a Genre Category to which the Release belongs.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetGenreCategory($index)
+    {
+        unset($this->genreCategory[$index]);
+    }
+
+    /**
+     * Gets as genreCategory
+     *
+     * A Composite containing details of a Genre Category to which the Release belongs.
+     *
+     * @return \DedexBundle\Entity\Ern42\GenreCategoryType[]
+     */
+    public function getGenreCategory()
+    {
+        return $this->genreCategory;
+    }
+
+    /**
+     * Sets a new genreCategory
+     *
+     * A Composite containing details of a Genre Category to which the Release belongs.
+     *
+     * @param \DedexBundle\Entity\Ern42\GenreCategoryType[] $genreCategory
+     * @return self
+     */
+    public function setGenreCategory(?array $genreCategory = null)
+    {
+        $this->genreCategory = $genreCategory;
+        return $this;
+    }
+
+    /**
+     * Adds as value
+     *
+     * A Composite containing details of a sub-genre of the Release.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\SubGenreCategoryValueType $value
+     */
+    public function addToSubGenreCategory(\DedexBundle\Entity\Ern42\SubGenreCategoryValueType $value)
+    {
+        $this->subGenreCategory[] = $value;
+        return $this;
+    }
+
+    /**
+     * isset subGenreCategory
+     *
+     * A Composite containing details of a sub-genre of the Release.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetSubGenreCategory($index)
+    {
+        return isset($this->subGenreCategory[$index]);
+    }
+
+    /**
+     * unset subGenreCategory
+     *
+     * A Composite containing details of a sub-genre of the Release.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetSubGenreCategory($index)
+    {
+        unset($this->subGenreCategory[$index]);
+    }
+
+    /**
+     * Gets as subGenreCategory
+     *
+     * A Composite containing details of a sub-genre of the Release.
+     *
+     * @return \DedexBundle\Entity\Ern42\SubGenreCategoryValueType[]
+     */
+    public function getSubGenreCategory()
+    {
+        return $this->subGenreCategory;
+    }
+
+    /**
+     * Sets a new subGenreCategory
+     *
+     * A Composite containing details of a sub-genre of the Release.
+     *
+     * @param \DedexBundle\Entity\Ern42\SubGenreCategoryValueType[] $subGenreCategory
+     * @return self
+     */
+    public function setSubGenreCategory(?array $subGenreCategory = null)
+    {
+        $this->subGenreCategory = $subGenreCategory;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/HashSumAlgorithmTypeType.php
+++ b/src/Entity/Ern42/HashSumAlgorithmTypeType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing HashSumAlgorithmTypeType
+ *
+ * A Composite containing details of a HashSumAlgorithmType.
+ * XSD Type: HashSumAlgorithmType
+ */
+class HashSumAlgorithmTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the HashSumAlgorithmType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the HashSumAlgorithmType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the HashSumAlgorithmType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the HashSumAlgorithmType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the HashSumAlgorithmType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the HashSumAlgorithmType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ImageCodecTypeType.php
+++ b/src/Entity/Ern42/ImageCodecTypeType.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ImageCodecTypeType
+ *
+ * A Composite containing details of an ImageCodecType.
+ * XSD Type: ImageCodecType
+ */
+class ImageCodecTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Identifier of the Version of the ImageCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $version
+     */
+    private $version = null;
+
+    /**
+     * The Namespace of the ImageCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the ImageCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as version
+     *
+     * The Identifier of the Version of the ImageCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getVersion()
+    {
+        return $this->version;
+    }
+
+    /**
+     * Sets a new version
+     *
+     * The Identifier of the Version of the ImageCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $version
+     * @return self
+     */
+    public function setVersion($version)
+    {
+        $this->version = $version;
+        return $this;
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the ImageCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the ImageCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the ImageCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the ImageCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ImageType.php
+++ b/src/Entity/Ern42/ImageType.php
@@ -1,0 +1,1609 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ImageType
+ *
+ * A Composite containing details of an Image.
+ * XSD Type: Image
+ */
+class ImageType
+{
+    /**
+     * The Language and script for the Elements of the Image as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * The Flag indicating whether the Image is provided in a addition to the Resources that form part of the Release (=true) or not (=false). If the flag is set to false (or absent) the Image is part of at least one Release in the message. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isSupplemental
+     */
+    private $isSupplemental = null;
+
+    /**
+     * The Identifier (specific to the Message) of the Image within the Release which contains it. This is a LocalResourceAnchor starting with the letter A.
+     *
+     * @var string $resourceReference
+     */
+    private $resourceReference = null;
+
+    /**
+     * A Composite containing details of the Type of the Image.
+     *
+     * @var \DedexBundle\Entity\Ern42\ImageTypeType $type
+     */
+    private $type = null;
+
+    /**
+     * A Composite containing details of Identifiers of the Image.
+     *
+     * @var \DedexBundle\Entity\Ern42\ResourceProprietaryIdType[] $resourceId
+     */
+    private $resourceId = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Title of the Image as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayTitleTextType[] $displayTitleText
+     */
+    private $displayTitleText = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Title of the Image as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayTitleType[] $displayTitle
+     */
+    private $displayTitle = [
+        
+    ];
+
+    /**
+     * A Composite containing details of an AdditionalTitle of the Image. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @var \DedexBundle\Entity\Ern42\AdditionalTitleType[] $additionalTitle
+     */
+    private $additionalTitle = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Type of Version of the Image.
+     *
+     * @var \DedexBundle\Entity\Ern42\VersionTypeType[] $versionType
+     */
+    private $versionType = [
+        
+    ];
+
+    /**
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType[] $displayArtistName
+     */
+    private $displayArtistName = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the DisplayArtist for the Image. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayArtistType[] $displayArtist
+     */
+    private $displayArtist = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Contributor to the Image.
+     *
+     * @var \DedexBundle\Entity\Ern42\ContributorType[] $contributor
+     */
+    private $contributor = [
+        
+    ];
+
+    /**
+     * A Composite containing details of RightsController of Rights in the Image.
+     *
+     * @var \DedexBundle\Entity\Ern42\ResourceRightsControllerType[] $resourceRightsController
+     */
+    private $resourceRightsController = [
+        
+    ];
+
+    /**
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @var \DedexBundle\Entity\Ern42\WorkRightsControllerType[] $workRightsController
+     */
+    private $workRightsController = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the CLine for the Image.
+     *
+     * @var \DedexBundle\Entity\Ern42\CLineWithDefaultType[] $cLine
+     */
+    private $cLine = [
+        
+    ];
+
+    /**
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured on the Image.
+     *
+     * @var \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType[] $courtesyLine
+     */
+    private $courtesyLine = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the Date and Place of the Event in which the Image was created. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $creationDate
+     */
+    private $creationDate = null;
+
+    /**
+     * A Composite containing details of the Date and Place of the Event in which the Image was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @var \DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType[] $firstPublicationDate
+     */
+    private $firstPublicationDate = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the classification of the Image according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @var \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType[] $parentalWarningType
+     */
+    private $parentalWarningType = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Image.
+     *
+     * @var \DedexBundle\Entity\Ern42\RelatedReleaseType[] $relatedRelease
+     */
+    private $relatedRelease = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Image.
+     *
+     * @var \DedexBundle\Entity\Ern42\RelatedResourceType[] $relatedResource
+     */
+    private $relatedResource = [
+        
+    ];
+
+    /**
+     * The Flag indicating whether the Image contains content that is hidden in some way from the Consumer (=true) or not (=false).
+     *
+     * @var bool $containsHiddenContent
+     */
+    private $containsHiddenContent = null;
+
+    /**
+     * A Composite containing a Description of the subject of the Image.
+     *
+     * @var \DedexBundle\Entity\Ern42\DescriptionWithTerritoryType[] $description
+     */
+    private $description = [
+        
+    ];
+
+    /**
+     * A Composite containing technical details of the Image.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @var \DedexBundle\Entity\Ern42\TechnicalImageDetailsType[] $technicalDetails
+     */
+    private $technicalDetails = [
+        
+    ];
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the Elements of the Image as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the Elements of the Image as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isSupplemental
+     *
+     * The Flag indicating whether the Image is provided in a addition to the Resources that form part of the Release (=true) or not (=false). If the flag is set to false (or absent) the Image is part of at least one Release in the message. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsSupplemental()
+    {
+        return $this->isSupplemental;
+    }
+
+    /**
+     * Sets a new isSupplemental
+     *
+     * The Flag indicating whether the Image is provided in a addition to the Resources that form part of the Release (=true) or not (=false). If the flag is set to false (or absent) the Image is part of at least one Release in the message. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isSupplemental
+     * @return self
+     */
+    public function setIsSupplemental($isSupplemental)
+    {
+        $this->isSupplemental = $isSupplemental;
+        return $this;
+    }
+
+    /**
+     * Gets as resourceReference
+     *
+     * The Identifier (specific to the Message) of the Image within the Release which contains it. This is a LocalResourceAnchor starting with the letter A.
+     *
+     * @return string
+     */
+    public function getResourceReference()
+    {
+        return $this->resourceReference;
+    }
+
+    /**
+     * Sets a new resourceReference
+     *
+     * The Identifier (specific to the Message) of the Image within the Release which contains it. This is a LocalResourceAnchor starting with the letter A.
+     *
+     * @param string $resourceReference
+     * @return self
+     */
+    public function setResourceReference($resourceReference)
+    {
+        $this->resourceReference = $resourceReference;
+        return $this;
+    }
+
+    /**
+     * Gets as type
+     *
+     * A Composite containing details of the Type of the Image.
+     *
+     * @return \DedexBundle\Entity\Ern42\ImageTypeType
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * Sets a new type
+     *
+     * A Composite containing details of the Type of the Image.
+     *
+     * @param \DedexBundle\Entity\Ern42\ImageTypeType $type
+     * @return self
+     */
+    public function setType(\DedexBundle\Entity\Ern42\ImageTypeType $type)
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    /**
+     * Adds as resourceId
+     *
+     * A Composite containing details of Identifiers of the Image.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ResourceProprietaryIdType $resourceId
+     */
+    public function addToResourceId(\DedexBundle\Entity\Ern42\ResourceProprietaryIdType $resourceId)
+    {
+        $this->resourceId[] = $resourceId;
+        return $this;
+    }
+
+    /**
+     * isset resourceId
+     *
+     * A Composite containing details of Identifiers of the Image.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetResourceId($index)
+    {
+        return isset($this->resourceId[$index]);
+    }
+
+    /**
+     * unset resourceId
+     *
+     * A Composite containing details of Identifiers of the Image.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetResourceId($index)
+    {
+        unset($this->resourceId[$index]);
+    }
+
+    /**
+     * Gets as resourceId
+     *
+     * A Composite containing details of Identifiers of the Image.
+     *
+     * @return \DedexBundle\Entity\Ern42\ResourceProprietaryIdType[]
+     */
+    public function getResourceId()
+    {
+        return $this->resourceId;
+    }
+
+    /**
+     * Sets a new resourceId
+     *
+     * A Composite containing details of Identifiers of the Image.
+     *
+     * @param \DedexBundle\Entity\Ern42\ResourceProprietaryIdType[] $resourceId
+     * @return self
+     */
+    public function setResourceId(array $resourceId)
+    {
+        $this->resourceId = $resourceId;
+        return $this;
+    }
+
+    /**
+     * Adds as displayTitleText
+     *
+     * A Composite containing details of a Title of the Image as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleTextType $displayTitleText
+     */
+    public function addToDisplayTitleText(\DedexBundle\Entity\Ern42\DisplayTitleTextType $displayTitleText)
+    {
+        $this->displayTitleText[] = $displayTitleText;
+        return $this;
+    }
+
+    /**
+     * isset displayTitleText
+     *
+     * A Composite containing details of a Title of the Image as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayTitleText($index)
+    {
+        return isset($this->displayTitleText[$index]);
+    }
+
+    /**
+     * unset displayTitleText
+     *
+     * A Composite containing details of a Title of the Image as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayTitleText($index)
+    {
+        unset($this->displayTitleText[$index]);
+    }
+
+    /**
+     * Gets as displayTitleText
+     *
+     * A Composite containing details of a Title of the Image as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayTitleTextType[]
+     */
+    public function getDisplayTitleText()
+    {
+        return $this->displayTitleText;
+    }
+
+    /**
+     * Sets a new displayTitleText
+     *
+     * A Composite containing details of a Title of the Image as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleTextType[] $displayTitleText
+     * @return self
+     */
+    public function setDisplayTitleText(?array $displayTitleText = null)
+    {
+        $this->displayTitleText = $displayTitleText;
+        return $this;
+    }
+
+    /**
+     * Adds as displayTitle
+     *
+     * A Composite containing details of a Title of the Image as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleType $displayTitle
+     */
+    public function addToDisplayTitle(\DedexBundle\Entity\Ern42\DisplayTitleType $displayTitle)
+    {
+        $this->displayTitle[] = $displayTitle;
+        return $this;
+    }
+
+    /**
+     * isset displayTitle
+     *
+     * A Composite containing details of a Title of the Image as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayTitle($index)
+    {
+        return isset($this->displayTitle[$index]);
+    }
+
+    /**
+     * unset displayTitle
+     *
+     * A Composite containing details of a Title of the Image as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayTitle($index)
+    {
+        unset($this->displayTitle[$index]);
+    }
+
+    /**
+     * Gets as displayTitle
+     *
+     * A Composite containing details of a Title of the Image as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayTitleType[]
+     */
+    public function getDisplayTitle()
+    {
+        return $this->displayTitle;
+    }
+
+    /**
+     * Sets a new displayTitle
+     *
+     * A Composite containing details of a Title of the Image as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleType[] $displayTitle
+     * @return self
+     */
+    public function setDisplayTitle(?array $displayTitle = null)
+    {
+        $this->displayTitle = $displayTitle;
+        return $this;
+    }
+
+    /**
+     * Adds as additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Image. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\AdditionalTitleType $additionalTitle
+     */
+    public function addToAdditionalTitle(\DedexBundle\Entity\Ern42\AdditionalTitleType $additionalTitle)
+    {
+        $this->additionalTitle[] = $additionalTitle;
+        return $this;
+    }
+
+    /**
+     * isset additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Image. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetAdditionalTitle($index)
+    {
+        return isset($this->additionalTitle[$index]);
+    }
+
+    /**
+     * unset additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Image. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetAdditionalTitle($index)
+    {
+        unset($this->additionalTitle[$index]);
+    }
+
+    /**
+     * Gets as additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Image. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return \DedexBundle\Entity\Ern42\AdditionalTitleType[]
+     */
+    public function getAdditionalTitle()
+    {
+        return $this->additionalTitle;
+    }
+
+    /**
+     * Sets a new additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Image. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param \DedexBundle\Entity\Ern42\AdditionalTitleType[] $additionalTitle
+     * @return self
+     */
+    public function setAdditionalTitle(?array $additionalTitle = null)
+    {
+        $this->additionalTitle = $additionalTitle;
+        return $this;
+    }
+
+    /**
+     * Adds as versionType
+     *
+     * A Composite containing details of a Type of Version of the Image.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\VersionTypeType $versionType
+     */
+    public function addToVersionType(\DedexBundle\Entity\Ern42\VersionTypeType $versionType)
+    {
+        $this->versionType[] = $versionType;
+        return $this;
+    }
+
+    /**
+     * isset versionType
+     *
+     * A Composite containing details of a Type of Version of the Image.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetVersionType($index)
+    {
+        return isset($this->versionType[$index]);
+    }
+
+    /**
+     * unset versionType
+     *
+     * A Composite containing details of a Type of Version of the Image.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetVersionType($index)
+    {
+        unset($this->versionType[$index]);
+    }
+
+    /**
+     * Gets as versionType
+     *
+     * A Composite containing details of a Type of Version of the Image.
+     *
+     * @return \DedexBundle\Entity\Ern42\VersionTypeType[]
+     */
+    public function getVersionType()
+    {
+        return $this->versionType;
+    }
+
+    /**
+     * Sets a new versionType
+     *
+     * A Composite containing details of a Type of Version of the Image.
+     *
+     * @param \DedexBundle\Entity\Ern42\VersionTypeType[] $versionType
+     * @return self
+     */
+    public function setVersionType(?array $versionType = null)
+    {
+        $this->versionType = $versionType;
+        return $this;
+    }
+
+    /**
+     * Adds as displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType $displayArtistName
+     */
+    public function addToDisplayArtistName(\DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType $displayArtistName)
+    {
+        $this->displayArtistName[] = $displayArtistName;
+        return $this;
+    }
+
+    /**
+     * isset displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayArtistName($index)
+    {
+        return isset($this->displayArtistName[$index]);
+    }
+
+    /**
+     * unset displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayArtistName($index)
+    {
+        unset($this->displayArtistName[$index]);
+    }
+
+    /**
+     * Gets as displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType[]
+     */
+    public function getDisplayArtistName()
+    {
+        return $this->displayArtistName;
+    }
+
+    /**
+     * Sets a new displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType[] $displayArtistName
+     * @return self
+     */
+    public function setDisplayArtistName(?array $displayArtistName = null)
+    {
+        $this->displayArtistName = $displayArtistName;
+        return $this;
+    }
+
+    /**
+     * Adds as displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the Image. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistType $displayArtist
+     */
+    public function addToDisplayArtist(\DedexBundle\Entity\Ern42\DisplayArtistType $displayArtist)
+    {
+        $this->displayArtist[] = $displayArtist;
+        return $this;
+    }
+
+    /**
+     * isset displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the Image. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayArtist($index)
+    {
+        return isset($this->displayArtist[$index]);
+    }
+
+    /**
+     * unset displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the Image. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayArtist($index)
+    {
+        unset($this->displayArtist[$index]);
+    }
+
+    /**
+     * Gets as displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the Image. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayArtistType[]
+     */
+    public function getDisplayArtist()
+    {
+        return $this->displayArtist;
+    }
+
+    /**
+     * Sets a new displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the Image. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistType[] $displayArtist
+     * @return self
+     */
+    public function setDisplayArtist(?array $displayArtist = null)
+    {
+        $this->displayArtist = $displayArtist;
+        return $this;
+    }
+
+    /**
+     * Adds as contributor
+     *
+     * A Composite containing details of a Contributor to the Image.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ContributorType $contributor
+     */
+    public function addToContributor(\DedexBundle\Entity\Ern42\ContributorType $contributor)
+    {
+        $this->contributor[] = $contributor;
+        return $this;
+    }
+
+    /**
+     * isset contributor
+     *
+     * A Composite containing details of a Contributor to the Image.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetContributor($index)
+    {
+        return isset($this->contributor[$index]);
+    }
+
+    /**
+     * unset contributor
+     *
+     * A Composite containing details of a Contributor to the Image.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetContributor($index)
+    {
+        unset($this->contributor[$index]);
+    }
+
+    /**
+     * Gets as contributor
+     *
+     * A Composite containing details of a Contributor to the Image.
+     *
+     * @return \DedexBundle\Entity\Ern42\ContributorType[]
+     */
+    public function getContributor()
+    {
+        return $this->contributor;
+    }
+
+    /**
+     * Sets a new contributor
+     *
+     * A Composite containing details of a Contributor to the Image.
+     *
+     * @param \DedexBundle\Entity\Ern42\ContributorType[] $contributor
+     * @return self
+     */
+    public function setContributor(?array $contributor = null)
+    {
+        $this->contributor = $contributor;
+        return $this;
+    }
+
+    /**
+     * Adds as resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Image.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ResourceRightsControllerType $resourceRightsController
+     */
+    public function addToResourceRightsController(\DedexBundle\Entity\Ern42\ResourceRightsControllerType $resourceRightsController)
+    {
+        $this->resourceRightsController[] = $resourceRightsController;
+        return $this;
+    }
+
+    /**
+     * isset resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Image.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetResourceRightsController($index)
+    {
+        return isset($this->resourceRightsController[$index]);
+    }
+
+    /**
+     * unset resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Image.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetResourceRightsController($index)
+    {
+        unset($this->resourceRightsController[$index]);
+    }
+
+    /**
+     * Gets as resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Image.
+     *
+     * @return \DedexBundle\Entity\Ern42\ResourceRightsControllerType[]
+     */
+    public function getResourceRightsController()
+    {
+        return $this->resourceRightsController;
+    }
+
+    /**
+     * Sets a new resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Image.
+     *
+     * @param \DedexBundle\Entity\Ern42\ResourceRightsControllerType[] $resourceRightsController
+     * @return self
+     */
+    public function setResourceRightsController(?array $resourceRightsController = null)
+    {
+        $this->resourceRightsController = $resourceRightsController;
+        return $this;
+    }
+
+    /**
+     * Adds as workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\WorkRightsControllerType $workRightsController
+     */
+    public function addToWorkRightsController(\DedexBundle\Entity\Ern42\WorkRightsControllerType $workRightsController)
+    {
+        $this->workRightsController[] = $workRightsController;
+        return $this;
+    }
+
+    /**
+     * isset workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetWorkRightsController($index)
+    {
+        return isset($this->workRightsController[$index]);
+    }
+
+    /**
+     * unset workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetWorkRightsController($index)
+    {
+        unset($this->workRightsController[$index]);
+    }
+
+    /**
+     * Gets as workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @return \DedexBundle\Entity\Ern42\WorkRightsControllerType[]
+     */
+    public function getWorkRightsController()
+    {
+        return $this->workRightsController;
+    }
+
+    /**
+     * Sets a new workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @param \DedexBundle\Entity\Ern42\WorkRightsControllerType[] $workRightsController
+     * @return self
+     */
+    public function setWorkRightsController(?array $workRightsController = null)
+    {
+        $this->workRightsController = $workRightsController;
+        return $this;
+    }
+
+    /**
+     * Adds as cLine
+     *
+     * A Composite containing details of the CLine for the Image.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\CLineWithDefaultType $cLine
+     */
+    public function addToCLine(\DedexBundle\Entity\Ern42\CLineWithDefaultType $cLine)
+    {
+        $this->cLine[] = $cLine;
+        return $this;
+    }
+
+    /**
+     * isset cLine
+     *
+     * A Composite containing details of the CLine for the Image.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetCLine($index)
+    {
+        return isset($this->cLine[$index]);
+    }
+
+    /**
+     * unset cLine
+     *
+     * A Composite containing details of the CLine for the Image.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetCLine($index)
+    {
+        unset($this->cLine[$index]);
+    }
+
+    /**
+     * Gets as cLine
+     *
+     * A Composite containing details of the CLine for the Image.
+     *
+     * @return \DedexBundle\Entity\Ern42\CLineWithDefaultType[]
+     */
+    public function getCLine()
+    {
+        return $this->cLine;
+    }
+
+    /**
+     * Sets a new cLine
+     *
+     * A Composite containing details of the CLine for the Image.
+     *
+     * @param \DedexBundle\Entity\Ern42\CLineWithDefaultType[] $cLine
+     * @return self
+     */
+    public function setCLine(?array $cLine = null)
+    {
+        $this->cLine = $cLine;
+        return $this;
+    }
+
+    /**
+     * Adds as courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured on the Image.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType $courtesyLine
+     */
+    public function addToCourtesyLine(\DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType $courtesyLine)
+    {
+        $this->courtesyLine[] = $courtesyLine;
+        return $this;
+    }
+
+    /**
+     * isset courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured on the Image.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetCourtesyLine($index)
+    {
+        return isset($this->courtesyLine[$index]);
+    }
+
+    /**
+     * unset courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured on the Image.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetCourtesyLine($index)
+    {
+        unset($this->courtesyLine[$index]);
+    }
+
+    /**
+     * Gets as courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured on the Image.
+     *
+     * @return \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType[]
+     */
+    public function getCourtesyLine()
+    {
+        return $this->courtesyLine;
+    }
+
+    /**
+     * Sets a new courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured on the Image.
+     *
+     * @param \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType[] $courtesyLine
+     * @return self
+     */
+    public function setCourtesyLine(?array $courtesyLine = null)
+    {
+        $this->courtesyLine = $courtesyLine;
+        return $this;
+    }
+
+    /**
+     * Gets as creationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Image was created. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType
+     */
+    public function getCreationDate()
+    {
+        return $this->creationDate;
+    }
+
+    /**
+     * Sets a new creationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Image was created. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $creationDate
+     * @return self
+     */
+    public function setCreationDate(?\DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $creationDate = null)
+    {
+        $this->creationDate = $creationDate;
+        return $this;
+    }
+
+    /**
+     * Adds as firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Image was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType $firstPublicationDate
+     */
+    public function addToFirstPublicationDate(\DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType $firstPublicationDate)
+    {
+        $this->firstPublicationDate[] = $firstPublicationDate;
+        return $this;
+    }
+
+    /**
+     * isset firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Image was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetFirstPublicationDate($index)
+    {
+        return isset($this->firstPublicationDate[$index]);
+    }
+
+    /**
+     * unset firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Image was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetFirstPublicationDate($index)
+    {
+        unset($this->firstPublicationDate[$index]);
+    }
+
+    /**
+     * Gets as firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Image was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @return \DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType[]
+     */
+    public function getFirstPublicationDate()
+    {
+        return $this->firstPublicationDate;
+    }
+
+    /**
+     * Sets a new firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Image was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param \DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType[] $firstPublicationDate
+     * @return self
+     */
+    public function setFirstPublicationDate(?array $firstPublicationDate = null)
+    {
+        $this->firstPublicationDate = $firstPublicationDate;
+        return $this;
+    }
+
+    /**
+     * Adds as parentalWarningType
+     *
+     * A Composite containing details of the classification of the Image according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType $parentalWarningType
+     */
+    public function addToParentalWarningType(\DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType $parentalWarningType)
+    {
+        $this->parentalWarningType[] = $parentalWarningType;
+        return $this;
+    }
+
+    /**
+     * isset parentalWarningType
+     *
+     * A Composite containing details of the classification of the Image according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetParentalWarningType($index)
+    {
+        return isset($this->parentalWarningType[$index]);
+    }
+
+    /**
+     * unset parentalWarningType
+     *
+     * A Composite containing details of the classification of the Image according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetParentalWarningType($index)
+    {
+        unset($this->parentalWarningType[$index]);
+    }
+
+    /**
+     * Gets as parentalWarningType
+     *
+     * A Composite containing details of the classification of the Image according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @return \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType[]
+     */
+    public function getParentalWarningType()
+    {
+        return $this->parentalWarningType;
+    }
+
+    /**
+     * Sets a new parentalWarningType
+     *
+     * A Composite containing details of the classification of the Image according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @param \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType[] $parentalWarningType
+     * @return self
+     */
+    public function setParentalWarningType(?array $parentalWarningType = null)
+    {
+        $this->parentalWarningType = $parentalWarningType;
+        return $this;
+    }
+
+    /**
+     * Adds as relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Image.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\RelatedReleaseType $relatedRelease
+     */
+    public function addToRelatedRelease(\DedexBundle\Entity\Ern42\RelatedReleaseType $relatedRelease)
+    {
+        $this->relatedRelease[] = $relatedRelease;
+        return $this;
+    }
+
+    /**
+     * isset relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Image.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRelatedRelease($index)
+    {
+        return isset($this->relatedRelease[$index]);
+    }
+
+    /**
+     * unset relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Image.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRelatedRelease($index)
+    {
+        unset($this->relatedRelease[$index]);
+    }
+
+    /**
+     * Gets as relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Image.
+     *
+     * @return \DedexBundle\Entity\Ern42\RelatedReleaseType[]
+     */
+    public function getRelatedRelease()
+    {
+        return $this->relatedRelease;
+    }
+
+    /**
+     * Sets a new relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Image.
+     *
+     * @param \DedexBundle\Entity\Ern42\RelatedReleaseType[] $relatedRelease
+     * @return self
+     */
+    public function setRelatedRelease(?array $relatedRelease = null)
+    {
+        $this->relatedRelease = $relatedRelease;
+        return $this;
+    }
+
+    /**
+     * Adds as relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Image.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\RelatedResourceType $relatedResource
+     */
+    public function addToRelatedResource(\DedexBundle\Entity\Ern42\RelatedResourceType $relatedResource)
+    {
+        $this->relatedResource[] = $relatedResource;
+        return $this;
+    }
+
+    /**
+     * isset relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Image.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRelatedResource($index)
+    {
+        return isset($this->relatedResource[$index]);
+    }
+
+    /**
+     * unset relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Image.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRelatedResource($index)
+    {
+        unset($this->relatedResource[$index]);
+    }
+
+    /**
+     * Gets as relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Image.
+     *
+     * @return \DedexBundle\Entity\Ern42\RelatedResourceType[]
+     */
+    public function getRelatedResource()
+    {
+        return $this->relatedResource;
+    }
+
+    /**
+     * Sets a new relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Image.
+     *
+     * @param \DedexBundle\Entity\Ern42\RelatedResourceType[] $relatedResource
+     * @return self
+     */
+    public function setRelatedResource(?array $relatedResource = null)
+    {
+        $this->relatedResource = $relatedResource;
+        return $this;
+    }
+
+    /**
+     * Gets as containsHiddenContent
+     *
+     * The Flag indicating whether the Image contains content that is hidden in some way from the Consumer (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getContainsHiddenContent()
+    {
+        return $this->containsHiddenContent;
+    }
+
+    /**
+     * Sets a new containsHiddenContent
+     *
+     * The Flag indicating whether the Image contains content that is hidden in some way from the Consumer (=true) or not (=false).
+     *
+     * @param bool $containsHiddenContent
+     * @return self
+     */
+    public function setContainsHiddenContent($containsHiddenContent)
+    {
+        $this->containsHiddenContent = $containsHiddenContent;
+        return $this;
+    }
+
+    /**
+     * Adds as description
+     *
+     * A Composite containing a Description of the subject of the Image.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DescriptionWithTerritoryType $description
+     */
+    public function addToDescription(\DedexBundle\Entity\Ern42\DescriptionWithTerritoryType $description)
+    {
+        $this->description[] = $description;
+        return $this;
+    }
+
+    /**
+     * isset description
+     *
+     * A Composite containing a Description of the subject of the Image.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDescription($index)
+    {
+        return isset($this->description[$index]);
+    }
+
+    /**
+     * unset description
+     *
+     * A Composite containing a Description of the subject of the Image.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDescription($index)
+    {
+        unset($this->description[$index]);
+    }
+
+    /**
+     * Gets as description
+     *
+     * A Composite containing a Description of the subject of the Image.
+     *
+     * @return \DedexBundle\Entity\Ern42\DescriptionWithTerritoryType[]
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * Sets a new description
+     *
+     * A Composite containing a Description of the subject of the Image.
+     *
+     * @param \DedexBundle\Entity\Ern42\DescriptionWithTerritoryType[] $description
+     * @return self
+     */
+    public function setDescription(?array $description = null)
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    /**
+     * Adds as technicalDetails
+     *
+     * A Composite containing technical details of the Image.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\TechnicalImageDetailsType $technicalDetails
+     */
+    public function addToTechnicalDetails(\DedexBundle\Entity\Ern42\TechnicalImageDetailsType $technicalDetails)
+    {
+        $this->technicalDetails[] = $technicalDetails;
+        return $this;
+    }
+
+    /**
+     * isset technicalDetails
+     *
+     * A Composite containing technical details of the Image.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetTechnicalDetails($index)
+    {
+        return isset($this->technicalDetails[$index]);
+    }
+
+    /**
+     * unset technicalDetails
+     *
+     * A Composite containing technical details of the Image.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetTechnicalDetails($index)
+    {
+        unset($this->technicalDetails[$index]);
+    }
+
+    /**
+     * Gets as technicalDetails
+     *
+     * A Composite containing technical details of the Image.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @return \DedexBundle\Entity\Ern42\TechnicalImageDetailsType[]
+     */
+    public function getTechnicalDetails()
+    {
+        return $this->technicalDetails;
+    }
+
+    /**
+     * Sets a new technicalDetails
+     *
+     * A Composite containing technical details of the Image.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @param \DedexBundle\Entity\Ern42\TechnicalImageDetailsType[] $technicalDetails
+     * @return self
+     */
+    public function setTechnicalDetails(?array $technicalDetails = null)
+    {
+        $this->technicalDetails = $technicalDetails;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ImageTypeType.php
+++ b/src/Entity/Ern42/ImageTypeType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ImageTypeType
+ *
+ * A Composite containing details of an ImageType.
+ * XSD Type: ImageType
+ */
+class ImageTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the ImageType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the ImageType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the ImageType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the ImageType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the ImageType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the ImageType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/InstrumentTypeType.php
+++ b/src/Entity/Ern42/InstrumentTypeType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing InstrumentTypeType
+ *
+ * A Composite containing details of an InstrumentType.
+ * XSD Type: InstrumentType
+ */
+class InstrumentTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the InstrumentType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the InstrumentType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the InstrumentType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the InstrumentType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the InstrumentType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the InstrumentType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/IsCreditedType.php
+++ b/src/Entity/Ern42/IsCreditedType.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing IsCreditedType
+ *
+ * A Composite containing details of a Flag indicating whether the Contributor is credited as having played a role in creating the Recording.
+ * XSD Type: IsCredited
+ */
+class IsCreditedType
+{
+    /**
+     * @var bool $__value
+     */
+    private $__value = null;
+
+    /**
+     * A Flag indicating whether this information may be shared (=true) or not (=false). If the Flag is not present, the Contributor may be credited.
+     *
+     * @var bool $mayBeShared
+     */
+    private $mayBeShared = null;
+
+    /**
+     * Construct
+     *
+     * @param bool $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param bool $value
+     * @return bool
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as mayBeShared
+     *
+     * A Flag indicating whether this information may be shared (=true) or not (=false). If the Flag is not present, the Contributor may be credited.
+     *
+     * @return bool
+     */
+    public function getMayBeShared()
+    {
+        return $this->mayBeShared;
+    }
+
+    /**
+     * Sets a new mayBeShared
+     *
+     * A Flag indicating whether this information may be shared (=true) or not (=false). If the Flag is not present, the Contributor may be credited.
+     *
+     * @param bool $mayBeShared
+     * @return self
+     */
+    public function setMayBeShared($mayBeShared)
+    {
+        $this->mayBeShared = $mayBeShared;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/KeywordsWithTerritoryType.php
+++ b/src/Entity/Ern42/KeywordsWithTerritoryType.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing KeywordsWithTerritoryType
+ *
+ * A Composite containing details of a Description containing Keywords.
+ * Explanatory Note: This Composite is named KeywordsWithTerritory to disambiguate it from the basic Keywords Composite.
+ * XSD Type: KeywordsWithTerritory
+ */
+class KeywordsWithTerritoryType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Language and script of the Keywords as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * A Territory to which the Keywords applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script of the Keywords as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script of the Keywords as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the Keywords applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the Keywords applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/LinkedReleaseResourceReferenceType.php
+++ b/src/Entity/Ern42/LinkedReleaseResourceReferenceType.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing LinkedReleaseResourceReferenceType
+ *
+ * A Composite containing details of a LinkedReleaseResourceReference for a Resource which is linked to a ContentItem.
+ * XSD Type: LinkedReleaseResourceReference
+ */
+class LinkedReleaseResourceReferenceType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * A description of the link for the ReleaseResourceReference.
+     *
+     * @var string $linkDescription
+     */
+    private $linkDescription = null;
+
+    /**
+     * The Language and script for the LinkDescription as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * The Namespace of the LinkDescription. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the LinkDescription. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as linkDescription
+     *
+     * A description of the link for the ReleaseResourceReference.
+     *
+     * @return string
+     */
+    public function getLinkDescription()
+    {
+        return $this->linkDescription;
+    }
+
+    /**
+     * Sets a new linkDescription
+     *
+     * A description of the link for the ReleaseResourceReference.
+     *
+     * @param string $linkDescription
+     * @return self
+     */
+    public function setLinkDescription($linkDescription)
+    {
+        $this->linkDescription = $linkDescription;
+        return $this;
+    }
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the LinkDescription as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the LinkDescription as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the LinkDescription. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the LinkDescription. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the LinkDescription. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the LinkDescription. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/LocationAndDateOfSessionType.php
+++ b/src/Entity/Ern42/LocationAndDateOfSessionType.php
@@ -1,0 +1,304 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing LocationAndDateOfSessionType
+ *
+ * A Composite containing details of a Session.
+ * XSD Type: LocationAndDateOfSession
+ */
+class LocationAndDateOfSessionType
+{
+    /**
+     * The Type of Session.
+     *
+     * @var \DedexBundle\Entity\Ern42\SessionTypeType[] $sessionType
+     */
+    private $sessionType = [
+        
+    ];
+
+    /**
+     * A Composite containing details about a Period of the Session. Periods are typically described by at least a StartDate or EndDate.
+     *
+     * @var \DedexBundle\Entity\Ern42\PeriodType $period
+     */
+    private $period = null;
+
+    /**
+     * A Composite containing details of the venue where the Session took place.
+     *
+     * @var \DedexBundle\Entity\Ern42\VenueType[] $venue
+     */
+    private $venue = [
+        
+    ];
+
+    /**
+     * A Composite containing a human-readable Comment about the Session.
+     *
+     * @var \DedexBundle\Entity\Ern42\TextWithFormatType $comment
+     */
+    private $comment = null;
+
+    /**
+     * A Composite containing details of a Contributor.
+     *
+     * @var \DedexBundle\Entity\Ern42\PartyWithRoleType[] $contributor
+     */
+    private $contributor = [
+        
+    ];
+
+    /**
+     * Adds as sessionType
+     *
+     * The Type of Session.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\SessionTypeType $sessionType
+     */
+    public function addToSessionType(\DedexBundle\Entity\Ern42\SessionTypeType $sessionType)
+    {
+        $this->sessionType[] = $sessionType;
+        return $this;
+    }
+
+    /**
+     * isset sessionType
+     *
+     * The Type of Session.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetSessionType($index)
+    {
+        return isset($this->sessionType[$index]);
+    }
+
+    /**
+     * unset sessionType
+     *
+     * The Type of Session.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetSessionType($index)
+    {
+        unset($this->sessionType[$index]);
+    }
+
+    /**
+     * Gets as sessionType
+     *
+     * The Type of Session.
+     *
+     * @return \DedexBundle\Entity\Ern42\SessionTypeType[]
+     */
+    public function getSessionType()
+    {
+        return $this->sessionType;
+    }
+
+    /**
+     * Sets a new sessionType
+     *
+     * The Type of Session.
+     *
+     * @param \DedexBundle\Entity\Ern42\SessionTypeType[] $sessionType
+     * @return self
+     */
+    public function setSessionType(?array $sessionType = null)
+    {
+        $this->sessionType = $sessionType;
+        return $this;
+    }
+
+    /**
+     * Gets as period
+     *
+     * A Composite containing details about a Period of the Session. Periods are typically described by at least a StartDate or EndDate.
+     *
+     * @return \DedexBundle\Entity\Ern42\PeriodType
+     */
+    public function getPeriod()
+    {
+        return $this->period;
+    }
+
+    /**
+     * Sets a new period
+     *
+     * A Composite containing details about a Period of the Session. Periods are typically described by at least a StartDate or EndDate.
+     *
+     * @param \DedexBundle\Entity\Ern42\PeriodType $period
+     * @return self
+     */
+    public function setPeriod(?\DedexBundle\Entity\Ern42\PeriodType $period = null)
+    {
+        $this->period = $period;
+        return $this;
+    }
+
+    /**
+     * Adds as venue
+     *
+     * A Composite containing details of the venue where the Session took place.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\VenueType $venue
+     */
+    public function addToVenue(\DedexBundle\Entity\Ern42\VenueType $venue)
+    {
+        $this->venue[] = $venue;
+        return $this;
+    }
+
+    /**
+     * isset venue
+     *
+     * A Composite containing details of the venue where the Session took place.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetVenue($index)
+    {
+        return isset($this->venue[$index]);
+    }
+
+    /**
+     * unset venue
+     *
+     * A Composite containing details of the venue where the Session took place.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetVenue($index)
+    {
+        unset($this->venue[$index]);
+    }
+
+    /**
+     * Gets as venue
+     *
+     * A Composite containing details of the venue where the Session took place.
+     *
+     * @return \DedexBundle\Entity\Ern42\VenueType[]
+     */
+    public function getVenue()
+    {
+        return $this->venue;
+    }
+
+    /**
+     * Sets a new venue
+     *
+     * A Composite containing details of the venue where the Session took place.
+     *
+     * @param \DedexBundle\Entity\Ern42\VenueType[] $venue
+     * @return self
+     */
+    public function setVenue(?array $venue = null)
+    {
+        $this->venue = $venue;
+        return $this;
+    }
+
+    /**
+     * Gets as comment
+     *
+     * A Composite containing a human-readable Comment about the Session.
+     *
+     * @return \DedexBundle\Entity\Ern42\TextWithFormatType
+     */
+    public function getComment()
+    {
+        return $this->comment;
+    }
+
+    /**
+     * Sets a new comment
+     *
+     * A Composite containing a human-readable Comment about the Session.
+     *
+     * @param \DedexBundle\Entity\Ern42\TextWithFormatType $comment
+     * @return self
+     */
+    public function setComment(?\DedexBundle\Entity\Ern42\TextWithFormatType $comment = null)
+    {
+        $this->comment = $comment;
+        return $this;
+    }
+
+    /**
+     * Adds as contributor
+     *
+     * A Composite containing details of a Contributor.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\PartyWithRoleType $contributor
+     */
+    public function addToContributor(\DedexBundle\Entity\Ern42\PartyWithRoleType $contributor)
+    {
+        $this->contributor[] = $contributor;
+        return $this;
+    }
+
+    /**
+     * isset contributor
+     *
+     * A Composite containing details of a Contributor.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetContributor($index)
+    {
+        return isset($this->contributor[$index]);
+    }
+
+    /**
+     * unset contributor
+     *
+     * A Composite containing details of a Contributor.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetContributor($index)
+    {
+        unset($this->contributor[$index]);
+    }
+
+    /**
+     * Gets as contributor
+     *
+     * A Composite containing details of a Contributor.
+     *
+     * @return \DedexBundle\Entity\Ern42\PartyWithRoleType[]
+     */
+    public function getContributor()
+    {
+        return $this->contributor;
+    }
+
+    /**
+     * Sets a new contributor
+     *
+     * A Composite containing details of a Contributor.
+     *
+     * @param \DedexBundle\Entity\Ern42\PartyWithRoleType[] $contributor
+     * @return self
+     */
+    public function setContributor(?array $contributor = null)
+    {
+        $this->contributor = $contributor;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/MarketingCommentType.php
+++ b/src/Entity/Ern42/MarketingCommentType.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing MarketingCommentType
+ *
+ * A Composite containing details of a MarketingComment.
+ * XSD Type: MarketingComment
+ */
+class MarketingCommentType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Language and script of the Comment as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * A Territory to which the Comment applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script of the Comment as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script of the Comment as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the Comment applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the Comment applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/MessageAuditTrailEventType.php
+++ b/src/Entity/Ern42/MessageAuditTrailEventType.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing MessageAuditTrailEventType
+ *
+ * A Composite containing details of a Party handling a Message and the Time at which the handling took place.
+ * XSD Type: MessageAuditTrailEvent
+ */
+class MessageAuditTrailEventType
+{
+    /**
+     * A Composite containing details of a MessagingParty.
+     *
+     * @var \DedexBundle\Entity\Ern42\MessagingPartyWithoutCodeType $messagingPartyDescriptor
+     */
+    private $messagingPartyDescriptor = null;
+
+    /**
+     * The DateTime at which the Message was handled by the MessagingParty (the only allowed format is ISO 8601: YYYY-MM-DDThh:mm:ssTZD).
+     *
+     * @var \DateTime $dateTime
+     */
+    private $dateTime = null;
+
+    /**
+     * Gets as messagingPartyDescriptor
+     *
+     * A Composite containing details of a MessagingParty.
+     *
+     * @return \DedexBundle\Entity\Ern42\MessagingPartyWithoutCodeType
+     */
+    public function getMessagingPartyDescriptor()
+    {
+        return $this->messagingPartyDescriptor;
+    }
+
+    /**
+     * Sets a new messagingPartyDescriptor
+     *
+     * A Composite containing details of a MessagingParty.
+     *
+     * @param \DedexBundle\Entity\Ern42\MessagingPartyWithoutCodeType $messagingPartyDescriptor
+     * @return self
+     */
+    public function setMessagingPartyDescriptor(\DedexBundle\Entity\Ern42\MessagingPartyWithoutCodeType $messagingPartyDescriptor)
+    {
+        $this->messagingPartyDescriptor = $messagingPartyDescriptor;
+        return $this;
+    }
+
+    /**
+     * Gets as dateTime
+     *
+     * The DateTime at which the Message was handled by the MessagingParty (the only allowed format is ISO 8601: YYYY-MM-DDThh:mm:ssTZD).
+     *
+     * @return \DateTime
+     */
+    public function getDateTime()
+    {
+        return $this->dateTime;
+    }
+
+    /**
+     * Sets a new dateTime
+     *
+     * The DateTime at which the Message was handled by the MessagingParty (the only allowed format is ISO 8601: YYYY-MM-DDThh:mm:ssTZD).
+     *
+     * @param \DateTime $dateTime
+     * @return self
+     */
+    public function setDateTime(\DateTime $dateTime)
+    {
+        $this->dateTime = $dateTime;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/MessageAuditTrailType.php
+++ b/src/Entity/Ern42/MessageAuditTrailType.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing MessageAuditTrailType
+ *
+ * A Composite containing information about Parties in between the original MessageSender and ultimate MessageRecipient.
+ * XSD Type: MessageAuditTrail
+ */
+class MessageAuditTrailType
+{
+    /**
+     * A Composite containing details of a Party handling the Message and the Time at which the handling took place.
+     *
+     * @var \DedexBundle\Entity\Ern42\MessageAuditTrailEventType[] $messageAuditTrailEvent
+     */
+    private $messageAuditTrailEvent = [
+        
+    ];
+
+    /**
+     * Adds as messageAuditTrailEvent
+     *
+     * A Composite containing details of a Party handling the Message and the Time at which the handling took place.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\MessageAuditTrailEventType $messageAuditTrailEvent
+     */
+    public function addToMessageAuditTrailEvent(\DedexBundle\Entity\Ern42\MessageAuditTrailEventType $messageAuditTrailEvent)
+    {
+        $this->messageAuditTrailEvent[] = $messageAuditTrailEvent;
+        return $this;
+    }
+
+    /**
+     * isset messageAuditTrailEvent
+     *
+     * A Composite containing details of a Party handling the Message and the Time at which the handling took place.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetMessageAuditTrailEvent($index)
+    {
+        return isset($this->messageAuditTrailEvent[$index]);
+    }
+
+    /**
+     * unset messageAuditTrailEvent
+     *
+     * A Composite containing details of a Party handling the Message and the Time at which the handling took place.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetMessageAuditTrailEvent($index)
+    {
+        unset($this->messageAuditTrailEvent[$index]);
+    }
+
+    /**
+     * Gets as messageAuditTrailEvent
+     *
+     * A Composite containing details of a Party handling the Message and the Time at which the handling took place.
+     *
+     * @return \DedexBundle\Entity\Ern42\MessageAuditTrailEventType[]
+     */
+    public function getMessageAuditTrailEvent()
+    {
+        return $this->messageAuditTrailEvent;
+    }
+
+    /**
+     * Sets a new messageAuditTrailEvent
+     *
+     * A Composite containing details of a Party handling the Message and the Time at which the handling took place.
+     *
+     * @param \DedexBundle\Entity\Ern42\MessageAuditTrailEventType[] $messageAuditTrailEvent
+     * @return self
+     */
+    public function setMessageAuditTrailEvent(array $messageAuditTrailEvent)
+    {
+        $this->messageAuditTrailEvent = $messageAuditTrailEvent;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/MessageHeaderType.php
+++ b/src/Entity/Ern42/MessageHeaderType.php
@@ -1,0 +1,392 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing MessageHeaderType
+ *
+ * A Composite placed at the beginning of each DdexMessage providing information about the Message, such as MessageSender, MessageRecipient and a Message creation time stamp.
+ * XSD Type: MessageHeader
+ */
+class MessageHeaderType
+{
+    /**
+     * A xs:string used to uniquely identify the thread of Messages of which the current Message is a part. The MessageThreadId shall be, in combination with the DdexPartyId (DPID) of the MessageSender, globally unique. Thus, a MessageSender shall never re-use a MessageThreadId. One example of such a 'thread' is the chain of NewReleaseMessages being sent from ReleaseCreator to wholesale ReleaseDistributor 1 to retail DSP when communicating information about the same Release(s). A common MessageThreadId will allow all these messages to be tied together.
+     *
+     * @var string $messageThreadId
+     */
+    private $messageThreadId = null;
+
+    /**
+     * A xs:string used to uniquely identify the current Message. The MessageId shall be, in combination with the DdexPartyId (DPID) of the MessageSender, globally unique. Thus, a MessageSender shall never re-use a MessageId.
+     *
+     * @var string $messageId
+     */
+    private $messageId = null;
+
+    /**
+     * The FileName, possibly including the FilePath, of the XML File containing the current Message.
+     *
+     * @var string $messageFileName
+     */
+    private $messageFileName = null;
+
+    /**
+     * A Composite containing details of the MessageSender.
+     *
+     * @var \DedexBundle\Entity\Ern42\MessagingPartyWithoutCodeType $messageSender
+     */
+    private $messageSender = null;
+
+    /**
+     * A Composite containing details of the Party on whose behalf the Message is sent.
+     *
+     * @var \DedexBundle\Entity\Ern42\MessagingPartyWithoutCodeType $sentOnBehalfOf
+     */
+    private $sentOnBehalfOf = null;
+
+    /**
+     * A Composite containing details of the MessageRecipient. Note that if multiple MessageRecipients are provided, all of them will be able to read this information.
+     *
+     * @var \DedexBundle\Entity\Ern42\MessagingPartyWithoutCodeType[] $messageRecipient
+     */
+    private $messageRecipient = [
+        
+    ];
+
+    /**
+     * The DateTime on which the Message was created (the only allowed format is ISO 8601: YYYY-MM-DDThh:mm:ssTZD).
+     *
+     * @var \DateTime $messageCreatedDateTime
+     */
+    private $messageCreatedDateTime = null;
+
+    /**
+     * A Composite containing information about Parties in between the original MessageSender and ultimate MessageRecipient.
+     *
+     * @var \DedexBundle\Entity\Ern42\MessageAuditTrailEventType[] $messageAuditTrail
+     */
+    private $messageAuditTrail = null;
+
+    /**
+     * The indicator used to distinguish a live Message from a test Message.
+     *
+     * @var string $messageControlType
+     */
+    private $messageControlType = null;
+
+    /**
+     * Gets as messageThreadId
+     *
+     * A xs:string used to uniquely identify the thread of Messages of which the current Message is a part. The MessageThreadId shall be, in combination with the DdexPartyId (DPID) of the MessageSender, globally unique. Thus, a MessageSender shall never re-use a MessageThreadId. One example of such a 'thread' is the chain of NewReleaseMessages being sent from ReleaseCreator to wholesale ReleaseDistributor 1 to retail DSP when communicating information about the same Release(s). A common MessageThreadId will allow all these messages to be tied together.
+     *
+     * @return string
+     */
+    public function getMessageThreadId()
+    {
+        return $this->messageThreadId;
+    }
+
+    /**
+     * Sets a new messageThreadId
+     *
+     * A xs:string used to uniquely identify the thread of Messages of which the current Message is a part. The MessageThreadId shall be, in combination with the DdexPartyId (DPID) of the MessageSender, globally unique. Thus, a MessageSender shall never re-use a MessageThreadId. One example of such a 'thread' is the chain of NewReleaseMessages being sent from ReleaseCreator to wholesale ReleaseDistributor 1 to retail DSP when communicating information about the same Release(s). A common MessageThreadId will allow all these messages to be tied together.
+     *
+     * @param string $messageThreadId
+     * @return self
+     */
+    public function setMessageThreadId($messageThreadId)
+    {
+        $this->messageThreadId = $messageThreadId;
+        return $this;
+    }
+
+    /**
+     * Gets as messageId
+     *
+     * A xs:string used to uniquely identify the current Message. The MessageId shall be, in combination with the DdexPartyId (DPID) of the MessageSender, globally unique. Thus, a MessageSender shall never re-use a MessageId.
+     *
+     * @return string
+     */
+    public function getMessageId()
+    {
+        return $this->messageId;
+    }
+
+    /**
+     * Sets a new messageId
+     *
+     * A xs:string used to uniquely identify the current Message. The MessageId shall be, in combination with the DdexPartyId (DPID) of the MessageSender, globally unique. Thus, a MessageSender shall never re-use a MessageId.
+     *
+     * @param string $messageId
+     * @return self
+     */
+    public function setMessageId($messageId)
+    {
+        $this->messageId = $messageId;
+        return $this;
+    }
+
+    /**
+     * Gets as messageFileName
+     *
+     * The FileName, possibly including the FilePath, of the XML File containing the current Message.
+     *
+     * @return string
+     */
+    public function getMessageFileName()
+    {
+        return $this->messageFileName;
+    }
+
+    /**
+     * Sets a new messageFileName
+     *
+     * The FileName, possibly including the FilePath, of the XML File containing the current Message.
+     *
+     * @param string $messageFileName
+     * @return self
+     */
+    public function setMessageFileName($messageFileName)
+    {
+        $this->messageFileName = $messageFileName;
+        return $this;
+    }
+
+    /**
+     * Gets as messageSender
+     *
+     * A Composite containing details of the MessageSender.
+     *
+     * @return \DedexBundle\Entity\Ern42\MessagingPartyWithoutCodeType
+     */
+    public function getMessageSender()
+    {
+        return $this->messageSender;
+    }
+
+    /**
+     * Sets a new messageSender
+     *
+     * A Composite containing details of the MessageSender.
+     *
+     * @param \DedexBundle\Entity\Ern42\MessagingPartyWithoutCodeType $messageSender
+     * @return self
+     */
+    public function setMessageSender(\DedexBundle\Entity\Ern42\MessagingPartyWithoutCodeType $messageSender)
+    {
+        $this->messageSender = $messageSender;
+        return $this;
+    }
+
+    /**
+     * Gets as sentOnBehalfOf
+     *
+     * A Composite containing details of the Party on whose behalf the Message is sent.
+     *
+     * @return \DedexBundle\Entity\Ern42\MessagingPartyWithoutCodeType
+     */
+    public function getSentOnBehalfOf()
+    {
+        return $this->sentOnBehalfOf;
+    }
+
+    /**
+     * Sets a new sentOnBehalfOf
+     *
+     * A Composite containing details of the Party on whose behalf the Message is sent.
+     *
+     * @param \DedexBundle\Entity\Ern42\MessagingPartyWithoutCodeType $sentOnBehalfOf
+     * @return self
+     */
+    public function setSentOnBehalfOf(?\DedexBundle\Entity\Ern42\MessagingPartyWithoutCodeType $sentOnBehalfOf = null)
+    {
+        $this->sentOnBehalfOf = $sentOnBehalfOf;
+        return $this;
+    }
+
+    /**
+     * Adds as messageRecipient
+     *
+     * A Composite containing details of the MessageRecipient. Note that if multiple MessageRecipients are provided, all of them will be able to read this information.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\MessagingPartyWithoutCodeType $messageRecipient
+     */
+    public function addToMessageRecipient(\DedexBundle\Entity\Ern42\MessagingPartyWithoutCodeType $messageRecipient)
+    {
+        $this->messageRecipient[] = $messageRecipient;
+        return $this;
+    }
+
+    /**
+     * isset messageRecipient
+     *
+     * A Composite containing details of the MessageRecipient. Note that if multiple MessageRecipients are provided, all of them will be able to read this information.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetMessageRecipient($index)
+    {
+        return isset($this->messageRecipient[$index]);
+    }
+
+    /**
+     * unset messageRecipient
+     *
+     * A Composite containing details of the MessageRecipient. Note that if multiple MessageRecipients are provided, all of them will be able to read this information.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetMessageRecipient($index)
+    {
+        unset($this->messageRecipient[$index]);
+    }
+
+    /**
+     * Gets as messageRecipient
+     *
+     * A Composite containing details of the MessageRecipient. Note that if multiple MessageRecipients are provided, all of them will be able to read this information.
+     *
+     * @return \DedexBundle\Entity\Ern42\MessagingPartyWithoutCodeType[]
+     */
+    public function getMessageRecipient()
+    {
+        return $this->messageRecipient;
+    }
+
+    /**
+     * Sets a new messageRecipient
+     *
+     * A Composite containing details of the MessageRecipient. Note that if multiple MessageRecipients are provided, all of them will be able to read this information.
+     *
+     * @param \DedexBundle\Entity\Ern42\MessagingPartyWithoutCodeType[] $messageRecipient
+     * @return self
+     */
+    public function setMessageRecipient(array $messageRecipient)
+    {
+        $this->messageRecipient = $messageRecipient;
+        return $this;
+    }
+
+    /**
+     * Gets as messageCreatedDateTime
+     *
+     * The DateTime on which the Message was created (the only allowed format is ISO 8601: YYYY-MM-DDThh:mm:ssTZD).
+     *
+     * @return \DateTime
+     */
+    public function getMessageCreatedDateTime()
+    {
+        return $this->messageCreatedDateTime;
+    }
+
+    /**
+     * Sets a new messageCreatedDateTime
+     *
+     * The DateTime on which the Message was created (the only allowed format is ISO 8601: YYYY-MM-DDThh:mm:ssTZD).
+     *
+     * @param \DateTime $messageCreatedDateTime
+     * @return self
+     */
+    public function setMessageCreatedDateTime(\DateTime $messageCreatedDateTime)
+    {
+        $this->messageCreatedDateTime = $messageCreatedDateTime;
+        return $this;
+    }
+
+    /**
+     * Adds as messageAuditTrailEvent
+     *
+     * A Composite containing information about Parties in between the original MessageSender and ultimate MessageRecipient.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\MessageAuditTrailEventType $messageAuditTrailEvent
+     */
+    public function addToMessageAuditTrail(\DedexBundle\Entity\Ern42\MessageAuditTrailEventType $messageAuditTrailEvent)
+    {
+        $this->messageAuditTrail[] = $messageAuditTrailEvent;
+        return $this;
+    }
+
+    /**
+     * isset messageAuditTrail
+     *
+     * A Composite containing information about Parties in between the original MessageSender and ultimate MessageRecipient.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetMessageAuditTrail($index)
+    {
+        return isset($this->messageAuditTrail[$index]);
+    }
+
+    /**
+     * unset messageAuditTrail
+     *
+     * A Composite containing information about Parties in between the original MessageSender and ultimate MessageRecipient.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetMessageAuditTrail($index)
+    {
+        unset($this->messageAuditTrail[$index]);
+    }
+
+    /**
+     * Gets as messageAuditTrail
+     *
+     * A Composite containing information about Parties in between the original MessageSender and ultimate MessageRecipient.
+     *
+     * @return \DedexBundle\Entity\Ern42\MessageAuditTrailEventType[]
+     */
+    public function getMessageAuditTrail()
+    {
+        return $this->messageAuditTrail;
+    }
+
+    /**
+     * Sets a new messageAuditTrail
+     *
+     * A Composite containing information about Parties in between the original MessageSender and ultimate MessageRecipient.
+     *
+     * @param \DedexBundle\Entity\Ern42\MessageAuditTrailEventType[] $messageAuditTrail
+     * @return self
+     */
+    public function setMessageAuditTrail(?array $messageAuditTrail = null)
+    {
+        $this->messageAuditTrail = $messageAuditTrail;
+        return $this;
+    }
+
+    /**
+     * Gets as messageControlType
+     *
+     * The indicator used to distinguish a live Message from a test Message.
+     *
+     * @return string
+     */
+    public function getMessageControlType()
+    {
+        return $this->messageControlType;
+    }
+
+    /**
+     * Sets a new messageControlType
+     *
+     * The indicator used to distinguish a live Message from a test Message.
+     *
+     * @param string $messageControlType
+     * @return self
+     */
+    public function setMessageControlType($messageControlType)
+    {
+        $this->messageControlType = $messageControlType;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/MessagingPartyWithoutCodeType.php
+++ b/src/Entity/Ern42/MessagingPartyWithoutCodeType.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing MessagingPartyWithoutCodeType
+ *
+ * A Composite containing details of a MessagingParty.
+ * Explanatory Note: This Composite is named MessagingPartyWithoutCode to disambiguate it from the basic MessagingParty Composite.
+ * XSD Type: MessagingPartyWithoutCode
+ */
+class MessagingPartyWithoutCodeType
+{
+    /**
+     * An Identifier of a Party according to the DdexPartyId standard DDEX-DPID.
+     *
+     * @var string $partyId
+     */
+    private $partyId = null;
+
+    /**
+     * A Composite containing details of the PartyNames for the Party handling the Message.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers
+     *
+     * @var \DedexBundle\Entity\Ern42\PartyNameWithoutCodeType $partyName
+     */
+    private $partyName = null;
+
+    /**
+     * A Composite containing a TradingName for the Party handling the Message.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @var string $tradingName
+     */
+    private $tradingName = null;
+
+    /**
+     * Gets as partyId
+     *
+     * An Identifier of a Party according to the DdexPartyId standard DDEX-DPID.
+     *
+     * @return string
+     */
+    public function getPartyId()
+    {
+        return $this->partyId;
+    }
+
+    /**
+     * Sets a new partyId
+     *
+     * An Identifier of a Party according to the DdexPartyId standard DDEX-DPID.
+     *
+     * @param string $partyId
+     * @return self
+     */
+    public function setPartyId($partyId)
+    {
+        $this->partyId = $partyId;
+        return $this;
+    }
+
+    /**
+     * Gets as partyName
+     *
+     * A Composite containing details of the PartyNames for the Party handling the Message.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers
+     *
+     * @return \DedexBundle\Entity\Ern42\PartyNameWithoutCodeType
+     */
+    public function getPartyName()
+    {
+        return $this->partyName;
+    }
+
+    /**
+     * Sets a new partyName
+     *
+     * A Composite containing details of the PartyNames for the Party handling the Message.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers
+     *
+     * @param \DedexBundle\Entity\Ern42\PartyNameWithoutCodeType $partyName
+     * @return self
+     */
+    public function setPartyName(?\DedexBundle\Entity\Ern42\PartyNameWithoutCodeType $partyName = null)
+    {
+        $this->partyName = $partyName;
+        return $this;
+    }
+
+    /**
+     * Gets as tradingName
+     *
+     * A Composite containing a TradingName for the Party handling the Message.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return string
+     */
+    public function getTradingName()
+    {
+        return $this->tradingName;
+    }
+
+    /**
+     * Sets a new tradingName
+     *
+     * A Composite containing a TradingName for the Party handling the Message.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param string $tradingName
+     * @return self
+     */
+    public function setTradingName($tradingName)
+    {
+        $this->tradingName = $tradingName;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/MusicalWorkIdType.php
+++ b/src/Entity/Ern42/MusicalWorkIdType.php
@@ -1,0 +1,262 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing MusicalWorkIdType
+ *
+ * A Composite containing details of a MusicalWorkId.
+ * XSD Type: MusicalWorkId
+ */
+class MusicalWorkIdType
+{
+    /**
+     * The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.
+     *
+     * @var bool $isReplaced
+     */
+    private $isReplaced = null;
+
+    /**
+     * The ISWC (International Standard Musical Work Code defined in ISO 15707) identifying the MusicalWork. An ISWC comprises three parts: the letter 'T', followed by nine digits and then one check digit. DDEX will enforce the syntax [a-zA-Z][0-9]{10} using XML Schema in the future.
+     *
+     * @var string $iSWC
+     */
+    private $iSWC = null;
+
+    /**
+     * The MusicalWorkId identifying the MusicalWork within the catalog of its Composer (typically of classical music) as an opus number.
+     *
+     * @var string $opusNumber
+     */
+    private $opusNumber = null;
+
+    /**
+     * A MusicalWorkId identifying a MusicalWork within the catalog of its Composer (typically of classical music) according to a standardized numbering (e.g. 'K' numbers for Koechel's catalog of Mozart).
+     *
+     * @var string[] $composerCatalogNumber
+     */
+    private $composerCatalogNumber = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a ProprietaryIdentifier of the MusicalWork.
+     *
+     * @var \DedexBundle\Entity\Ern42\ProprietaryIdType[] $proprietaryId
+     */
+    private $proprietaryId = [
+        
+    ];
+
+    /**
+     * Gets as isReplaced
+     *
+     * The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.
+     *
+     * @return bool
+     */
+    public function getIsReplaced()
+    {
+        return $this->isReplaced;
+    }
+
+    /**
+     * Sets a new isReplaced
+     *
+     * The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.
+     *
+     * @param bool $isReplaced
+     * @return self
+     */
+    public function setIsReplaced($isReplaced)
+    {
+        $this->isReplaced = $isReplaced;
+        return $this;
+    }
+
+    /**
+     * Gets as iSWC
+     *
+     * The ISWC (International Standard Musical Work Code defined in ISO 15707) identifying the MusicalWork. An ISWC comprises three parts: the letter 'T', followed by nine digits and then one check digit. DDEX will enforce the syntax [a-zA-Z][0-9]{10} using XML Schema in the future.
+     *
+     * @return string
+     */
+    public function getISWC()
+    {
+        return $this->iSWC;
+    }
+
+    /**
+     * Sets a new iSWC
+     *
+     * The ISWC (International Standard Musical Work Code defined in ISO 15707) identifying the MusicalWork. An ISWC comprises three parts: the letter 'T', followed by nine digits and then one check digit. DDEX will enforce the syntax [a-zA-Z][0-9]{10} using XML Schema in the future.
+     *
+     * @param string $iSWC
+     * @return self
+     */
+    public function setISWC($iSWC)
+    {
+        $this->iSWC = $iSWC;
+        return $this;
+    }
+
+    /**
+     * Gets as opusNumber
+     *
+     * The MusicalWorkId identifying the MusicalWork within the catalog of its Composer (typically of classical music) as an opus number.
+     *
+     * @return string
+     */
+    public function getOpusNumber()
+    {
+        return $this->opusNumber;
+    }
+
+    /**
+     * Sets a new opusNumber
+     *
+     * The MusicalWorkId identifying the MusicalWork within the catalog of its Composer (typically of classical music) as an opus number.
+     *
+     * @param string $opusNumber
+     * @return self
+     */
+    public function setOpusNumber($opusNumber)
+    {
+        $this->opusNumber = $opusNumber;
+        return $this;
+    }
+
+    /**
+     * Adds as composerCatalogNumber
+     *
+     * A MusicalWorkId identifying a MusicalWork within the catalog of its Composer (typically of classical music) according to a standardized numbering (e.g. 'K' numbers for Koechel's catalog of Mozart).
+     *
+     * @return self
+     * @param string $composerCatalogNumber
+     */
+    public function addToComposerCatalogNumber($composerCatalogNumber)
+    {
+        $this->composerCatalogNumber[] = $composerCatalogNumber;
+        return $this;
+    }
+
+    /**
+     * isset composerCatalogNumber
+     *
+     * A MusicalWorkId identifying a MusicalWork within the catalog of its Composer (typically of classical music) according to a standardized numbering (e.g. 'K' numbers for Koechel's catalog of Mozart).
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetComposerCatalogNumber($index)
+    {
+        return isset($this->composerCatalogNumber[$index]);
+    }
+
+    /**
+     * unset composerCatalogNumber
+     *
+     * A MusicalWorkId identifying a MusicalWork within the catalog of its Composer (typically of classical music) according to a standardized numbering (e.g. 'K' numbers for Koechel's catalog of Mozart).
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetComposerCatalogNumber($index)
+    {
+        unset($this->composerCatalogNumber[$index]);
+    }
+
+    /**
+     * Gets as composerCatalogNumber
+     *
+     * A MusicalWorkId identifying a MusicalWork within the catalog of its Composer (typically of classical music) according to a standardized numbering (e.g. 'K' numbers for Koechel's catalog of Mozart).
+     *
+     * @return string[]
+     */
+    public function getComposerCatalogNumber()
+    {
+        return $this->composerCatalogNumber;
+    }
+
+    /**
+     * Sets a new composerCatalogNumber
+     *
+     * A MusicalWorkId identifying a MusicalWork within the catalog of its Composer (typically of classical music) according to a standardized numbering (e.g. 'K' numbers for Koechel's catalog of Mozart).
+     *
+     * @param string[] $composerCatalogNumber
+     * @return self
+     */
+    public function setComposerCatalogNumber(?array $composerCatalogNumber = null)
+    {
+        $this->composerCatalogNumber = $composerCatalogNumber;
+        return $this;
+    }
+
+    /**
+     * Adds as proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the MusicalWork.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ProprietaryIdType $proprietaryId
+     */
+    public function addToProprietaryId(\DedexBundle\Entity\Ern42\ProprietaryIdType $proprietaryId)
+    {
+        $this->proprietaryId[] = $proprietaryId;
+        return $this;
+    }
+
+    /**
+     * isset proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the MusicalWork.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetProprietaryId($index)
+    {
+        return isset($this->proprietaryId[$index]);
+    }
+
+    /**
+     * unset proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the MusicalWork.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetProprietaryId($index)
+    {
+        unset($this->proprietaryId[$index]);
+    }
+
+    /**
+     * Gets as proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the MusicalWork.
+     *
+     * @return \DedexBundle\Entity\Ern42\ProprietaryIdType[]
+     */
+    public function getProprietaryId()
+    {
+        return $this->proprietaryId;
+    }
+
+    /**
+     * Sets a new proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the MusicalWork.
+     *
+     * @param \DedexBundle\Entity\Ern42\ProprietaryIdType[] $proprietaryId
+     * @return self
+     */
+    public function setProprietaryId(?array $proprietaryId = null)
+    {
+        $this->proprietaryId = $proprietaryId;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/NameType.php
+++ b/src/Entity/Ern42/NameType.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing NameType
+ *
+ * A Composite containing details of a Name.
+ * XSD Type: Name
+ */
+class NameType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Language and script of the Name as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script of the Name as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script of the Name as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/NewReleaseMessage.php
+++ b/src/Entity/Ern42/NewReleaseMessage.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+use DedexBundle\Entity\Ern42\NewReleaseMessage\NewReleaseMessageAnonymousPHPType;
+
+/**
+ * Class representing NewReleaseMessage
+ *
+ * A Message in the Release Notification Message Suite Standard, containing details of a new Release.
+ * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-message-exchange-protocols-and-choreographies
+ */
+class NewReleaseMessage extends NewReleaseMessageAnonymousPHPType
+{
+}
+

--- a/src/Entity/Ern42/NewReleaseMessage/NewReleaseMessageAnonymousPHPType.php
+++ b/src/Entity/Ern42/NewReleaseMessage/NewReleaseMessageAnonymousPHPType.php
@@ -1,0 +1,571 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42\NewReleaseMessage;
+
+/**
+ * Class representing NewReleaseMessageAnonymousPHPType
+ */
+class NewReleaseMessageAnonymousPHPType
+{
+    /**
+     * The Identifier of the Version of the release profile used for the Message. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $releaseProfileVersionId
+     */
+    private $releaseProfileVersionId = null;
+
+    /**
+     * The Identifier of the Version of the release profile variant used for the Message. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $releaseProfileVariantVersionId
+     */
+    private $releaseProfileVariantVersionId = null;
+
+    /**
+     * The Language and script for the Elements of this Message as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * The MessageHeader for the NewReleaseMessage.
+     *
+     * @var \DedexBundle\Entity\Ern42\MessageHeaderType $messageHeader
+     */
+    private $messageHeader = null;
+
+    /**
+     * A Composite containing details of Release administration.
+     *
+     * @var \DedexBundle\Entity\Ern42\ReleaseAdminType[] $releaseAdmin
+     */
+    private $releaseAdmin = [
+        
+    ];
+
+    /**
+     * A Composite containing details of one or more Parties relating to the reported MusicalWorks.
+     *
+     * @var \DedexBundle\Entity\Ern42\PartyType[] $partyList
+     */
+    private $partyList = null;
+
+    /**
+     * A Composite containing details of one or more CueSheets contained in Releases for which data is provided in the NewReleaseMessage.
+     *
+     * @var \DedexBundle\Entity\Ern42\DetailedCueSheetType[] $cueSheetList
+     */
+    private $cueSheetList = null;
+
+    /**
+     * A Composite containing details of one or more Resources.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/sequencing-resources
+     *
+     * @var \DedexBundle\Entity\Ern42\ResourceListType $resourceList
+     */
+    private $resourceList = null;
+
+    /**
+     * A Composite containing details of one or more Chapters contained in Releases for which data is provided in the NewReleaseMessage.
+     *
+     * @var \DedexBundle\Entity\Ern42\ChapterListType $chapterList
+     */
+    private $chapterList = null;
+
+    /**
+     * A Composite containing details of one or more DDEX Releases contained in the NewReleaseMessage.
+     *
+     * @var \DedexBundle\Entity\Ern42\ReleaseListType $releaseList
+     */
+    private $releaseList = null;
+
+    /**
+     * A Composite containing details of one or more Deals governing the Usage of the Releases in the Message.
+     *
+     * @var \DedexBundle\Entity\Ern42\DealListType $dealList
+     */
+    private $dealList = null;
+
+    /**
+     * A Composite containing details of one or more XML documents communicated with the Message.
+     *
+     * @var \DedexBundle\Entity\Ern42\FileType[] $supplementalDocumentList
+     */
+    private $supplementalDocumentList = null;
+
+    /**
+     * Gets as releaseProfileVersionId
+     *
+     * The Identifier of the Version of the release profile used for the Message. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getReleaseProfileVersionId()
+    {
+        return $this->releaseProfileVersionId;
+    }
+
+    /**
+     * Sets a new releaseProfileVersionId
+     *
+     * The Identifier of the Version of the release profile used for the Message. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $releaseProfileVersionId
+     * @return self
+     */
+    public function setReleaseProfileVersionId($releaseProfileVersionId)
+    {
+        $this->releaseProfileVersionId = $releaseProfileVersionId;
+        return $this;
+    }
+
+    /**
+     * Gets as releaseProfileVariantVersionId
+     *
+     * The Identifier of the Version of the release profile variant used for the Message. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getReleaseProfileVariantVersionId()
+    {
+        return $this->releaseProfileVariantVersionId;
+    }
+
+    /**
+     * Sets a new releaseProfileVariantVersionId
+     *
+     * The Identifier of the Version of the release profile variant used for the Message. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $releaseProfileVariantVersionId
+     * @return self
+     */
+    public function setReleaseProfileVariantVersionId($releaseProfileVariantVersionId)
+    {
+        $this->releaseProfileVariantVersionId = $releaseProfileVariantVersionId;
+        return $this;
+    }
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the Elements of this Message as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the Elements of this Message as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as messageHeader
+     *
+     * The MessageHeader for the NewReleaseMessage.
+     *
+     * @return \DedexBundle\Entity\Ern42\MessageHeaderType
+     */
+    public function getMessageHeader()
+    {
+        return $this->messageHeader;
+    }
+
+    /**
+     * Sets a new messageHeader
+     *
+     * The MessageHeader for the NewReleaseMessage.
+     *
+     * @param \DedexBundle\Entity\Ern42\MessageHeaderType $messageHeader
+     * @return self
+     */
+    public function setMessageHeader(\DedexBundle\Entity\Ern42\MessageHeaderType $messageHeader)
+    {
+        $this->messageHeader = $messageHeader;
+        return $this;
+    }
+
+    /**
+     * Adds as releaseAdmin
+     *
+     * A Composite containing details of Release administration.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ReleaseAdminType $releaseAdmin
+     */
+    public function addToReleaseAdmin(\DedexBundle\Entity\Ern42\ReleaseAdminType $releaseAdmin)
+    {
+        $this->releaseAdmin[] = $releaseAdmin;
+        return $this;
+    }
+
+    /**
+     * isset releaseAdmin
+     *
+     * A Composite containing details of Release administration.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetReleaseAdmin($index)
+    {
+        return isset($this->releaseAdmin[$index]);
+    }
+
+    /**
+     * unset releaseAdmin
+     *
+     * A Composite containing details of Release administration.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetReleaseAdmin($index)
+    {
+        unset($this->releaseAdmin[$index]);
+    }
+
+    /**
+     * Gets as releaseAdmin
+     *
+     * A Composite containing details of Release administration.
+     *
+     * @return \DedexBundle\Entity\Ern42\ReleaseAdminType[]
+     */
+    public function getReleaseAdmin()
+    {
+        return $this->releaseAdmin;
+    }
+
+    /**
+     * Sets a new releaseAdmin
+     *
+     * A Composite containing details of Release administration.
+     *
+     * @param \DedexBundle\Entity\Ern42\ReleaseAdminType[] $releaseAdmin
+     * @return self
+     */
+    public function setReleaseAdmin(?array $releaseAdmin = null)
+    {
+        $this->releaseAdmin = $releaseAdmin;
+        return $this;
+    }
+
+    /**
+     * Adds as party
+     *
+     * A Composite containing details of one or more Parties relating to the reported MusicalWorks.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\PartyType $party
+     */
+    public function addToPartyList(\DedexBundle\Entity\Ern42\PartyType $party)
+    {
+        $this->partyList[] = $party;
+        return $this;
+    }
+
+    /**
+     * isset partyList
+     *
+     * A Composite containing details of one or more Parties relating to the reported MusicalWorks.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetPartyList($index)
+    {
+        return isset($this->partyList[$index]);
+    }
+
+    /**
+     * unset partyList
+     *
+     * A Composite containing details of one or more Parties relating to the reported MusicalWorks.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetPartyList($index)
+    {
+        unset($this->partyList[$index]);
+    }
+
+    /**
+     * Gets as partyList
+     *
+     * A Composite containing details of one or more Parties relating to the reported MusicalWorks.
+     *
+     * @return \DedexBundle\Entity\Ern42\PartyType[]
+     */
+    public function getPartyList()
+    {
+        return $this->partyList;
+    }
+
+    /**
+     * Sets a new partyList
+     *
+     * A Composite containing details of one or more Parties relating to the reported MusicalWorks.
+     *
+     * @param \DedexBundle\Entity\Ern42\PartyType[] $partyList
+     * @return self
+     */
+    public function setPartyList(array $partyList)
+    {
+        $this->partyList = $partyList;
+        return $this;
+    }
+
+    /**
+     * Adds as cueSheet
+     *
+     * A Composite containing details of one or more CueSheets contained in Releases for which data is provided in the NewReleaseMessage.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DetailedCueSheetType $cueSheet
+     */
+    public function addToCueSheetList(\DedexBundle\Entity\Ern42\DetailedCueSheetType $cueSheet)
+    {
+        $this->cueSheetList[] = $cueSheet;
+        return $this;
+    }
+
+    /**
+     * isset cueSheetList
+     *
+     * A Composite containing details of one or more CueSheets contained in Releases for which data is provided in the NewReleaseMessage.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetCueSheetList($index)
+    {
+        return isset($this->cueSheetList[$index]);
+    }
+
+    /**
+     * unset cueSheetList
+     *
+     * A Composite containing details of one or more CueSheets contained in Releases for which data is provided in the NewReleaseMessage.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetCueSheetList($index)
+    {
+        unset($this->cueSheetList[$index]);
+    }
+
+    /**
+     * Gets as cueSheetList
+     *
+     * A Composite containing details of one or more CueSheets contained in Releases for which data is provided in the NewReleaseMessage.
+     *
+     * @return \DedexBundle\Entity\Ern42\DetailedCueSheetType[]
+     */
+    public function getCueSheetList()
+    {
+        return $this->cueSheetList;
+    }
+
+    /**
+     * Sets a new cueSheetList
+     *
+     * A Composite containing details of one or more CueSheets contained in Releases for which data is provided in the NewReleaseMessage.
+     *
+     * @param \DedexBundle\Entity\Ern42\DetailedCueSheetType[] $cueSheetList
+     * @return self
+     */
+    public function setCueSheetList(?array $cueSheetList = null)
+    {
+        $this->cueSheetList = $cueSheetList;
+        return $this;
+    }
+
+    /**
+     * Gets as resourceList
+     *
+     * A Composite containing details of one or more Resources.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/sequencing-resources
+     *
+     * @return \DedexBundle\Entity\Ern42\ResourceListType
+     */
+    public function getResourceList()
+    {
+        return $this->resourceList;
+    }
+
+    /**
+     * Sets a new resourceList
+     *
+     * A Composite containing details of one or more Resources.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/sequencing-resources
+     *
+     * @param \DedexBundle\Entity\Ern42\ResourceListType $resourceList
+     * @return self
+     */
+    public function setResourceList(\DedexBundle\Entity\Ern42\ResourceListType $resourceList)
+    {
+        $this->resourceList = $resourceList;
+        return $this;
+    }
+
+    /**
+     * Gets as chapterList
+     *
+     * A Composite containing details of one or more Chapters contained in Releases for which data is provided in the NewReleaseMessage.
+     *
+     * @return \DedexBundle\Entity\Ern42\ChapterListType
+     */
+    public function getChapterList()
+    {
+        return $this->chapterList;
+    }
+
+    /**
+     * Sets a new chapterList
+     *
+     * A Composite containing details of one or more Chapters contained in Releases for which data is provided in the NewReleaseMessage.
+     *
+     * @param \DedexBundle\Entity\Ern42\ChapterListType $chapterList
+     * @return self
+     */
+    public function setChapterList(?\DedexBundle\Entity\Ern42\ChapterListType $chapterList = null)
+    {
+        $this->chapterList = $chapterList;
+        return $this;
+    }
+
+    /**
+     * Gets as releaseList
+     *
+     * A Composite containing details of one or more DDEX Releases contained in the NewReleaseMessage.
+     *
+     * @return \DedexBundle\Entity\Ern42\ReleaseListType
+     */
+    public function getReleaseList()
+    {
+        return $this->releaseList;
+    }
+
+    /**
+     * Sets a new releaseList
+     *
+     * A Composite containing details of one or more DDEX Releases contained in the NewReleaseMessage.
+     *
+     * @param \DedexBundle\Entity\Ern42\ReleaseListType $releaseList
+     * @return self
+     */
+    public function setReleaseList(\DedexBundle\Entity\Ern42\ReleaseListType $releaseList)
+    {
+        $this->releaseList = $releaseList;
+        return $this;
+    }
+
+    /**
+     * Gets as dealList
+     *
+     * A Composite containing details of one or more Deals governing the Usage of the Releases in the Message.
+     *
+     * @return \DedexBundle\Entity\Ern42\DealListType
+     */
+    public function getDealList()
+    {
+        return $this->dealList;
+    }
+
+    /**
+     * Sets a new dealList
+     *
+     * A Composite containing details of one or more Deals governing the Usage of the Releases in the Message.
+     *
+     * @param \DedexBundle\Entity\Ern42\DealListType $dealList
+     * @return self
+     */
+    public function setDealList(?\DedexBundle\Entity\Ern42\DealListType $dealList = null)
+    {
+        $this->dealList = $dealList;
+        return $this;
+    }
+
+    /**
+     * Adds as supplementalDocument
+     *
+     * A Composite containing details of one or more XML documents communicated with the Message.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\FileType $supplementalDocument
+     */
+    public function addToSupplementalDocumentList(\DedexBundle\Entity\Ern42\FileType $supplementalDocument)
+    {
+        $this->supplementalDocumentList[] = $supplementalDocument;
+        return $this;
+    }
+
+    /**
+     * isset supplementalDocumentList
+     *
+     * A Composite containing details of one or more XML documents communicated with the Message.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetSupplementalDocumentList($index)
+    {
+        return isset($this->supplementalDocumentList[$index]);
+    }
+
+    /**
+     * unset supplementalDocumentList
+     *
+     * A Composite containing details of one or more XML documents communicated with the Message.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetSupplementalDocumentList($index)
+    {
+        unset($this->supplementalDocumentList[$index]);
+    }
+
+    /**
+     * Gets as supplementalDocumentList
+     *
+     * A Composite containing details of one or more XML documents communicated with the Message.
+     *
+     * @return \DedexBundle\Entity\Ern42\FileType[]
+     */
+    public function getSupplementalDocumentList()
+    {
+        return $this->supplementalDocumentList;
+    }
+
+    /**
+     * Sets a new supplementalDocumentList
+     *
+     * A Composite containing details of one or more XML documents communicated with the Message.
+     *
+     * @param \DedexBundle\Entity\Ern42\FileType[] $supplementalDocumentList
+     * @return self
+     */
+    public function setSupplementalDocumentList(?array $supplementalDocumentList = null)
+    {
+        $this->supplementalDocumentList = $supplementalDocumentList;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/OperatingSystemTypeType.php
+++ b/src/Entity/Ern42/OperatingSystemTypeType.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing OperatingSystemTypeType
+ *
+ * A Composite containing details of an OperatingSystemType.
+ * XSD Type: OperatingSystemType
+ */
+class OperatingSystemTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Identifier of the Version of the OperatingSystemType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $version
+     */
+    private $version = null;
+
+    /**
+     * The Namespace of the OperatingSystemType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the OperatingSystemType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as version
+     *
+     * The Identifier of the Version of the OperatingSystemType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getVersion()
+    {
+        return $this->version;
+    }
+
+    /**
+     * Sets a new version
+     *
+     * The Identifier of the Version of the OperatingSystemType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $version
+     * @return self
+     */
+    public function setVersion($version)
+    {
+        $this->version = $version;
+        return $this;
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the OperatingSystemType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the OperatingSystemType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the OperatingSystemType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the OperatingSystemType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/PLineType.php
+++ b/src/Entity/Ern42/PLineType.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing PLineType
+ *
+ * A Composite containing details of a PLine.
+ * XSD Type: PLine
+ */
+class PLineType
+{
+    /**
+     * The Language and script of the PLineText as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * A Type of PLine. This is represented in an XML schema as an XML Attribute. If this Attribute is not provided, it is assumed that the PLine is an OriginalPLine.
+     *
+     * @var string $pLineType
+     */
+    private $pLineType = null;
+
+    /**
+     * The Year of the PLine.
+     *
+     * @var int $year
+     */
+    private $year = null;
+
+    /**
+     * The Name of the company releasing the Creation. This may be an owner or a Licensee of the Creation.
+     *
+     * @var string $pLineCompany
+     */
+    private $pLineCompany = null;
+
+    /**
+     * The text of the PLine.
+     *
+     * @var string $pLineText
+     */
+    private $pLineText = null;
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script of the PLineText as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script of the PLineText as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as pLineType
+     *
+     * A Type of PLine. This is represented in an XML schema as an XML Attribute. If this Attribute is not provided, it is assumed that the PLine is an OriginalPLine.
+     *
+     * @return string
+     */
+    public function getPLineType()
+    {
+        return $this->pLineType;
+    }
+
+    /**
+     * Sets a new pLineType
+     *
+     * A Type of PLine. This is represented in an XML schema as an XML Attribute. If this Attribute is not provided, it is assumed that the PLine is an OriginalPLine.
+     *
+     * @param string $pLineType
+     * @return self
+     */
+    public function setPLineType($pLineType)
+    {
+        $this->pLineType = $pLineType;
+        return $this;
+    }
+
+    /**
+     * Gets as year
+     *
+     * The Year of the PLine.
+     *
+     * @return int
+     */
+    public function getYear()
+    {
+        return $this->year;
+    }
+
+    /**
+     * Sets a new year
+     *
+     * The Year of the PLine.
+     *
+     * @param int $year
+     * @return self
+     */
+    public function setYear($year)
+    {
+        $this->year = $year;
+        return $this;
+    }
+
+    /**
+     * Gets as pLineCompany
+     *
+     * The Name of the company releasing the Creation. This may be an owner or a Licensee of the Creation.
+     *
+     * @return string
+     */
+    public function getPLineCompany()
+    {
+        return $this->pLineCompany;
+    }
+
+    /**
+     * Sets a new pLineCompany
+     *
+     * The Name of the company releasing the Creation. This may be an owner or a Licensee of the Creation.
+     *
+     * @param string $pLineCompany
+     * @return self
+     */
+    public function setPLineCompany($pLineCompany)
+    {
+        $this->pLineCompany = $pLineCompany;
+        return $this;
+    }
+
+    /**
+     * Gets as pLineText
+     *
+     * The text of the PLine.
+     *
+     * @return string
+     */
+    public function getPLineText()
+    {
+        return $this->pLineText;
+    }
+
+    /**
+     * Sets a new pLineText
+     *
+     * The text of the PLine.
+     *
+     * @param string $pLineText
+     * @return self
+     */
+    public function setPLineText($pLineText)
+    {
+        $this->pLineText = $pLineText;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/PLineWithDefaultType.php
+++ b/src/Entity/Ern42/PLineWithDefaultType.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing PLineWithDefaultType
+ *
+ * A Composite containing details of a PLine.
+ * Explanatory Note: This Composite is named PLineWithDefault to disambiguate it from the basic PLine Composite.
+ * XSD Type: PLineWithDefault
+ */
+class PLineWithDefaultType
+{
+    /**
+     * A Territory to which the PLine applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * The Language and script of the PLineText as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * The Year of the PLine.
+     *
+     * @var int $year
+     */
+    private $year = null;
+
+    /**
+     * The Name of the company releasing the Creation. This may be an owner or a Licensee of the Creation.
+     *
+     * @var string $pLineCompany
+     */
+    private $pLineCompany = null;
+
+    /**
+     * The text of the PLine.
+     *
+     * @var string $pLineText
+     */
+    private $pLineText = null;
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the PLine applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the PLine applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script of the PLineText as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script of the PLineText as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as year
+     *
+     * The Year of the PLine.
+     *
+     * @return int
+     */
+    public function getYear()
+    {
+        return $this->year;
+    }
+
+    /**
+     * Sets a new year
+     *
+     * The Year of the PLine.
+     *
+     * @param int $year
+     * @return self
+     */
+    public function setYear($year)
+    {
+        $this->year = $year;
+        return $this;
+    }
+
+    /**
+     * Gets as pLineCompany
+     *
+     * The Name of the company releasing the Creation. This may be an owner or a Licensee of the Creation.
+     *
+     * @return string
+     */
+    public function getPLineCompany()
+    {
+        return $this->pLineCompany;
+    }
+
+    /**
+     * Sets a new pLineCompany
+     *
+     * The Name of the company releasing the Creation. This may be an owner or a Licensee of the Creation.
+     *
+     * @param string $pLineCompany
+     * @return self
+     */
+    public function setPLineCompany($pLineCompany)
+    {
+        $this->pLineCompany = $pLineCompany;
+        return $this;
+    }
+
+    /**
+     * Gets as pLineText
+     *
+     * The text of the PLine.
+     *
+     * @return string
+     */
+    public function getPLineText()
+    {
+        return $this->pLineText;
+    }
+
+    /**
+     * Sets a new pLineText
+     *
+     * The text of the PLine.
+     *
+     * @param string $pLineText
+     * @return self
+     */
+    public function setPLineText($pLineText)
+    {
+        $this->pLineText = $pLineText;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ParentalWarningTypeWithTerritoryType.php
+++ b/src/Entity/Ern42/ParentalWarningTypeWithTerritoryType.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ParentalWarningTypeWithTerritoryType
+ *
+ * A Composite containing details of a ParentalWarningType.
+ * Explanatory Note: This Composite is named ParentalWarningTypeWithTerritory to disambiguate it from the basic ParentalWarningType Composite.
+ * XSD Type: ParentalWarningTypeWithTerritory
+ */
+class ParentalWarningTypeWithTerritoryType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the ParentalWarningType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A Territory to which the ParentalWarningType applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * A UserDefined value of the ParentalWarningType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the ParentalWarningType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the ParentalWarningType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the ParentalWarningType applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the ParentalWarningType applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the ParentalWarningType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the ParentalWarningType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/PartyListType.php
+++ b/src/Entity/Ern42/PartyListType.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing PartyListType
+ *
+ * A Composite containing details of one or more Parties.
+ * XSD Type: PartyList
+ */
+class PartyListType
+{
+    /**
+     * A Composite containing details of a Party.
+     *
+     * @var \DedexBundle\Entity\Ern42\PartyType[] $party
+     */
+    private $party = [
+        
+    ];
+
+    /**
+     * Adds as party
+     *
+     * A Composite containing details of a Party.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\PartyType $party
+     */
+    public function addToParty(\DedexBundle\Entity\Ern42\PartyType $party)
+    {
+        $this->party[] = $party;
+        return $this;
+    }
+
+    /**
+     * isset party
+     *
+     * A Composite containing details of a Party.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetParty($index)
+    {
+        return isset($this->party[$index]);
+    }
+
+    /**
+     * unset party
+     *
+     * A Composite containing details of a Party.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetParty($index)
+    {
+        unset($this->party[$index]);
+    }
+
+    /**
+     * Gets as party
+     *
+     * A Composite containing details of a Party.
+     *
+     * @return \DedexBundle\Entity\Ern42\PartyType[]
+     */
+    public function getParty()
+    {
+        return $this->party;
+    }
+
+    /**
+     * Sets a new party
+     *
+     * A Composite containing details of a Party.
+     *
+     * @param \DedexBundle\Entity\Ern42\PartyType[] $party
+     * @return self
+     */
+    public function setParty(array $party)
+    {
+        $this->party = $party;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/PartyNameType.php
+++ b/src/Entity/Ern42/PartyNameType.php
@@ -1,0 +1,279 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing PartyNameType
+ *
+ * A Composite containing details of a PartyName. Name details for a Party typically either contain a FullName or a KeyName.
+ * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+ * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers
+ * XSD Type: PartyName
+ */
+class PartyNameType
+{
+    /**
+     * The Language and script for the Elements of the PartyName as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * A Composite containing the complete Name of the Party, in its normal form of presentation (e.g. John H. Smith, Acme Music Inc, the Beatles).
+     *
+     * @var \DedexBundle\Entity\Ern42\NameType $fullName
+     */
+    private $fullName = null;
+
+    /**
+     * The FullName transcribed using 7-bit ASCII code.
+     *
+     * @var string $fullNameAsciiTranscribed
+     */
+    private $fullNameAsciiTranscribed = null;
+
+    /**
+     * A Composite containing the complete Name of the Party in the form in which it normally appears in an alphabetic index, with the KeyName first (e.g. Smith, John H.; Beatles, The).
+     *
+     * @var \DedexBundle\Entity\Ern42\NameType $fullNameIndexed
+     */
+    private $fullNameIndexed = null;
+
+    /**
+     * A Composite containing the Name(s) preceding the KeyName in the FullName (and that is placed after it in a FullNameIndexed). Examples: 'George' in 'George Michael'; 'John Fitzgerald' in 'John Fitzgerald Kennedy'. Not all PartyNames have a NamesBeforeKeyName (e.g. Madonna, EMI Music Inc).
+     *
+     * @var \DedexBundle\Entity\Ern42\NameType $namesBeforeKeyName
+     */
+    private $namesBeforeKeyName = null;
+
+    /**
+     * A Composite containing the Part of a Name of the Party normally used to index an entry in an alphabetical list, such as 'Smith' (in John Smith) or 'Garcia Marquez' or 'Madonna' or 'Francis de Sales' (in Saint Francis de Sales). For persons, this normally corresponds to the 'family name' or names, which in Western name forms usually comes as a surname at the end of a FullName, and in Asian name forms often at the beginning of a FullName.
+     *
+     * @var \DedexBundle\Entity\Ern42\NameType $keyName
+     */
+    private $keyName = null;
+
+    /**
+     * A Composite containing the Name(s) following the KeyName. Example:'Ibrahim' (in Anwar Ibrahim). This is common, e.g., in many Asian personal name forms where a FullName begins with the KeyName, which is followed by other names.
+     *
+     * @var \DedexBundle\Entity\Ern42\NameType $namesAfterKeyName
+     */
+    private $namesAfterKeyName = null;
+
+    /**
+     * A Composite containing a short version of the PartyName (e.g. for use on devices with a small display).
+     *
+     * @var \DedexBundle\Entity\Ern42\NameType $abbreviatedName
+     */
+    private $abbreviatedName = null;
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the Elements of the PartyName as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the Elements of the PartyName as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as fullName
+     *
+     * A Composite containing the complete Name of the Party, in its normal form of presentation (e.g. John H. Smith, Acme Music Inc, the Beatles).
+     *
+     * @return \DedexBundle\Entity\Ern42\NameType
+     */
+    public function getFullName()
+    {
+        return $this->fullName;
+    }
+
+    /**
+     * Sets a new fullName
+     *
+     * A Composite containing the complete Name of the Party, in its normal form of presentation (e.g. John H. Smith, Acme Music Inc, the Beatles).
+     *
+     * @param \DedexBundle\Entity\Ern42\NameType $fullName
+     * @return self
+     */
+    public function setFullName(\DedexBundle\Entity\Ern42\NameType $fullName)
+    {
+        $this->fullName = $fullName;
+        return $this;
+    }
+
+    /**
+     * Gets as fullNameAsciiTranscribed
+     *
+     * The FullName transcribed using 7-bit ASCII code.
+     *
+     * @return string
+     */
+    public function getFullNameAsciiTranscribed()
+    {
+        return $this->fullNameAsciiTranscribed;
+    }
+
+    /**
+     * Sets a new fullNameAsciiTranscribed
+     *
+     * The FullName transcribed using 7-bit ASCII code.
+     *
+     * @param string $fullNameAsciiTranscribed
+     * @return self
+     */
+    public function setFullNameAsciiTranscribed($fullNameAsciiTranscribed)
+    {
+        $this->fullNameAsciiTranscribed = $fullNameAsciiTranscribed;
+        return $this;
+    }
+
+    /**
+     * Gets as fullNameIndexed
+     *
+     * A Composite containing the complete Name of the Party in the form in which it normally appears in an alphabetic index, with the KeyName first (e.g. Smith, John H.; Beatles, The).
+     *
+     * @return \DedexBundle\Entity\Ern42\NameType
+     */
+    public function getFullNameIndexed()
+    {
+        return $this->fullNameIndexed;
+    }
+
+    /**
+     * Sets a new fullNameIndexed
+     *
+     * A Composite containing the complete Name of the Party in the form in which it normally appears in an alphabetic index, with the KeyName first (e.g. Smith, John H.; Beatles, The).
+     *
+     * @param \DedexBundle\Entity\Ern42\NameType $fullNameIndexed
+     * @return self
+     */
+    public function setFullNameIndexed(?\DedexBundle\Entity\Ern42\NameType $fullNameIndexed = null)
+    {
+        $this->fullNameIndexed = $fullNameIndexed;
+        return $this;
+    }
+
+    /**
+     * Gets as namesBeforeKeyName
+     *
+     * A Composite containing the Name(s) preceding the KeyName in the FullName (and that is placed after it in a FullNameIndexed). Examples: 'George' in 'George Michael'; 'John Fitzgerald' in 'John Fitzgerald Kennedy'. Not all PartyNames have a NamesBeforeKeyName (e.g. Madonna, EMI Music Inc).
+     *
+     * @return \DedexBundle\Entity\Ern42\NameType
+     */
+    public function getNamesBeforeKeyName()
+    {
+        return $this->namesBeforeKeyName;
+    }
+
+    /**
+     * Sets a new namesBeforeKeyName
+     *
+     * A Composite containing the Name(s) preceding the KeyName in the FullName (and that is placed after it in a FullNameIndexed). Examples: 'George' in 'George Michael'; 'John Fitzgerald' in 'John Fitzgerald Kennedy'. Not all PartyNames have a NamesBeforeKeyName (e.g. Madonna, EMI Music Inc).
+     *
+     * @param \DedexBundle\Entity\Ern42\NameType $namesBeforeKeyName
+     * @return self
+     */
+    public function setNamesBeforeKeyName(?\DedexBundle\Entity\Ern42\NameType $namesBeforeKeyName = null)
+    {
+        $this->namesBeforeKeyName = $namesBeforeKeyName;
+        return $this;
+    }
+
+    /**
+     * Gets as keyName
+     *
+     * A Composite containing the Part of a Name of the Party normally used to index an entry in an alphabetical list, such as 'Smith' (in John Smith) or 'Garcia Marquez' or 'Madonna' or 'Francis de Sales' (in Saint Francis de Sales). For persons, this normally corresponds to the 'family name' or names, which in Western name forms usually comes as a surname at the end of a FullName, and in Asian name forms often at the beginning of a FullName.
+     *
+     * @return \DedexBundle\Entity\Ern42\NameType
+     */
+    public function getKeyName()
+    {
+        return $this->keyName;
+    }
+
+    /**
+     * Sets a new keyName
+     *
+     * A Composite containing the Part of a Name of the Party normally used to index an entry in an alphabetical list, such as 'Smith' (in John Smith) or 'Garcia Marquez' or 'Madonna' or 'Francis de Sales' (in Saint Francis de Sales). For persons, this normally corresponds to the 'family name' or names, which in Western name forms usually comes as a surname at the end of a FullName, and in Asian name forms often at the beginning of a FullName.
+     *
+     * @param \DedexBundle\Entity\Ern42\NameType $keyName
+     * @return self
+     */
+    public function setKeyName(?\DedexBundle\Entity\Ern42\NameType $keyName = null)
+    {
+        $this->keyName = $keyName;
+        return $this;
+    }
+
+    /**
+     * Gets as namesAfterKeyName
+     *
+     * A Composite containing the Name(s) following the KeyName. Example:'Ibrahim' (in Anwar Ibrahim). This is common, e.g., in many Asian personal name forms where a FullName begins with the KeyName, which is followed by other names.
+     *
+     * @return \DedexBundle\Entity\Ern42\NameType
+     */
+    public function getNamesAfterKeyName()
+    {
+        return $this->namesAfterKeyName;
+    }
+
+    /**
+     * Sets a new namesAfterKeyName
+     *
+     * A Composite containing the Name(s) following the KeyName. Example:'Ibrahim' (in Anwar Ibrahim). This is common, e.g., in many Asian personal name forms where a FullName begins with the KeyName, which is followed by other names.
+     *
+     * @param \DedexBundle\Entity\Ern42\NameType $namesAfterKeyName
+     * @return self
+     */
+    public function setNamesAfterKeyName(?\DedexBundle\Entity\Ern42\NameType $namesAfterKeyName = null)
+    {
+        $this->namesAfterKeyName = $namesAfterKeyName;
+        return $this;
+    }
+
+    /**
+     * Gets as abbreviatedName
+     *
+     * A Composite containing a short version of the PartyName (e.g. for use on devices with a small display).
+     *
+     * @return \DedexBundle\Entity\Ern42\NameType
+     */
+    public function getAbbreviatedName()
+    {
+        return $this->abbreviatedName;
+    }
+
+    /**
+     * Sets a new abbreviatedName
+     *
+     * A Composite containing a short version of the PartyName (e.g. for use on devices with a small display).
+     *
+     * @param \DedexBundle\Entity\Ern42\NameType $abbreviatedName
+     * @return self
+     */
+    public function setAbbreviatedName(?\DedexBundle\Entity\Ern42\NameType $abbreviatedName = null)
+    {
+        $this->abbreviatedName = $abbreviatedName;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/PartyNameWithTerritoryType.php
+++ b/src/Entity/Ern42/PartyNameWithTerritoryType.php
@@ -1,0 +1,443 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing PartyNameWithTerritoryType
+ *
+ * A Composite containing details of a PartyName. Name details for a Party typically either contain a FullName or a KeyName.
+ * Explanatory Note: This Composite is named PartyNameWithTerritory to disambiguate it from the basic PartyName Composite.
+ * XSD Type: PartyNameWithTerritory
+ */
+class PartyNameWithTerritoryType
+{
+    /**
+     * The Language and script for the Elements of the PartyName as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * The Flag indicating whether this Name is a nickname (=true) or not (=false). A nickname is a substitute for the proper name (e.g. an affective or diminutive name) and not to be confused with a pseudonym or a stage name.
+     *
+     * @var bool $isNickname
+     */
+    private $isNickname = null;
+
+    /**
+     * The Flag indicating whether this Name is a stage name (=true) or not (=false).
+     *
+     * @var bool $isStageName
+     */
+    private $isStageName = null;
+
+    /**
+     * The Flag indicating whether this Name is a legal name (=true) or not (=false).
+     *
+     * @var bool $isLegalName
+     */
+    private $isLegalName = null;
+
+    /**
+     * A Territory to which the PartyName applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * A Composite containing the complete Name of the Party, in its normal form of presentation (e.g. John H. Smith, Acme Music Inc, the Beatles).
+     *
+     * @var \DedexBundle\Entity\Ern42\NameType $fullName
+     */
+    private $fullName = null;
+
+    /**
+     * The FullName transcribed using 7-bit ASCII code.
+     *
+     * @var string $fullNameAsciiTranscribed
+     */
+    private $fullNameAsciiTranscribed = null;
+
+    /**
+     * A Composite containing the complete Name of the Party in the form in which it normally appears in an alphabetic index, with the KeyName first (e.g. Smith, John H.; Beatles, The).
+     *
+     * @var \DedexBundle\Entity\Ern42\NameType $fullNameIndexed
+     */
+    private $fullNameIndexed = null;
+
+    /**
+     * A Composite containing the Name(s) preceding the KeyName in the FullName (and that is placed after it in a FullNameIndexed). Examples: 'George' in 'George Michael'; 'John Fitzgerald' in 'John Fitzgerald Kennedy'. Not all PartyNames have a NamesBeforeKeyName (e.g. Madonna, EMI Music Inc).
+     *
+     * @var \DedexBundle\Entity\Ern42\NameType $namesBeforeKeyName
+     */
+    private $namesBeforeKeyName = null;
+
+    /**
+     * A Composite containing the Part of a Name of the Party normally used to index an entry in an alphabetical list, such as 'Smith' (in John Smith) or 'Garcia Marquez' or 'Madonna' or 'Francis de Sales' (in Saint Francis de Sales). For persons, this normally corresponds to the 'family name' or names, which in Western name forms usually comes as a surname at the end of a FullName, and in Asian name forms often at the beginning of a FullName.
+     *
+     * @var \DedexBundle\Entity\Ern42\NameType $keyName
+     */
+    private $keyName = null;
+
+    /**
+     * A Composite containing the Name(s) following the KeyName. Example:'Ibrahim' (in Anwar Ibrahim). This is common, e.g., in many Asian personal name forms where a FullName begins with the KeyName, which is followed by other names.
+     *
+     * @var \DedexBundle\Entity\Ern42\NameType $namesAfterKeyName
+     */
+    private $namesAfterKeyName = null;
+
+    /**
+     * A Composite containing a short version of the PartyName (e.g. for use on devices with a small display).
+     *
+     * @var \DedexBundle\Entity\Ern42\NameType $abbreviatedName
+     */
+    private $abbreviatedName = null;
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the Elements of the PartyName as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the Elements of the PartyName as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isNickname
+     *
+     * The Flag indicating whether this Name is a nickname (=true) or not (=false). A nickname is a substitute for the proper name (e.g. an affective or diminutive name) and not to be confused with a pseudonym or a stage name.
+     *
+     * @return bool
+     */
+    public function getIsNickname()
+    {
+        return $this->isNickname;
+    }
+
+    /**
+     * Sets a new isNickname
+     *
+     * The Flag indicating whether this Name is a nickname (=true) or not (=false). A nickname is a substitute for the proper name (e.g. an affective or diminutive name) and not to be confused with a pseudonym or a stage name.
+     *
+     * @param bool $isNickname
+     * @return self
+     */
+    public function setIsNickname($isNickname)
+    {
+        $this->isNickname = $isNickname;
+        return $this;
+    }
+
+    /**
+     * Gets as isStageName
+     *
+     * The Flag indicating whether this Name is a stage name (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getIsStageName()
+    {
+        return $this->isStageName;
+    }
+
+    /**
+     * Sets a new isStageName
+     *
+     * The Flag indicating whether this Name is a stage name (=true) or not (=false).
+     *
+     * @param bool $isStageName
+     * @return self
+     */
+    public function setIsStageName($isStageName)
+    {
+        $this->isStageName = $isStageName;
+        return $this;
+    }
+
+    /**
+     * Gets as isLegalName
+     *
+     * The Flag indicating whether this Name is a legal name (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getIsLegalName()
+    {
+        return $this->isLegalName;
+    }
+
+    /**
+     * Sets a new isLegalName
+     *
+     * The Flag indicating whether this Name is a legal name (=true) or not (=false).
+     *
+     * @param bool $isLegalName
+     * @return self
+     */
+    public function setIsLegalName($isLegalName)
+    {
+        $this->isLegalName = $isLegalName;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the PartyName applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the PartyName applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+
+    /**
+     * Gets as fullName
+     *
+     * A Composite containing the complete Name of the Party, in its normal form of presentation (e.g. John H. Smith, Acme Music Inc, the Beatles).
+     *
+     * @return \DedexBundle\Entity\Ern42\NameType
+     */
+    public function getFullName()
+    {
+        return $this->fullName;
+    }
+
+    /**
+     * Sets a new fullName
+     *
+     * A Composite containing the complete Name of the Party, in its normal form of presentation (e.g. John H. Smith, Acme Music Inc, the Beatles).
+     *
+     * @param \DedexBundle\Entity\Ern42\NameType $fullName
+     * @return self
+     */
+    public function setFullName(\DedexBundle\Entity\Ern42\NameType $fullName)
+    {
+        $this->fullName = $fullName;
+        return $this;
+    }
+
+    /**
+     * Gets as fullNameAsciiTranscribed
+     *
+     * The FullName transcribed using 7-bit ASCII code.
+     *
+     * @return string
+     */
+    public function getFullNameAsciiTranscribed()
+    {
+        return $this->fullNameAsciiTranscribed;
+    }
+
+    /**
+     * Sets a new fullNameAsciiTranscribed
+     *
+     * The FullName transcribed using 7-bit ASCII code.
+     *
+     * @param string $fullNameAsciiTranscribed
+     * @return self
+     */
+    public function setFullNameAsciiTranscribed($fullNameAsciiTranscribed)
+    {
+        $this->fullNameAsciiTranscribed = $fullNameAsciiTranscribed;
+        return $this;
+    }
+
+    /**
+     * Gets as fullNameIndexed
+     *
+     * A Composite containing the complete Name of the Party in the form in which it normally appears in an alphabetic index, with the KeyName first (e.g. Smith, John H.; Beatles, The).
+     *
+     * @return \DedexBundle\Entity\Ern42\NameType
+     */
+    public function getFullNameIndexed()
+    {
+        return $this->fullNameIndexed;
+    }
+
+    /**
+     * Sets a new fullNameIndexed
+     *
+     * A Composite containing the complete Name of the Party in the form in which it normally appears in an alphabetic index, with the KeyName first (e.g. Smith, John H.; Beatles, The).
+     *
+     * @param \DedexBundle\Entity\Ern42\NameType $fullNameIndexed
+     * @return self
+     */
+    public function setFullNameIndexed(?\DedexBundle\Entity\Ern42\NameType $fullNameIndexed = null)
+    {
+        $this->fullNameIndexed = $fullNameIndexed;
+        return $this;
+    }
+
+    /**
+     * Gets as namesBeforeKeyName
+     *
+     * A Composite containing the Name(s) preceding the KeyName in the FullName (and that is placed after it in a FullNameIndexed). Examples: 'George' in 'George Michael'; 'John Fitzgerald' in 'John Fitzgerald Kennedy'. Not all PartyNames have a NamesBeforeKeyName (e.g. Madonna, EMI Music Inc).
+     *
+     * @return \DedexBundle\Entity\Ern42\NameType
+     */
+    public function getNamesBeforeKeyName()
+    {
+        return $this->namesBeforeKeyName;
+    }
+
+    /**
+     * Sets a new namesBeforeKeyName
+     *
+     * A Composite containing the Name(s) preceding the KeyName in the FullName (and that is placed after it in a FullNameIndexed). Examples: 'George' in 'George Michael'; 'John Fitzgerald' in 'John Fitzgerald Kennedy'. Not all PartyNames have a NamesBeforeKeyName (e.g. Madonna, EMI Music Inc).
+     *
+     * @param \DedexBundle\Entity\Ern42\NameType $namesBeforeKeyName
+     * @return self
+     */
+    public function setNamesBeforeKeyName(?\DedexBundle\Entity\Ern42\NameType $namesBeforeKeyName = null)
+    {
+        $this->namesBeforeKeyName = $namesBeforeKeyName;
+        return $this;
+    }
+
+    /**
+     * Gets as keyName
+     *
+     * A Composite containing the Part of a Name of the Party normally used to index an entry in an alphabetical list, such as 'Smith' (in John Smith) or 'Garcia Marquez' or 'Madonna' or 'Francis de Sales' (in Saint Francis de Sales). For persons, this normally corresponds to the 'family name' or names, which in Western name forms usually comes as a surname at the end of a FullName, and in Asian name forms often at the beginning of a FullName.
+     *
+     * @return \DedexBundle\Entity\Ern42\NameType
+     */
+    public function getKeyName()
+    {
+        return $this->keyName;
+    }
+
+    /**
+     * Sets a new keyName
+     *
+     * A Composite containing the Part of a Name of the Party normally used to index an entry in an alphabetical list, such as 'Smith' (in John Smith) or 'Garcia Marquez' or 'Madonna' or 'Francis de Sales' (in Saint Francis de Sales). For persons, this normally corresponds to the 'family name' or names, which in Western name forms usually comes as a surname at the end of a FullName, and in Asian name forms often at the beginning of a FullName.
+     *
+     * @param \DedexBundle\Entity\Ern42\NameType $keyName
+     * @return self
+     */
+    public function setKeyName(?\DedexBundle\Entity\Ern42\NameType $keyName = null)
+    {
+        $this->keyName = $keyName;
+        return $this;
+    }
+
+    /**
+     * Gets as namesAfterKeyName
+     *
+     * A Composite containing the Name(s) following the KeyName. Example:'Ibrahim' (in Anwar Ibrahim). This is common, e.g., in many Asian personal name forms where a FullName begins with the KeyName, which is followed by other names.
+     *
+     * @return \DedexBundle\Entity\Ern42\NameType
+     */
+    public function getNamesAfterKeyName()
+    {
+        return $this->namesAfterKeyName;
+    }
+
+    /**
+     * Sets a new namesAfterKeyName
+     *
+     * A Composite containing the Name(s) following the KeyName. Example:'Ibrahim' (in Anwar Ibrahim). This is common, e.g., in many Asian personal name forms where a FullName begins with the KeyName, which is followed by other names.
+     *
+     * @param \DedexBundle\Entity\Ern42\NameType $namesAfterKeyName
+     * @return self
+     */
+    public function setNamesAfterKeyName(?\DedexBundle\Entity\Ern42\NameType $namesAfterKeyName = null)
+    {
+        $this->namesAfterKeyName = $namesAfterKeyName;
+        return $this;
+    }
+
+    /**
+     * Gets as abbreviatedName
+     *
+     * A Composite containing a short version of the PartyName (e.g. for use on devices with a small display).
+     *
+     * @return \DedexBundle\Entity\Ern42\NameType
+     */
+    public function getAbbreviatedName()
+    {
+        return $this->abbreviatedName;
+    }
+
+    /**
+     * Sets a new abbreviatedName
+     *
+     * A Composite containing a short version of the PartyName (e.g. for use on devices with a small display).
+     *
+     * @param \DedexBundle\Entity\Ern42\NameType $abbreviatedName
+     * @return self
+     */
+    public function setAbbreviatedName(?\DedexBundle\Entity\Ern42\NameType $abbreviatedName = null)
+    {
+        $this->abbreviatedName = $abbreviatedName;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/PartyNameWithoutCodeType.php
+++ b/src/Entity/Ern42/PartyNameWithoutCodeType.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing PartyNameWithoutCodeType
+ *
+ * A Composite containing details of a PartyName. Name details for a Party typically either contain a FullName or a KeyName.
+ * Explanatory Note: This Composite is named PartyNameWithoutCode to disambiguate it from the basic PartyName Composite.
+ * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+ * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers
+ * XSD Type: PartyNameWithoutCode
+ */
+class PartyNameWithoutCodeType
+{
+    /**
+     * The complete Name of the Party, in its normal form of presentation (e.g. John H. Smith, Acme Music Inc, the Beatles).
+     *
+     * @var string $fullName
+     */
+    private $fullName = null;
+
+    /**
+     * The FullName transcribed using 7-bit ASCII code.
+     *
+     * @var string $fullNameAsciiTranscribed
+     */
+    private $fullNameAsciiTranscribed = null;
+
+    /**
+     * The complete Name of the Party in the form in which it normally appears in an alphabetic index, with the KeyName first (e.g. Smith, John H.; Beatles, The).
+     *
+     * @var string $fullNameIndexed
+     */
+    private $fullNameIndexed = null;
+
+    /**
+     * The Name(s) preceding the KeyName in the FullName (and that is placed after it in a FullNameIndexed). Examples: 'George' in 'George Michael'; 'John Fitzgerald' in 'John Fitzgerald Kennedy'. Not all PartyNames have a NamesBeforeKeyName (e.g. Madonna, EMI Music Inc).
+     *
+     * @var string $namesBeforeKeyName
+     */
+    private $namesBeforeKeyName = null;
+
+    /**
+     * The Part of a Name of the Party normally used to index an entry in an alphabetical list, such as 'Smith' (in John Smith) or 'Garcia Marquez' or 'Madonna' or 'Francis de Sales' (in Saint Francis de Sales). For persons, this normally corresponds to the 'family name' or names, which in Western name forms usually comes as a surname at the end of a FullName, and in Asian name forms often at the beginning of a FullName.
+     *
+     * @var string $keyName
+     */
+    private $keyName = null;
+
+    /**
+     * The Name(s) following the KeyName. Example: 'Ibrahim' (in Anwar Ibrahim). This is common, e.g., in many Asian personal name forms where a FullName begins with the KeyName, which is followed by other names.
+     *
+     * @var string $namesAfterKeyName
+     */
+    private $namesAfterKeyName = null;
+
+    /**
+     * A short version of the PartyName (e.g. for use on devices with a small display).
+     *
+     * @var string $abbreviatedName
+     */
+    private $abbreviatedName = null;
+
+    /**
+     * Gets as fullName
+     *
+     * The complete Name of the Party, in its normal form of presentation (e.g. John H. Smith, Acme Music Inc, the Beatles).
+     *
+     * @return string
+     */
+    public function getFullName()
+    {
+        return $this->fullName;
+    }
+
+    /**
+     * Sets a new fullName
+     *
+     * The complete Name of the Party, in its normal form of presentation (e.g. John H. Smith, Acme Music Inc, the Beatles).
+     *
+     * @param string $fullName
+     * @return self
+     */
+    public function setFullName($fullName)
+    {
+        $this->fullName = $fullName;
+        return $this;
+    }
+
+    /**
+     * Gets as fullNameAsciiTranscribed
+     *
+     * The FullName transcribed using 7-bit ASCII code.
+     *
+     * @return string
+     */
+    public function getFullNameAsciiTranscribed()
+    {
+        return $this->fullNameAsciiTranscribed;
+    }
+
+    /**
+     * Sets a new fullNameAsciiTranscribed
+     *
+     * The FullName transcribed using 7-bit ASCII code.
+     *
+     * @param string $fullNameAsciiTranscribed
+     * @return self
+     */
+    public function setFullNameAsciiTranscribed($fullNameAsciiTranscribed)
+    {
+        $this->fullNameAsciiTranscribed = $fullNameAsciiTranscribed;
+        return $this;
+    }
+
+    /**
+     * Gets as fullNameIndexed
+     *
+     * The complete Name of the Party in the form in which it normally appears in an alphabetic index, with the KeyName first (e.g. Smith, John H.; Beatles, The).
+     *
+     * @return string
+     */
+    public function getFullNameIndexed()
+    {
+        return $this->fullNameIndexed;
+    }
+
+    /**
+     * Sets a new fullNameIndexed
+     *
+     * The complete Name of the Party in the form in which it normally appears in an alphabetic index, with the KeyName first (e.g. Smith, John H.; Beatles, The).
+     *
+     * @param string $fullNameIndexed
+     * @return self
+     */
+    public function setFullNameIndexed($fullNameIndexed)
+    {
+        $this->fullNameIndexed = $fullNameIndexed;
+        return $this;
+    }
+
+    /**
+     * Gets as namesBeforeKeyName
+     *
+     * The Name(s) preceding the KeyName in the FullName (and that is placed after it in a FullNameIndexed). Examples: 'George' in 'George Michael'; 'John Fitzgerald' in 'John Fitzgerald Kennedy'. Not all PartyNames have a NamesBeforeKeyName (e.g. Madonna, EMI Music Inc).
+     *
+     * @return string
+     */
+    public function getNamesBeforeKeyName()
+    {
+        return $this->namesBeforeKeyName;
+    }
+
+    /**
+     * Sets a new namesBeforeKeyName
+     *
+     * The Name(s) preceding the KeyName in the FullName (and that is placed after it in a FullNameIndexed). Examples: 'George' in 'George Michael'; 'John Fitzgerald' in 'John Fitzgerald Kennedy'. Not all PartyNames have a NamesBeforeKeyName (e.g. Madonna, EMI Music Inc).
+     *
+     * @param string $namesBeforeKeyName
+     * @return self
+     */
+    public function setNamesBeforeKeyName($namesBeforeKeyName)
+    {
+        $this->namesBeforeKeyName = $namesBeforeKeyName;
+        return $this;
+    }
+
+    /**
+     * Gets as keyName
+     *
+     * The Part of a Name of the Party normally used to index an entry in an alphabetical list, such as 'Smith' (in John Smith) or 'Garcia Marquez' or 'Madonna' or 'Francis de Sales' (in Saint Francis de Sales). For persons, this normally corresponds to the 'family name' or names, which in Western name forms usually comes as a surname at the end of a FullName, and in Asian name forms often at the beginning of a FullName.
+     *
+     * @return string
+     */
+    public function getKeyName()
+    {
+        return $this->keyName;
+    }
+
+    /**
+     * Sets a new keyName
+     *
+     * The Part of a Name of the Party normally used to index an entry in an alphabetical list, such as 'Smith' (in John Smith) or 'Garcia Marquez' or 'Madonna' or 'Francis de Sales' (in Saint Francis de Sales). For persons, this normally corresponds to the 'family name' or names, which in Western name forms usually comes as a surname at the end of a FullName, and in Asian name forms often at the beginning of a FullName.
+     *
+     * @param string $keyName
+     * @return self
+     */
+    public function setKeyName($keyName)
+    {
+        $this->keyName = $keyName;
+        return $this;
+    }
+
+    /**
+     * Gets as namesAfterKeyName
+     *
+     * The Name(s) following the KeyName. Example: 'Ibrahim' (in Anwar Ibrahim). This is common, e.g., in many Asian personal name forms where a FullName begins with the KeyName, which is followed by other names.
+     *
+     * @return string
+     */
+    public function getNamesAfterKeyName()
+    {
+        return $this->namesAfterKeyName;
+    }
+
+    /**
+     * Sets a new namesAfterKeyName
+     *
+     * The Name(s) following the KeyName. Example: 'Ibrahim' (in Anwar Ibrahim). This is common, e.g., in many Asian personal name forms where a FullName begins with the KeyName, which is followed by other names.
+     *
+     * @param string $namesAfterKeyName
+     * @return self
+     */
+    public function setNamesAfterKeyName($namesAfterKeyName)
+    {
+        $this->namesAfterKeyName = $namesAfterKeyName;
+        return $this;
+    }
+
+    /**
+     * Gets as abbreviatedName
+     *
+     * A short version of the PartyName (e.g. for use on devices with a small display).
+     *
+     * @return string
+     */
+    public function getAbbreviatedName()
+    {
+        return $this->abbreviatedName;
+    }
+
+    /**
+     * Sets a new abbreviatedName
+     *
+     * A short version of the PartyName (e.g. for use on devices with a small display).
+     *
+     * @param string $abbreviatedName
+     * @return self
+     */
+    public function setAbbreviatedName($abbreviatedName)
+    {
+        $this->abbreviatedName = $abbreviatedName;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/PartyRelationshipTypeType.php
+++ b/src/Entity/Ern42/PartyRelationshipTypeType.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing PartyRelationshipTypeType
+ *
+ * A Composite containing details of a PartyRelationshipType.
+ * XSD Type: PartyRelationshipType
+ */
+class PartyRelationshipTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the PartyRelationshipType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the PartyRelationshipType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * A Flag indicating whether this information may be shared (=true) or not (=false). If the Flag is not present, the information may be shared.
+     *
+     * @var bool $mayBeShared
+     */
+    private $mayBeShared = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the PartyRelationshipType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the PartyRelationshipType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the PartyRelationshipType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the PartyRelationshipType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+
+    /**
+     * Gets as mayBeShared
+     *
+     * A Flag indicating whether this information may be shared (=true) or not (=false). If the Flag is not present, the information may be shared.
+     *
+     * @return bool
+     */
+    public function getMayBeShared()
+    {
+        return $this->mayBeShared;
+    }
+
+    /**
+     * Sets a new mayBeShared
+     *
+     * A Flag indicating whether this information may be shared (=true) or not (=false). If the Flag is not present, the information may be shared.
+     *
+     * @param bool $mayBeShared
+     * @return self
+     */
+    public function setMayBeShared($mayBeShared)
+    {
+        $this->mayBeShared = $mayBeShared;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/PartyType.php
+++ b/src/Entity/Ern42/PartyType.php
@@ -1,0 +1,421 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing PartyType
+ *
+ * A Composite containing details of a Party.
+ * XSD Type: Party
+ */
+class PartyType
+{
+    /**
+     * The Identifier (specific to the Message) of the Party. This is a LocalPartyAnchor starting with the letter P.
+     *
+     * @var string $partyReference
+     */
+    private $partyReference = null;
+
+    /**
+     * A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.
+     *
+     * @var \DedexBundle\Entity\Ern42\DetailedPartyIdType[] $partyId
+     */
+    private $partyId = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the PartyName(s).
+     *
+     * @var \DedexBundle\Entity\Ern42\PartyNameWithTerritoryType[] $partyName
+     */
+    private $partyName = [
+        
+    ];
+
+    /**
+     * A Composite containing details of an affiliation for the Party.
+     *
+     * @var \DedexBundle\Entity\Ern42\AffiliationType[] $affiliation
+     */
+    private $affiliation = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a PartyRelatedPartyReference referring to a Party that is related to the current Party. This can be used to express, for instance, relationships between a band and its members or between a label and its parent company.
+     *
+     * @var \DedexBundle\Entity\Ern42\RelatedPartyType[] $relatedParty
+     */
+    private $relatedParty = [
+        
+    ];
+
+    /**
+     * A URL of a WebPage for the Artist.
+     *
+     * @var string[] $artistProfilePage
+     */
+    private $artistProfilePage = [
+        
+    ];
+
+    /**
+     * Gets as partyReference
+     *
+     * The Identifier (specific to the Message) of the Party. This is a LocalPartyAnchor starting with the letter P.
+     *
+     * @return string
+     */
+    public function getPartyReference()
+    {
+        return $this->partyReference;
+    }
+
+    /**
+     * Sets a new partyReference
+     *
+     * The Identifier (specific to the Message) of the Party. This is a LocalPartyAnchor starting with the letter P.
+     *
+     * @param string $partyReference
+     * @return self
+     */
+    public function setPartyReference($partyReference)
+    {
+        $this->partyReference = $partyReference;
+        return $this;
+    }
+
+    /**
+     * Adds as partyId
+     *
+     * A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DetailedPartyIdType $partyId
+     */
+    public function addToPartyId(\DedexBundle\Entity\Ern42\DetailedPartyIdType $partyId)
+    {
+        $this->partyId[] = $partyId;
+        return $this;
+    }
+
+    /**
+     * isset partyId
+     *
+     * A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetPartyId($index)
+    {
+        return isset($this->partyId[$index]);
+    }
+
+    /**
+     * unset partyId
+     *
+     * A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetPartyId($index)
+    {
+        unset($this->partyId[$index]);
+    }
+
+    /**
+     * Gets as partyId
+     *
+     * A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.
+     *
+     * @return \DedexBundle\Entity\Ern42\DetailedPartyIdType[]
+     */
+    public function getPartyId()
+    {
+        return $this->partyId;
+    }
+
+    /**
+     * Sets a new partyId
+     *
+     * A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.
+     *
+     * @param \DedexBundle\Entity\Ern42\DetailedPartyIdType[] $partyId
+     * @return self
+     */
+    public function setPartyId(?array $partyId = null)
+    {
+        $this->partyId = $partyId;
+        return $this;
+    }
+
+    /**
+     * Adds as partyName
+     *
+     * A Composite containing details of the PartyName(s).
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\PartyNameWithTerritoryType $partyName
+     */
+    public function addToPartyName(\DedexBundle\Entity\Ern42\PartyNameWithTerritoryType $partyName)
+    {
+        $this->partyName[] = $partyName;
+        return $this;
+    }
+
+    /**
+     * isset partyName
+     *
+     * A Composite containing details of the PartyName(s).
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetPartyName($index)
+    {
+        return isset($this->partyName[$index]);
+    }
+
+    /**
+     * unset partyName
+     *
+     * A Composite containing details of the PartyName(s).
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetPartyName($index)
+    {
+        unset($this->partyName[$index]);
+    }
+
+    /**
+     * Gets as partyName
+     *
+     * A Composite containing details of the PartyName(s).
+     *
+     * @return \DedexBundle\Entity\Ern42\PartyNameWithTerritoryType[]
+     */
+    public function getPartyName()
+    {
+        return $this->partyName;
+    }
+
+    /**
+     * Sets a new partyName
+     *
+     * A Composite containing details of the PartyName(s).
+     *
+     * @param \DedexBundle\Entity\Ern42\PartyNameWithTerritoryType[] $partyName
+     * @return self
+     */
+    public function setPartyName(?array $partyName = null)
+    {
+        $this->partyName = $partyName;
+        return $this;
+    }
+
+    /**
+     * Adds as affiliation
+     *
+     * A Composite containing details of an affiliation for the Party.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\AffiliationType $affiliation
+     */
+    public function addToAffiliation(\DedexBundle\Entity\Ern42\AffiliationType $affiliation)
+    {
+        $this->affiliation[] = $affiliation;
+        return $this;
+    }
+
+    /**
+     * isset affiliation
+     *
+     * A Composite containing details of an affiliation for the Party.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetAffiliation($index)
+    {
+        return isset($this->affiliation[$index]);
+    }
+
+    /**
+     * unset affiliation
+     *
+     * A Composite containing details of an affiliation for the Party.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetAffiliation($index)
+    {
+        unset($this->affiliation[$index]);
+    }
+
+    /**
+     * Gets as affiliation
+     *
+     * A Composite containing details of an affiliation for the Party.
+     *
+     * @return \DedexBundle\Entity\Ern42\AffiliationType[]
+     */
+    public function getAffiliation()
+    {
+        return $this->affiliation;
+    }
+
+    /**
+     * Sets a new affiliation
+     *
+     * A Composite containing details of an affiliation for the Party.
+     *
+     * @param \DedexBundle\Entity\Ern42\AffiliationType[] $affiliation
+     * @return self
+     */
+    public function setAffiliation(?array $affiliation = null)
+    {
+        $this->affiliation = $affiliation;
+        return $this;
+    }
+
+    /**
+     * Adds as relatedParty
+     *
+     * A Composite containing details of a PartyRelatedPartyReference referring to a Party that is related to the current Party. This can be used to express, for instance, relationships between a band and its members or between a label and its parent company.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\RelatedPartyType $relatedParty
+     */
+    public function addToRelatedParty(\DedexBundle\Entity\Ern42\RelatedPartyType $relatedParty)
+    {
+        $this->relatedParty[] = $relatedParty;
+        return $this;
+    }
+
+    /**
+     * isset relatedParty
+     *
+     * A Composite containing details of a PartyRelatedPartyReference referring to a Party that is related to the current Party. This can be used to express, for instance, relationships between a band and its members or between a label and its parent company.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRelatedParty($index)
+    {
+        return isset($this->relatedParty[$index]);
+    }
+
+    /**
+     * unset relatedParty
+     *
+     * A Composite containing details of a PartyRelatedPartyReference referring to a Party that is related to the current Party. This can be used to express, for instance, relationships between a band and its members or between a label and its parent company.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRelatedParty($index)
+    {
+        unset($this->relatedParty[$index]);
+    }
+
+    /**
+     * Gets as relatedParty
+     *
+     * A Composite containing details of a PartyRelatedPartyReference referring to a Party that is related to the current Party. This can be used to express, for instance, relationships between a band and its members or between a label and its parent company.
+     *
+     * @return \DedexBundle\Entity\Ern42\RelatedPartyType[]
+     */
+    public function getRelatedParty()
+    {
+        return $this->relatedParty;
+    }
+
+    /**
+     * Sets a new relatedParty
+     *
+     * A Composite containing details of a PartyRelatedPartyReference referring to a Party that is related to the current Party. This can be used to express, for instance, relationships between a band and its members or between a label and its parent company.
+     *
+     * @param \DedexBundle\Entity\Ern42\RelatedPartyType[] $relatedParty
+     * @return self
+     */
+    public function setRelatedParty(?array $relatedParty = null)
+    {
+        $this->relatedParty = $relatedParty;
+        return $this;
+    }
+
+    /**
+     * Adds as artistProfilePage
+     *
+     * A URL of a WebPage for the Artist.
+     *
+     * @return self
+     * @param string $artistProfilePage
+     */
+    public function addToArtistProfilePage($artistProfilePage)
+    {
+        $this->artistProfilePage[] = $artistProfilePage;
+        return $this;
+    }
+
+    /**
+     * isset artistProfilePage
+     *
+     * A URL of a WebPage for the Artist.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetArtistProfilePage($index)
+    {
+        return isset($this->artistProfilePage[$index]);
+    }
+
+    /**
+     * unset artistProfilePage
+     *
+     * A URL of a WebPage for the Artist.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetArtistProfilePage($index)
+    {
+        unset($this->artistProfilePage[$index]);
+    }
+
+    /**
+     * Gets as artistProfilePage
+     *
+     * A URL of a WebPage for the Artist.
+     *
+     * @return string[]
+     */
+    public function getArtistProfilePage()
+    {
+        return $this->artistProfilePage;
+    }
+
+    /**
+     * Sets a new artistProfilePage
+     *
+     * A URL of a WebPage for the Artist.
+     *
+     * @param string[] $artistProfilePage
+     * @return self
+     */
+    public function setArtistProfilePage(?array $artistProfilePage = null)
+    {
+        $this->artistProfilePage = $artistProfilePage;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/PartyWithRoleType.php
+++ b/src/Entity/Ern42/PartyWithRoleType.php
@@ -1,0 +1,287 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing PartyWithRoleType
+ *
+ * A Composite containing details of a Party.
+ * Explanatory Note: This Composite is named PartyWithRole to disambiguate it from the basic mead:Party Composite.
+ * XSD Type: PartyWithRole
+ */
+class PartyWithRoleType
+{
+    /**
+     * An International Standard Name Identifier, the ISO 27729 Standard Identifier for names, of the Party for which information is provided. DDEX will enforce the syntax [0-9]{15}[X0-9] using XML Schema in the future.
+     *
+     * @var string $iSNI
+     */
+    private $iSNI = null;
+
+    /**
+     * An Identifier of the Party for which information is provided according to the DdexPartyId standard DDEX-DPID.
+     *
+     * @var string $dPID
+     */
+    private $dPID = null;
+
+    /**
+     * An Interested Party Identifier, a CISAC standard Identifier, of the Party for which information is provided. An IpiNameNumber comprises 11 digits.
+     *
+     * @var string $ipiNameNumber
+     */
+    private $ipiNameNumber = null;
+
+    /**
+     * An International Performer Number, an IPDA Identifier, of the Party for which information is provided.
+     *
+     * @var string $iPN
+     */
+    private $iPN = null;
+
+    /**
+     * A Composite containing details of a ProprietaryIdentifier of the Party for which information is provided.
+     *
+     * @var \DedexBundle\Entity\Ern42\ProprietaryIdType[] $proprietaryId
+     */
+    private $proprietaryId = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Name of the Contributor.
+     *
+     * @var \DedexBundle\Entity\Ern42\PartyNameWithTerritoryType $partyName
+     */
+    private $partyName = null;
+
+    /**
+     * A Role played by the Contributor.
+     *
+     * @var \DedexBundle\Entity\Ern42\ResourceContributorRoleType $role
+     */
+    private $role = null;
+
+    /**
+     * Gets as iSNI
+     *
+     * An International Standard Name Identifier, the ISO 27729 Standard Identifier for names, of the Party for which information is provided. DDEX will enforce the syntax [0-9]{15}[X0-9] using XML Schema in the future.
+     *
+     * @return string
+     */
+    public function getISNI()
+    {
+        return $this->iSNI;
+    }
+
+    /**
+     * Sets a new iSNI
+     *
+     * An International Standard Name Identifier, the ISO 27729 Standard Identifier for names, of the Party for which information is provided. DDEX will enforce the syntax [0-9]{15}[X0-9] using XML Schema in the future.
+     *
+     * @param string $iSNI
+     * @return self
+     */
+    public function setISNI($iSNI)
+    {
+        $this->iSNI = $iSNI;
+        return $this;
+    }
+
+    /**
+     * Gets as dPID
+     *
+     * An Identifier of the Party for which information is provided according to the DdexPartyId standard DDEX-DPID.
+     *
+     * @return string
+     */
+    public function getDPID()
+    {
+        return $this->dPID;
+    }
+
+    /**
+     * Sets a new dPID
+     *
+     * An Identifier of the Party for which information is provided according to the DdexPartyId standard DDEX-DPID.
+     *
+     * @param string $dPID
+     * @return self
+     */
+    public function setDPID($dPID)
+    {
+        $this->dPID = $dPID;
+        return $this;
+    }
+
+    /**
+     * Gets as ipiNameNumber
+     *
+     * An Interested Party Identifier, a CISAC standard Identifier, of the Party for which information is provided. An IpiNameNumber comprises 11 digits.
+     *
+     * @return string
+     */
+    public function getIpiNameNumber()
+    {
+        return $this->ipiNameNumber;
+    }
+
+    /**
+     * Sets a new ipiNameNumber
+     *
+     * An Interested Party Identifier, a CISAC standard Identifier, of the Party for which information is provided. An IpiNameNumber comprises 11 digits.
+     *
+     * @param string $ipiNameNumber
+     * @return self
+     */
+    public function setIpiNameNumber($ipiNameNumber)
+    {
+        $this->ipiNameNumber = $ipiNameNumber;
+        return $this;
+    }
+
+    /**
+     * Gets as iPN
+     *
+     * An International Performer Number, an IPDA Identifier, of the Party for which information is provided.
+     *
+     * @return string
+     */
+    public function getIPN()
+    {
+        return $this->iPN;
+    }
+
+    /**
+     * Sets a new iPN
+     *
+     * An International Performer Number, an IPDA Identifier, of the Party for which information is provided.
+     *
+     * @param string $iPN
+     * @return self
+     */
+    public function setIPN($iPN)
+    {
+        $this->iPN = $iPN;
+        return $this;
+    }
+
+    /**
+     * Adds as proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Party for which information is provided.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ProprietaryIdType $proprietaryId
+     */
+    public function addToProprietaryId(\DedexBundle\Entity\Ern42\ProprietaryIdType $proprietaryId)
+    {
+        $this->proprietaryId[] = $proprietaryId;
+        return $this;
+    }
+
+    /**
+     * isset proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Party for which information is provided.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetProprietaryId($index)
+    {
+        return isset($this->proprietaryId[$index]);
+    }
+
+    /**
+     * unset proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Party for which information is provided.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetProprietaryId($index)
+    {
+        unset($this->proprietaryId[$index]);
+    }
+
+    /**
+     * Gets as proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Party for which information is provided.
+     *
+     * @return \DedexBundle\Entity\Ern42\ProprietaryIdType[]
+     */
+    public function getProprietaryId()
+    {
+        return $this->proprietaryId;
+    }
+
+    /**
+     * Sets a new proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Party for which information is provided.
+     *
+     * @param \DedexBundle\Entity\Ern42\ProprietaryIdType[] $proprietaryId
+     * @return self
+     */
+    public function setProprietaryId(?array $proprietaryId = null)
+    {
+        $this->proprietaryId = $proprietaryId;
+        return $this;
+    }
+
+    /**
+     * Gets as partyName
+     *
+     * A Composite containing details of a Name of the Contributor.
+     *
+     * @return \DedexBundle\Entity\Ern42\PartyNameWithTerritoryType
+     */
+    public function getPartyName()
+    {
+        return $this->partyName;
+    }
+
+    /**
+     * Sets a new partyName
+     *
+     * A Composite containing details of a Name of the Contributor.
+     *
+     * @param \DedexBundle\Entity\Ern42\PartyNameWithTerritoryType $partyName
+     * @return self
+     */
+    public function setPartyName(?\DedexBundle\Entity\Ern42\PartyNameWithTerritoryType $partyName = null)
+    {
+        $this->partyName = $partyName;
+        return $this;
+    }
+
+    /**
+     * Gets as role
+     *
+     * A Role played by the Contributor.
+     *
+     * @return \DedexBundle\Entity\Ern42\ResourceContributorRoleType
+     */
+    public function getRole()
+    {
+        return $this->role;
+    }
+
+    /**
+     * Sets a new role
+     *
+     * A Role played by the Contributor.
+     *
+     * @param \DedexBundle\Entity\Ern42\ResourceContributorRoleType $role
+     * @return self
+     */
+    public function setRole(?\DedexBundle\Entity\Ern42\ResourceContributorRoleType $role = null)
+    {
+        $this->role = $role;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/PercentageType.php
+++ b/src/Entity/Ern42/PercentageType.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing PercentageType
+ *
+ * A Composite containing details of a PercentageRate.
+ * XSD Type: Percentage
+ */
+class PercentageType
+{
+    /**
+     * @var float $__value
+     */
+    private $__value = null;
+
+    /**
+     * A Flag indicating whether a PercentageRate is given as a value in the range [0,1] (=true) instead of a value in the range [0,100] (=false). This is represented in an XML schema as an XML Attribute. Absence of this attribute is synonymous with false.
+     *
+     * @var bool $hasMaxValueOfOne
+     */
+    private $hasMaxValueOfOne = null;
+
+    /**
+     * Construct
+     *
+     * @param float $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param float $value
+     * @return float
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as hasMaxValueOfOne
+     *
+     * A Flag indicating whether a PercentageRate is given as a value in the range [0,1] (=true) instead of a value in the range [0,100] (=false). This is represented in an XML schema as an XML Attribute. Absence of this attribute is synonymous with false.
+     *
+     * @return bool
+     */
+    public function getHasMaxValueOfOne()
+    {
+        return $this->hasMaxValueOfOne;
+    }
+
+    /**
+     * Sets a new hasMaxValueOfOne
+     *
+     * A Flag indicating whether a PercentageRate is given as a value in the range [0,1] (=true) instead of a value in the range [0,100] (=false). This is represented in an XML schema as an XML Attribute. Absence of this attribute is synonymous with false.
+     *
+     * @param bool $hasMaxValueOfOne
+     * @return self
+     */
+    public function setHasMaxValueOfOne($hasMaxValueOfOne)
+    {
+        $this->hasMaxValueOfOne = $hasMaxValueOfOne;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/PeriodType.php
+++ b/src/Entity/Ern42/PeriodType.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing PeriodType
+ *
+ * A Composite containing details about a Period of Time. Periods are typically describedby at least a StartDate or EndDate (or StartDateTime or EndDateTime) where the StartDate(Time) and EndDate(Time) are included in the Period. Thus a one-day period can be described by using the same date in the StartDate and EndDate. If two subsequent Periods form a continuum (i.e. with no break in-between) there are two ways to express this: (a) if using dates, the EndDate of the first Period must be one day before the StartDate of the second Period; (b) if using date times, the EndDateTime of the first Period must be the same as the StartDateTime of the second Period.
+ * XSD Type: Period
+ */
+class PeriodType
+{
+    /**
+     * A Composite containing details of the Date and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DD). The StartDate must be no later than the EndDate if both are provided.
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateType $startDate
+     */
+    private $startDate = null;
+
+    /**
+     * A Composite containing details of the Date and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DD). The EndDate must not be earlier than the StartDate if both are provided.
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateType $endDate
+     */
+    private $endDate = null;
+
+    /**
+     * A Composite containing details of the DateTime and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DDThh:mm:ss). The StartDateTime must be no later than the EndDateTime if both are provided.
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateTimeType $startDateTime
+     */
+    private $startDateTime = null;
+
+    /**
+     * A Composite containing details of the DateTime and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DDThh:mm:ss). The EndDateTime must not be earlier than the StartDateTime if both are provided.
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateTimeType $endDateTime
+     */
+    private $endDateTime = null;
+
+    /**
+     * Gets as startDate
+     *
+     * A Composite containing details of the Date and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DD). The StartDate must be no later than the EndDate if both are provided.
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateType
+     */
+    public function getStartDate()
+    {
+        return $this->startDate;
+    }
+
+    /**
+     * Sets a new startDate
+     *
+     * A Composite containing details of the Date and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DD). The StartDate must be no later than the EndDate if both are provided.
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateType $startDate
+     * @return self
+     */
+    public function setStartDate(?\DedexBundle\Entity\Ern42\EventDateType $startDate = null)
+    {
+        $this->startDate = $startDate;
+        return $this;
+    }
+
+    /**
+     * Gets as endDate
+     *
+     * A Composite containing details of the Date and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DD). The EndDate must not be earlier than the StartDate if both are provided.
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateType
+     */
+    public function getEndDate()
+    {
+        return $this->endDate;
+    }
+
+    /**
+     * Sets a new endDate
+     *
+     * A Composite containing details of the Date and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DD). The EndDate must not be earlier than the StartDate if both are provided.
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateType $endDate
+     * @return self
+     */
+    public function setEndDate(?\DedexBundle\Entity\Ern42\EventDateType $endDate = null)
+    {
+        $this->endDate = $endDate;
+        return $this;
+    }
+
+    /**
+     * Gets as startDateTime
+     *
+     * A Composite containing details of the DateTime and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DDThh:mm:ss). The StartDateTime must be no later than the EndDateTime if both are provided.
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateTimeType
+     */
+    public function getStartDateTime()
+    {
+        return $this->startDateTime;
+    }
+
+    /**
+     * Sets a new startDateTime
+     *
+     * A Composite containing details of the DateTime and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DDThh:mm:ss). The StartDateTime must be no later than the EndDateTime if both are provided.
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateTimeType $startDateTime
+     * @return self
+     */
+    public function setStartDateTime(?\DedexBundle\Entity\Ern42\EventDateTimeType $startDateTime = null)
+    {
+        $this->startDateTime = $startDateTime;
+        return $this;
+    }
+
+    /**
+     * Gets as endDateTime
+     *
+     * A Composite containing details of the DateTime and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DDThh:mm:ss). The EndDateTime must not be earlier than the StartDateTime if both are provided.
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateTimeType
+     */
+    public function getEndDateTime()
+    {
+        return $this->endDateTime;
+    }
+
+    /**
+     * Sets a new endDateTime
+     *
+     * A Composite containing details of the DateTime and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DDThh:mm:ss). The EndDateTime must not be earlier than the StartDateTime if both are provided.
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateTimeType $endDateTime
+     * @return self
+     */
+    public function setEndDateTime(?\DedexBundle\Entity\Ern42\EventDateTimeType $endDateTime = null)
+    {
+        $this->endDateTime = $endDateTime;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/PeriodWithStartDateType.php
+++ b/src/Entity/Ern42/PeriodWithStartDateType.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing PeriodWithStartDateType
+ *
+ * A Composite containing details about a Period of Time with a mandatory StartDate or StartDateTime.
+ * Explanatory Note: This Composite is named PeriodWithStartDate to disambiguate it from the basic Period Composite.
+ * XSD Type: PeriodWithStartDate
+ */
+class PeriodWithStartDateType
+{
+    /**
+     * A Composite containing details of the Date and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DD). The StartDate must be no later than the EndDate if both are provided. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateWithCurrentTerritoryType $startDate
+     */
+    private $startDate = null;
+
+    /**
+     * A Composite containing details of the Date and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DD). The EndDate must not be earlier than the StartDate if both are provided. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateWithCurrentTerritoryType $endDate
+     */
+    private $endDate = null;
+
+    /**
+     * A Composite containing details of the DateTime and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DDThh:mm:ss). The StartDateTime must be no later than the EndDateTime if both are provided.
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateTimeWithoutFlagsType $startDateTime
+     */
+    private $startDateTime = null;
+
+    /**
+     * A Composite containing details of the DateTime and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DDThh:mm:ss). The EndDateTime must not be earlier than the StartDateTime if both are provided.
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateTimeWithoutFlagsType $endDateTime
+     */
+    private $endDateTime = null;
+
+    /**
+     * Gets as startDate
+     *
+     * A Composite containing details of the Date and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DD). The StartDate must be no later than the EndDate if both are provided. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateWithCurrentTerritoryType
+     */
+    public function getStartDate()
+    {
+        return $this->startDate;
+    }
+
+    /**
+     * Sets a new startDate
+     *
+     * A Composite containing details of the Date and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DD). The StartDate must be no later than the EndDate if both are provided. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateWithCurrentTerritoryType $startDate
+     * @return self
+     */
+    public function setStartDate(?\DedexBundle\Entity\Ern42\EventDateWithCurrentTerritoryType $startDate = null)
+    {
+        $this->startDate = $startDate;
+        return $this;
+    }
+
+    /**
+     * Gets as endDate
+     *
+     * A Composite containing details of the Date and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DD). The EndDate must not be earlier than the StartDate if both are provided. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateWithCurrentTerritoryType
+     */
+    public function getEndDate()
+    {
+        return $this->endDate;
+    }
+
+    /**
+     * Sets a new endDate
+     *
+     * A Composite containing details of the Date and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DD). The EndDate must not be earlier than the StartDate if both are provided. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateWithCurrentTerritoryType $endDate
+     * @return self
+     */
+    public function setEndDate(?\DedexBundle\Entity\Ern42\EventDateWithCurrentTerritoryType $endDate = null)
+    {
+        $this->endDate = $endDate;
+        return $this;
+    }
+
+    /**
+     * Gets as startDateTime
+     *
+     * A Composite containing details of the DateTime and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DDThh:mm:ss). The StartDateTime must be no later than the EndDateTime if both are provided.
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateTimeWithoutFlagsType
+     */
+    public function getStartDateTime()
+    {
+        return $this->startDateTime;
+    }
+
+    /**
+     * Sets a new startDateTime
+     *
+     * A Composite containing details of the DateTime and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DDThh:mm:ss). The StartDateTime must be no later than the EndDateTime if both are provided.
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateTimeWithoutFlagsType $startDateTime
+     * @return self
+     */
+    public function setStartDateTime(?\DedexBundle\Entity\Ern42\EventDateTimeWithoutFlagsType $startDateTime = null)
+    {
+        $this->startDateTime = $startDateTime;
+        return $this;
+    }
+
+    /**
+     * Gets as endDateTime
+     *
+     * A Composite containing details of the DateTime and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DDThh:mm:ss). The EndDateTime must not be earlier than the StartDateTime if both are provided.
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateTimeWithoutFlagsType
+     */
+    public function getEndDateTime()
+    {
+        return $this->endDateTime;
+    }
+
+    /**
+     * Sets a new endDateTime
+     *
+     * A Composite containing details of the DateTime and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DDThh:mm:ss). The EndDateTime must not be earlier than the StartDateTime if both are provided.
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateTimeWithoutFlagsType $endDateTime
+     * @return self
+     */
+    public function setEndDateTime(?\DedexBundle\Entity\Ern42\EventDateTimeWithoutFlagsType $endDateTime = null)
+    {
+        $this->endDateTime = $endDateTime;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/PeriodWithoutFlagsType.php
+++ b/src/Entity/Ern42/PeriodWithoutFlagsType.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing PeriodWithoutFlagsType
+ *
+ * A Composite containing details about a Period of Time. Periods are typically describedby at least a StartDate or EndDate (or StartDateTime or EndDateTime) where the StartDate(Time) and EndDate(Time) are included in the Period. Thus a one-day period can be described by using the same date in the StartDate and EndDate. If two subsequent Periods form a continuum (i.e. with no break in-between) there are two ways to express this: (a) if using dates, the EndDate of the first Period must be one day before the StartDate of the second Period; (b) if using date times, the EndDateTime of the first Period must be the same as the StartDateTime of the second Period.
+ * Explanatory Note: This Composite is named PeriodWithoutFlags to disambiguate it from the basic Period Composite.
+ * XSD Type: PeriodWithoutFlags
+ */
+class PeriodWithoutFlagsType
+{
+    /**
+     * A Composite containing details of the Date and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DD). The StartDate must be no later than the EndDate if both are provided. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateWithCurrentTerritoryType $startDate
+     */
+    private $startDate = null;
+
+    /**
+     * A Composite containing details of the Date and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DD). The EndDate must not be earlier than the StartDate if both are provided. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateWithCurrentTerritoryType $endDate
+     */
+    private $endDate = null;
+
+    /**
+     * A Composite containing details of the DateTime and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DDThh:mm:ss). The StartDateTime must be no later than the EndDateTime if both are provided.
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateTimeWithoutFlagsType $startDateTime
+     */
+    private $startDateTime = null;
+
+    /**
+     * A Composite containing details of the DateTime and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DDThh:mm:ss). The EndDateTime must not be earlier than the StartDateTime if both are provided.
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateTimeWithoutFlagsType $endDateTime
+     */
+    private $endDateTime = null;
+
+    /**
+     * Gets as startDate
+     *
+     * A Composite containing details of the Date and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DD). The StartDate must be no later than the EndDate if both are provided. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateWithCurrentTerritoryType
+     */
+    public function getStartDate()
+    {
+        return $this->startDate;
+    }
+
+    /**
+     * Sets a new startDate
+     *
+     * A Composite containing details of the Date and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DD). The StartDate must be no later than the EndDate if both are provided. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateWithCurrentTerritoryType $startDate
+     * @return self
+     */
+    public function setStartDate(?\DedexBundle\Entity\Ern42\EventDateWithCurrentTerritoryType $startDate = null)
+    {
+        $this->startDate = $startDate;
+        return $this;
+    }
+
+    /**
+     * Gets as endDate
+     *
+     * A Composite containing details of the Date and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DD). The EndDate must not be earlier than the StartDate if both are provided. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateWithCurrentTerritoryType
+     */
+    public function getEndDate()
+    {
+        return $this->endDate;
+    }
+
+    /**
+     * Sets a new endDate
+     *
+     * A Composite containing details of the Date and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DD). The EndDate must not be earlier than the StartDate if both are provided. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateWithCurrentTerritoryType $endDate
+     * @return self
+     */
+    public function setEndDate(?\DedexBundle\Entity\Ern42\EventDateWithCurrentTerritoryType $endDate = null)
+    {
+        $this->endDate = $endDate;
+        return $this;
+    }
+
+    /**
+     * Gets as startDateTime
+     *
+     * A Composite containing details of the DateTime and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DDThh:mm:ss). The StartDateTime must be no later than the EndDateTime if both are provided.
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateTimeWithoutFlagsType
+     */
+    public function getStartDateTime()
+    {
+        return $this->startDateTime;
+    }
+
+    /**
+     * Sets a new startDateTime
+     *
+     * A Composite containing details of the DateTime and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DDThh:mm:ss). The StartDateTime must be no later than the EndDateTime if both are provided.
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateTimeWithoutFlagsType $startDateTime
+     * @return self
+     */
+    public function setStartDateTime(?\DedexBundle\Entity\Ern42\EventDateTimeWithoutFlagsType $startDateTime = null)
+    {
+        $this->startDateTime = $startDateTime;
+        return $this;
+    }
+
+    /**
+     * Gets as endDateTime
+     *
+     * A Composite containing details of the DateTime and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DDThh:mm:ss). The EndDateTime must not be earlier than the StartDateTime if both are provided.
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateTimeWithoutFlagsType
+     */
+    public function getEndDateTime()
+    {
+        return $this->endDateTime;
+    }
+
+    /**
+     * Sets a new endDateTime
+     *
+     * A Composite containing details of the DateTime and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DDThh:mm:ss). The EndDateTime must not be earlier than the StartDateTime if both are provided.
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateTimeWithoutFlagsType $endDateTime
+     * @return self
+     */
+    public function setEndDateTime(?\DedexBundle\Entity\Ern42\EventDateTimeWithoutFlagsType $endDateTime = null)
+    {
+        $this->endDateTime = $endDateTime;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/PhysicalReturnsType.php
+++ b/src/Entity/Ern42/PhysicalReturnsType.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing PhysicalReturnsType
+ *
+ * A Composite containing details of physical returns.
+ * XSD Type: PhysicalReturns
+ */
+class PhysicalReturnsType
+{
+    /**
+     * The Flag indicating whether physical returns are allowed (=true) or not (=false).
+     *
+     * @var bool $physicalReturnsAllowed
+     */
+    private $physicalReturnsAllowed = null;
+
+    /**
+     * A Date which is the latest one for physical returns (in ISO 8601 format: YYYY-MM-DD).
+     *
+     * @var string $latestDateForPhysicalReturns
+     */
+    private $latestDateForPhysicalReturns = null;
+
+    /**
+     * Gets as physicalReturnsAllowed
+     *
+     * The Flag indicating whether physical returns are allowed (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getPhysicalReturnsAllowed()
+    {
+        return $this->physicalReturnsAllowed;
+    }
+
+    /**
+     * Sets a new physicalReturnsAllowed
+     *
+     * The Flag indicating whether physical returns are allowed (=true) or not (=false).
+     *
+     * @param bool $physicalReturnsAllowed
+     * @return self
+     */
+    public function setPhysicalReturnsAllowed($physicalReturnsAllowed)
+    {
+        $this->physicalReturnsAllowed = $physicalReturnsAllowed;
+        return $this;
+    }
+
+    /**
+     * Gets as latestDateForPhysicalReturns
+     *
+     * A Date which is the latest one for physical returns (in ISO 8601 format: YYYY-MM-DD).
+     *
+     * @return string
+     */
+    public function getLatestDateForPhysicalReturns()
+    {
+        return $this->latestDateForPhysicalReturns;
+    }
+
+    /**
+     * Sets a new latestDateForPhysicalReturns
+     *
+     * A Date which is the latest one for physical returns (in ISO 8601 format: YYYY-MM-DD).
+     *
+     * @param string $latestDateForPhysicalReturns
+     * @return self
+     */
+    public function setLatestDateForPhysicalReturns($latestDateForPhysicalReturns)
+    {
+        $this->latestDateForPhysicalReturns = $latestDateForPhysicalReturns;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/PrefixType.php
+++ b/src/Entity/Ern42/PrefixType.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing PrefixType
+ *
+ * A Composite containing details of a Descriptor that precedes the display artist name when multiple display artist names are given.
+ * XSD Type: Prefix
+ */
+class PrefixType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Language and script of the Prefix as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script of the Prefix as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script of the Prefix as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/PreviewDetailsType.php
+++ b/src/Entity/Ern42/PreviewDetailsType.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing PreviewDetailsType
+ *
+ * A Composite containing details of a preview.
+ * XSD Type: PreviewDetails
+ */
+class PreviewDetailsType
+{
+    /**
+     * The position of the top left corner of the preview measured in Pixels from the top left corner of the Resource. The position is given as two coordinate values separated by a comma, the top left pixel being 0,0.
+     *
+     * @var string $topLeftCorner
+     */
+    private $topLeftCorner = null;
+
+    /**
+     * The position of the bottom right corner of the preview measured in Pixels from the top left corner of the Resource. The position is given as two coordinate values separated by a comma, the top left pixel being 0,0.
+     *
+     * @var string $bottomRightCorner
+     */
+    private $bottomRightCorner = null;
+
+    /**
+     * A Type of expression indicating how this should be perceived, e.g. as instruction (meaning that this has to be done to create the preview) or as information (meaning that this has been done to craete the preview).
+     *
+     * @var string $expressionType
+     */
+    private $expressionType = null;
+
+    /**
+     * Gets as topLeftCorner
+     *
+     * The position of the top left corner of the preview measured in Pixels from the top left corner of the Resource. The position is given as two coordinate values separated by a comma, the top left pixel being 0,0.
+     *
+     * @return string
+     */
+    public function getTopLeftCorner()
+    {
+        return $this->topLeftCorner;
+    }
+
+    /**
+     * Sets a new topLeftCorner
+     *
+     * The position of the top left corner of the preview measured in Pixels from the top left corner of the Resource. The position is given as two coordinate values separated by a comma, the top left pixel being 0,0.
+     *
+     * @param string $topLeftCorner
+     * @return self
+     */
+    public function setTopLeftCorner($topLeftCorner)
+    {
+        $this->topLeftCorner = $topLeftCorner;
+        return $this;
+    }
+
+    /**
+     * Gets as bottomRightCorner
+     *
+     * The position of the bottom right corner of the preview measured in Pixels from the top left corner of the Resource. The position is given as two coordinate values separated by a comma, the top left pixel being 0,0.
+     *
+     * @return string
+     */
+    public function getBottomRightCorner()
+    {
+        return $this->bottomRightCorner;
+    }
+
+    /**
+     * Sets a new bottomRightCorner
+     *
+     * The position of the bottom right corner of the preview measured in Pixels from the top left corner of the Resource. The position is given as two coordinate values separated by a comma, the top left pixel being 0,0.
+     *
+     * @param string $bottomRightCorner
+     * @return self
+     */
+    public function setBottomRightCorner($bottomRightCorner)
+    {
+        $this->bottomRightCorner = $bottomRightCorner;
+        return $this;
+    }
+
+    /**
+     * Gets as expressionType
+     *
+     * A Type of expression indicating how this should be perceived, e.g. as instruction (meaning that this has to be done to create the preview) or as information (meaning that this has been done to craete the preview).
+     *
+     * @return string
+     */
+    public function getExpressionType()
+    {
+        return $this->expressionType;
+    }
+
+    /**
+     * Sets a new expressionType
+     *
+     * A Type of expression indicating how this should be perceived, e.g. as instruction (meaning that this has to be done to create the preview) or as information (meaning that this has been done to craete the preview).
+     *
+     * @param string $expressionType
+     * @return self
+     */
+    public function setExpressionType($expressionType)
+    {
+        $this->expressionType = $expressionType;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/PriceInformationWithTypeType.php
+++ b/src/Entity/Ern42/PriceInformationWithTypeType.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing PriceInformationWithTypeType
+ *
+ * A Composite containing details of a Price.
+ * Explanatory Note: This Composite is named PriceInformationWithType to disambiguate it from the basic PriceInformation Composite.
+ * XSD Type: PriceInformationWithType
+ */
+class PriceInformationWithTypeType
+{
+    /**
+     * A Type of the Price. This is represented in an XML schema as an XML Attribute. If no value is provided, a StandardRetailPrice is assumed.
+     *
+     * @var string $priceType
+     */
+    private $priceType = null;
+
+    /**
+     * The Namespace of the PriceInformationType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the PriceInformationType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * A Composite containing further details of the Price, including a Price code that informs the DSP of the Price the Release should be offered at, often in combination with a rate card. This element should not be combined with WholesalePricePerUnit or BulkOrderWholesalePricePerUnit.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/price-information
+     *
+     * @var \DedexBundle\Entity\Ern42\PriceTypeType $priceCode
+     */
+    private $priceCode = null;
+
+    /**
+     * A Composite containing details of a wholesale Price for a single unit of Usage, which informs the informs the DSP of the Price the Release should be offered at. Note that this Price applies to all UseTypes referenced in a DealTerm Composite. This element should not be combined with PriceType.
+     *
+     * @var \DedexBundle\Entity\Ern42\PriceType $wholesalePricePerUnit
+     */
+    private $wholesalePricePerUnit = null;
+
+    /**
+     * A Composite containing details of a wholesale Price for a single unit, which informs the informs the DSP of the Price the Release should be offered at. Note that the size of a bulk order is defined in the contract between MessageSender and the MessageRecipient. This element should not be combined with PriceType.
+     *
+     * @var \DedexBundle\Entity\Ern42\PriceType $bulkOrderWholesalePricePerUnit
+     */
+    private $bulkOrderWholesalePricePerUnit = null;
+
+    /**
+     * A Composite containing details of a suggested retail Price.
+     *
+     * @var \DedexBundle\Entity\Ern42\PriceType $suggestedRetailPrice
+     */
+    private $suggestedRetailPrice = null;
+
+    /**
+     * Gets as priceType
+     *
+     * A Type of the Price. This is represented in an XML schema as an XML Attribute. If no value is provided, a StandardRetailPrice is assumed.
+     *
+     * @return string
+     */
+    public function getPriceType()
+    {
+        return $this->priceType;
+    }
+
+    /**
+     * Sets a new priceType
+     *
+     * A Type of the Price. This is represented in an XML schema as an XML Attribute. If no value is provided, a StandardRetailPrice is assumed.
+     *
+     * @param string $priceType
+     * @return self
+     */
+    public function setPriceType($priceType)
+    {
+        $this->priceType = $priceType;
+        return $this;
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the PriceInformationType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the PriceInformationType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the PriceInformationType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the PriceInformationType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+
+    /**
+     * Gets as priceCode
+     *
+     * A Composite containing further details of the Price, including a Price code that informs the DSP of the Price the Release should be offered at, often in combination with a rate card. This element should not be combined with WholesalePricePerUnit or BulkOrderWholesalePricePerUnit.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/price-information
+     *
+     * @return \DedexBundle\Entity\Ern42\PriceTypeType
+     */
+    public function getPriceCode()
+    {
+        return $this->priceCode;
+    }
+
+    /**
+     * Sets a new priceCode
+     *
+     * A Composite containing further details of the Price, including a Price code that informs the DSP of the Price the Release should be offered at, often in combination with a rate card. This element should not be combined with WholesalePricePerUnit or BulkOrderWholesalePricePerUnit.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/price-information
+     *
+     * @param \DedexBundle\Entity\Ern42\PriceTypeType $priceCode
+     * @return self
+     */
+    public function setPriceCode(?\DedexBundle\Entity\Ern42\PriceTypeType $priceCode = null)
+    {
+        $this->priceCode = $priceCode;
+        return $this;
+    }
+
+    /**
+     * Gets as wholesalePricePerUnit
+     *
+     * A Composite containing details of a wholesale Price for a single unit of Usage, which informs the informs the DSP of the Price the Release should be offered at. Note that this Price applies to all UseTypes referenced in a DealTerm Composite. This element should not be combined with PriceType.
+     *
+     * @return \DedexBundle\Entity\Ern42\PriceType
+     */
+    public function getWholesalePricePerUnit()
+    {
+        return $this->wholesalePricePerUnit;
+    }
+
+    /**
+     * Sets a new wholesalePricePerUnit
+     *
+     * A Composite containing details of a wholesale Price for a single unit of Usage, which informs the informs the DSP of the Price the Release should be offered at. Note that this Price applies to all UseTypes referenced in a DealTerm Composite. This element should not be combined with PriceType.
+     *
+     * @param \DedexBundle\Entity\Ern42\PriceType $wholesalePricePerUnit
+     * @return self
+     */
+    public function setWholesalePricePerUnit(?\DedexBundle\Entity\Ern42\PriceType $wholesalePricePerUnit = null)
+    {
+        $this->wholesalePricePerUnit = $wholesalePricePerUnit;
+        return $this;
+    }
+
+    /**
+     * Gets as bulkOrderWholesalePricePerUnit
+     *
+     * A Composite containing details of a wholesale Price for a single unit, which informs the informs the DSP of the Price the Release should be offered at. Note that the size of a bulk order is defined in the contract between MessageSender and the MessageRecipient. This element should not be combined with PriceType.
+     *
+     * @return \DedexBundle\Entity\Ern42\PriceType
+     */
+    public function getBulkOrderWholesalePricePerUnit()
+    {
+        return $this->bulkOrderWholesalePricePerUnit;
+    }
+
+    /**
+     * Sets a new bulkOrderWholesalePricePerUnit
+     *
+     * A Composite containing details of a wholesale Price for a single unit, which informs the informs the DSP of the Price the Release should be offered at. Note that the size of a bulk order is defined in the contract between MessageSender and the MessageRecipient. This element should not be combined with PriceType.
+     *
+     * @param \DedexBundle\Entity\Ern42\PriceType $bulkOrderWholesalePricePerUnit
+     * @return self
+     */
+    public function setBulkOrderWholesalePricePerUnit(?\DedexBundle\Entity\Ern42\PriceType $bulkOrderWholesalePricePerUnit = null)
+    {
+        $this->bulkOrderWholesalePricePerUnit = $bulkOrderWholesalePricePerUnit;
+        return $this;
+    }
+
+    /**
+     * Gets as suggestedRetailPrice
+     *
+     * A Composite containing details of a suggested retail Price.
+     *
+     * @return \DedexBundle\Entity\Ern42\PriceType
+     */
+    public function getSuggestedRetailPrice()
+    {
+        return $this->suggestedRetailPrice;
+    }
+
+    /**
+     * Sets a new suggestedRetailPrice
+     *
+     * A Composite containing details of a suggested retail Price.
+     *
+     * @param \DedexBundle\Entity\Ern42\PriceType $suggestedRetailPrice
+     * @return self
+     */
+    public function setSuggestedRetailPrice(?\DedexBundle\Entity\Ern42\PriceType $suggestedRetailPrice = null)
+    {
+        $this->suggestedRetailPrice = $suggestedRetailPrice;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/PriceType.php
+++ b/src/Entity/Ern42/PriceType.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing PriceType
+ *
+ * A Composite containing details of a Price.
+ * XSD Type: Price
+ */
+class PriceType
+{
+    /**
+     * @var float $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Currency of the Price (represented by an ISO 4217 CurrencyCode). This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $currencyCode
+     */
+    private $currencyCode = null;
+
+    /**
+     * Construct
+     *
+     * @param float $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param float $value
+     * @return float
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as currencyCode
+     *
+     * The Currency of the Price (represented by an ISO 4217 CurrencyCode). This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getCurrencyCode()
+    {
+        return $this->currencyCode;
+    }
+
+    /**
+     * Sets a new currencyCode
+     *
+     * The Currency of the Price (represented by an ISO 4217 CurrencyCode). This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $currencyCode
+     * @return self
+     */
+    public function setCurrencyCode($currencyCode)
+    {
+        $this->currencyCode = $currencyCode;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/PriceTypeType.php
+++ b/src/Entity/Ern42/PriceTypeType.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing PriceTypeType
+ *
+ * A Composite containing details of a PriceType.
+ * XSD Type: PriceType
+ */
+class PriceTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the PriceType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the PriceType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the PriceType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/PromotionalCodeType.php
+++ b/src/Entity/Ern42/PromotionalCodeType.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing PromotionalCodeType
+ *
+ * A Composite containing details of a PromotionalCode.
+ * XSD Type: PromotionalCode
+ */
+class PromotionalCodeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the PromotionalCode. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the PromotionalCode. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the PromotionalCode. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ProprietaryIdType.php
+++ b/src/Entity/Ern42/ProprietaryIdType.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ProprietaryIdType
+ *
+ * A Composite containing details of a ProprietaryIdentifier.
+ * XSD Type: ProprietaryId
+ */
+class ProprietaryIdType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the ProprietaryIdentifier. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the ProprietaryIdentifier. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the ProprietaryIdentifier. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/PurgeReleaseMessage.php
+++ b/src/Entity/Ern42/PurgeReleaseMessage.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+use DedexBundle\Entity\Ern42\PurgeReleaseMessage\PurgeReleaseMessageAnonymousPHPType;
+
+/**
+ * Class representing PurgeReleaseMessage
+ *
+ * A Message in the Release Notification Message Suite Standard, allowing a ReleaseCreator to 'purge' a Release that a DSP has on its books but that cannot be retracted or be taken down in the normal way (e.g. because its metadata is corrupt).
+ */
+class PurgeReleaseMessage extends PurgeReleaseMessageAnonymousPHPType
+{
+}
+

--- a/src/Entity/Ern42/PurgeReleaseMessage/PurgeReleaseMessageAnonymousPHPType.php
+++ b/src/Entity/Ern42/PurgeReleaseMessage/PurgeReleaseMessageAnonymousPHPType.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42\PurgeReleaseMessage;
+
+/**
+ * Class representing PurgeReleaseMessageAnonymousPHPType
+ */
+class PurgeReleaseMessageAnonymousPHPType
+{
+    /**
+     * The Language and script for the Elements of this Message as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * The MessageHeader for the PurgeReleaseMessage.
+     *
+     * @var \DedexBundle\Entity\Ern42\MessageHeaderType $messageHeader
+     */
+    private $messageHeader = null;
+
+    /**
+     * A Composite containing details of a DDEX Release to be purged.
+     *
+     * @var \DedexBundle\Entity\Ern42\PurgedReleaseType $purgedRelease
+     */
+    private $purgedRelease = null;
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the Elements of this Message as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the Elements of this Message as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as messageHeader
+     *
+     * The MessageHeader for the PurgeReleaseMessage.
+     *
+     * @return \DedexBundle\Entity\Ern42\MessageHeaderType
+     */
+    public function getMessageHeader()
+    {
+        return $this->messageHeader;
+    }
+
+    /**
+     * Sets a new messageHeader
+     *
+     * The MessageHeader for the PurgeReleaseMessage.
+     *
+     * @param \DedexBundle\Entity\Ern42\MessageHeaderType $messageHeader
+     * @return self
+     */
+    public function setMessageHeader(\DedexBundle\Entity\Ern42\MessageHeaderType $messageHeader)
+    {
+        $this->messageHeader = $messageHeader;
+        return $this;
+    }
+
+    /**
+     * Gets as purgedRelease
+     *
+     * A Composite containing details of a DDEX Release to be purged.
+     *
+     * @return \DedexBundle\Entity\Ern42\PurgedReleaseType
+     */
+    public function getPurgedRelease()
+    {
+        return $this->purgedRelease;
+    }
+
+    /**
+     * Sets a new purgedRelease
+     *
+     * A Composite containing details of a DDEX Release to be purged.
+     *
+     * @param \DedexBundle\Entity\Ern42\PurgedReleaseType $purgedRelease
+     * @return self
+     */
+    public function setPurgedRelease(\DedexBundle\Entity\Ern42\PurgedReleaseType $purgedRelease)
+    {
+        $this->purgedRelease = $purgedRelease;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/PurgedReleaseType.php
+++ b/src/Entity/Ern42/PurgedReleaseType.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing PurgedReleaseType
+ *
+ * A Composite containing details of a DDEX Release to be purged.
+ * XSD Type: PurgedRelease
+ */
+class PurgedReleaseType
+{
+    /**
+     * A Composite containing details of ReleaseIds. If available, a GRid has to be used. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.
+     *
+     * @var \DedexBundle\Entity\Ern42\ReleaseIdType $releaseId
+     */
+    private $releaseId = null;
+
+    /**
+     * A Composite containing details of a Title of the Release.
+     *
+     * @var \DedexBundle\Entity\Ern42\TitleType[] $title
+     */
+    private $title = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Contributor to the Release.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @var \DedexBundle\Entity\Ern42\DetailedResourceContributorType[] $contributor
+     */
+    private $contributor = [
+        
+    ];
+
+    /**
+     * Gets as releaseId
+     *
+     * A Composite containing details of ReleaseIds. If available, a GRid has to be used. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.
+     *
+     * @return \DedexBundle\Entity\Ern42\ReleaseIdType
+     */
+    public function getReleaseId()
+    {
+        return $this->releaseId;
+    }
+
+    /**
+     * Sets a new releaseId
+     *
+     * A Composite containing details of ReleaseIds. If available, a GRid has to be used. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.
+     *
+     * @param \DedexBundle\Entity\Ern42\ReleaseIdType $releaseId
+     * @return self
+     */
+    public function setReleaseId(?\DedexBundle\Entity\Ern42\ReleaseIdType $releaseId = null)
+    {
+        $this->releaseId = $releaseId;
+        return $this;
+    }
+
+    /**
+     * Adds as title
+     *
+     * A Composite containing details of a Title of the Release.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\TitleType $title
+     */
+    public function addToTitle(\DedexBundle\Entity\Ern42\TitleType $title)
+    {
+        $this->title[] = $title;
+        return $this;
+    }
+
+    /**
+     * isset title
+     *
+     * A Composite containing details of a Title of the Release.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetTitle($index)
+    {
+        return isset($this->title[$index]);
+    }
+
+    /**
+     * unset title
+     *
+     * A Composite containing details of a Title of the Release.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetTitle($index)
+    {
+        unset($this->title[$index]);
+    }
+
+    /**
+     * Gets as title
+     *
+     * A Composite containing details of a Title of the Release.
+     *
+     * @return \DedexBundle\Entity\Ern42\TitleType[]
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * Sets a new title
+     *
+     * A Composite containing details of a Title of the Release.
+     *
+     * @param \DedexBundle\Entity\Ern42\TitleType[] $title
+     * @return self
+     */
+    public function setTitle(?array $title = null)
+    {
+        $this->title = $title;
+        return $this;
+    }
+
+    /**
+     * Adds as contributor
+     *
+     * A Composite containing details of a Contributor to the Release.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DetailedResourceContributorType $contributor
+     */
+    public function addToContributor(\DedexBundle\Entity\Ern42\DetailedResourceContributorType $contributor)
+    {
+        $this->contributor[] = $contributor;
+        return $this;
+    }
+
+    /**
+     * isset contributor
+     *
+     * A Composite containing details of a Contributor to the Release.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetContributor($index)
+    {
+        return isset($this->contributor[$index]);
+    }
+
+    /**
+     * unset contributor
+     *
+     * A Composite containing details of a Contributor to the Release.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetContributor($index)
+    {
+        unset($this->contributor[$index]);
+    }
+
+    /**
+     * Gets as contributor
+     *
+     * A Composite containing details of a Contributor to the Release.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return \DedexBundle\Entity\Ern42\DetailedResourceContributorType[]
+     */
+    public function getContributor()
+    {
+        return $this->contributor;
+    }
+
+    /**
+     * Sets a new contributor
+     *
+     * A Composite containing details of a Contributor to the Release.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param \DedexBundle\Entity\Ern42\DetailedResourceContributorType[] $contributor
+     * @return self
+     */
+    public function setContributor(?array $contributor = null)
+    {
+        $this->contributor = $contributor;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/PurposeType.php
+++ b/src/Entity/Ern42/PurposeType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing PurposeType
+ *
+ * A Composite containing details of a Purpose.
+ * XSD Type: Purpose
+ */
+class PurposeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the Purpose. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the Purpose. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the Purpose. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the Purpose. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the Purpose. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the Purpose. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/RagaType.php
+++ b/src/Entity/Ern42/RagaType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing RagaType
+ *
+ * A Composite containing details of a Raga.
+ * XSD Type: Raga
+ */
+class RagaType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * A Territory to which the Raga applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the Raga applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the Raga applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/RatingAgencyType.php
+++ b/src/Entity/Ern42/RatingAgencyType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing RatingAgencyType
+ *
+ * A Composite containing details of a RatingAgency.
+ * XSD Type: RatingAgency
+ */
+class RatingAgencyType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the RatingAgency. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the RatingAgency. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the RatingAgency. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the RatingAgency. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the RatingAgency. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the RatingAgency. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/RatingReasonType.php
+++ b/src/Entity/Ern42/RatingReasonType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing RatingReasonType
+ *
+ * A Composite containing details of a RatingReason.
+ * XSD Type: RatingReason
+ */
+class RatingReasonType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the RatingReason. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the RatingReason. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the RatingReason. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the RatingReason. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the RatingReason. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the RatingReason. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ReasonType.php
+++ b/src/Entity/Ern42/ReasonType.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ReasonType
+ *
+ * A Composite containing details of a Reason.
+ * XSD Type: Reason
+ */
+class ReasonType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Language and script of the Reason as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script of the Reason as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script of the Reason as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/RelatedPartyType.php
+++ b/src/Entity/Ern42/RelatedPartyType.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing RelatedPartyType
+ *
+ * A Composite containing details of a PartyRelatedPartyReference for the case where one Party is related to another one.
+ * XSD Type: RelatedParty
+ */
+class RelatedPartyType
+{
+    /**
+     * A Reference for a related Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @var string $partyRelatedPartyReference
+     */
+    private $partyRelatedPartyReference = null;
+
+    /**
+     * A Type of relationship between two Parties.
+     *
+     * @var \DedexBundle\Entity\Ern42\PartyRelationshipTypeType $partyRelationshipType
+     */
+    private $partyRelationshipType = null;
+
+    /**
+     * Gets as partyRelatedPartyReference
+     *
+     * A Reference for a related Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @return string
+     */
+    public function getPartyRelatedPartyReference()
+    {
+        return $this->partyRelatedPartyReference;
+    }
+
+    /**
+     * Sets a new partyRelatedPartyReference
+     *
+     * A Reference for a related Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @param string $partyRelatedPartyReference
+     * @return self
+     */
+    public function setPartyRelatedPartyReference($partyRelatedPartyReference)
+    {
+        $this->partyRelatedPartyReference = $partyRelatedPartyReference;
+        return $this;
+    }
+
+    /**
+     * Gets as partyRelationshipType
+     *
+     * A Type of relationship between two Parties.
+     *
+     * @return \DedexBundle\Entity\Ern42\PartyRelationshipTypeType
+     */
+    public function getPartyRelationshipType()
+    {
+        return $this->partyRelationshipType;
+    }
+
+    /**
+     * Sets a new partyRelationshipType
+     *
+     * A Type of relationship between two Parties.
+     *
+     * @param \DedexBundle\Entity\Ern42\PartyRelationshipTypeType $partyRelationshipType
+     * @return self
+     */
+    public function setPartyRelationshipType(\DedexBundle\Entity\Ern42\PartyRelationshipTypeType $partyRelationshipType)
+    {
+        $this->partyRelationshipType = $partyRelationshipType;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/RelatedReleaseType.php
+++ b/src/Entity/Ern42/RelatedReleaseType.php
@@ -1,0 +1,544 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing RelatedReleaseType
+ *
+ * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to a Resource, Release or Product.
+ * XSD Type: RelatedRelease
+ */
+class RelatedReleaseType
+{
+    /**
+     * A Composite containing details of the Type of the relationship between the two Releases.
+     *
+     * @var \DedexBundle\Entity\Ern42\ReleaseRelationshipTypeType $releaseRelationshipType
+     */
+    private $releaseRelationshipType = null;
+
+    /**
+     * A Composite containing details of ReleaseIds. If available, a GRid shall always to be used. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.
+     *
+     * @var \DedexBundle\Entity\Ern42\ReleaseIdType $releaseId
+     */
+    private $releaseId = null;
+
+    /**
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayTitleTextType[] $displayTitleText
+     */
+    private $displayTitleText = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayTitleType[] $displayTitle
+     */
+    private $displayTitle = [
+        
+    ];
+
+    /**
+     * A Composite containing details of an AdditionalTitle of the Release. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @var \DedexBundle\Entity\Ern42\AdditionalTitleType[] $additionalTitle
+     */
+    private $additionalTitle = [
+        
+    ];
+
+    /**
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Release to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType[] $displayArtistName
+     */
+    private $displayArtistName = [
+        
+    ];
+
+    /**
+     * A Reference for a label of the Release (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @var \DedexBundle\Entity\Ern42\ReleaseLabelReferenceType[] $releaseLabelReference
+     */
+    private $releaseLabelReference = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the Date and Place of the Event in which the related Release was or will be first made available for Usage in its current form, whether for physical or electronic/online distribution (in ISO 8601 format: YYYY-MM-DD).
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $releaseDate
+     */
+    private $releaseDate = null;
+
+    /**
+     * A Composite containing details of the Date and Place of the Event in which the collection of tracks for the Release (e.g. the equivalent physical album on vinyl) was or will be first made available for Usage, whether for physical or electronic/online distribution (in ISO 8601 format: YYYY-MM-DD).
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $originalReleaseDate
+     */
+    private $originalReleaseDate = null;
+
+    /**
+     * Gets as releaseRelationshipType
+     *
+     * A Composite containing details of the Type of the relationship between the two Releases.
+     *
+     * @return \DedexBundle\Entity\Ern42\ReleaseRelationshipTypeType
+     */
+    public function getReleaseRelationshipType()
+    {
+        return $this->releaseRelationshipType;
+    }
+
+    /**
+     * Sets a new releaseRelationshipType
+     *
+     * A Composite containing details of the Type of the relationship between the two Releases.
+     *
+     * @param \DedexBundle\Entity\Ern42\ReleaseRelationshipTypeType $releaseRelationshipType
+     * @return self
+     */
+    public function setReleaseRelationshipType(\DedexBundle\Entity\Ern42\ReleaseRelationshipTypeType $releaseRelationshipType)
+    {
+        $this->releaseRelationshipType = $releaseRelationshipType;
+        return $this;
+    }
+
+    /**
+     * Gets as releaseId
+     *
+     * A Composite containing details of ReleaseIds. If available, a GRid shall always to be used. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.
+     *
+     * @return \DedexBundle\Entity\Ern42\ReleaseIdType
+     */
+    public function getReleaseId()
+    {
+        return $this->releaseId;
+    }
+
+    /**
+     * Sets a new releaseId
+     *
+     * A Composite containing details of ReleaseIds. If available, a GRid shall always to be used. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.
+     *
+     * @param \DedexBundle\Entity\Ern42\ReleaseIdType $releaseId
+     * @return self
+     */
+    public function setReleaseId(\DedexBundle\Entity\Ern42\ReleaseIdType $releaseId)
+    {
+        $this->releaseId = $releaseId;
+        return $this;
+    }
+
+    /**
+     * Adds as displayTitleText
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleTextType $displayTitleText
+     */
+    public function addToDisplayTitleText(\DedexBundle\Entity\Ern42\DisplayTitleTextType $displayTitleText)
+    {
+        $this->displayTitleText[] = $displayTitleText;
+        return $this;
+    }
+
+    /**
+     * isset displayTitleText
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayTitleText($index)
+    {
+        return isset($this->displayTitleText[$index]);
+    }
+
+    /**
+     * unset displayTitleText
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayTitleText($index)
+    {
+        unset($this->displayTitleText[$index]);
+    }
+
+    /**
+     * Gets as displayTitleText
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayTitleTextType[]
+     */
+    public function getDisplayTitleText()
+    {
+        return $this->displayTitleText;
+    }
+
+    /**
+     * Sets a new displayTitleText
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleTextType[] $displayTitleText
+     * @return self
+     */
+    public function setDisplayTitleText(?array $displayTitleText = null)
+    {
+        $this->displayTitleText = $displayTitleText;
+        return $this;
+    }
+
+    /**
+     * Adds as displayTitle
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleType $displayTitle
+     */
+    public function addToDisplayTitle(\DedexBundle\Entity\Ern42\DisplayTitleType $displayTitle)
+    {
+        $this->displayTitle[] = $displayTitle;
+        return $this;
+    }
+
+    /**
+     * isset displayTitle
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayTitle($index)
+    {
+        return isset($this->displayTitle[$index]);
+    }
+
+    /**
+     * unset displayTitle
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayTitle($index)
+    {
+        unset($this->displayTitle[$index]);
+    }
+
+    /**
+     * Gets as displayTitle
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayTitleType[]
+     */
+    public function getDisplayTitle()
+    {
+        return $this->displayTitle;
+    }
+
+    /**
+     * Sets a new displayTitle
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleType[] $displayTitle
+     * @return self
+     */
+    public function setDisplayTitle(?array $displayTitle = null)
+    {
+        $this->displayTitle = $displayTitle;
+        return $this;
+    }
+
+    /**
+     * Adds as additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Release. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\AdditionalTitleType $additionalTitle
+     */
+    public function addToAdditionalTitle(\DedexBundle\Entity\Ern42\AdditionalTitleType $additionalTitle)
+    {
+        $this->additionalTitle[] = $additionalTitle;
+        return $this;
+    }
+
+    /**
+     * isset additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Release. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetAdditionalTitle($index)
+    {
+        return isset($this->additionalTitle[$index]);
+    }
+
+    /**
+     * unset additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Release. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetAdditionalTitle($index)
+    {
+        unset($this->additionalTitle[$index]);
+    }
+
+    /**
+     * Gets as additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Release. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return \DedexBundle\Entity\Ern42\AdditionalTitleType[]
+     */
+    public function getAdditionalTitle()
+    {
+        return $this->additionalTitle;
+    }
+
+    /**
+     * Sets a new additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Release. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param \DedexBundle\Entity\Ern42\AdditionalTitleType[] $additionalTitle
+     * @return self
+     */
+    public function setAdditionalTitle(?array $additionalTitle = null)
+    {
+        $this->additionalTitle = $additionalTitle;
+        return $this;
+    }
+
+    /**
+     * Adds as displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Release to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType $displayArtistName
+     */
+    public function addToDisplayArtistName(\DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType $displayArtistName)
+    {
+        $this->displayArtistName[] = $displayArtistName;
+        return $this;
+    }
+
+    /**
+     * isset displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Release to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayArtistName($index)
+    {
+        return isset($this->displayArtistName[$index]);
+    }
+
+    /**
+     * unset displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Release to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayArtistName($index)
+    {
+        unset($this->displayArtistName[$index]);
+    }
+
+    /**
+     * Gets as displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Release to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType[]
+     */
+    public function getDisplayArtistName()
+    {
+        return $this->displayArtistName;
+    }
+
+    /**
+     * Sets a new displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Release to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType[] $displayArtistName
+     * @return self
+     */
+    public function setDisplayArtistName(?array $displayArtistName = null)
+    {
+        $this->displayArtistName = $displayArtistName;
+        return $this;
+    }
+
+    /**
+     * Adds as releaseLabelReference
+     *
+     * A Reference for a label of the Release (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ReleaseLabelReferenceType $releaseLabelReference
+     */
+    public function addToReleaseLabelReference(\DedexBundle\Entity\Ern42\ReleaseLabelReferenceType $releaseLabelReference)
+    {
+        $this->releaseLabelReference[] = $releaseLabelReference;
+        return $this;
+    }
+
+    /**
+     * isset releaseLabelReference
+     *
+     * A Reference for a label of the Release (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetReleaseLabelReference($index)
+    {
+        return isset($this->releaseLabelReference[$index]);
+    }
+
+    /**
+     * unset releaseLabelReference
+     *
+     * A Reference for a label of the Release (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetReleaseLabelReference($index)
+    {
+        unset($this->releaseLabelReference[$index]);
+    }
+
+    /**
+     * Gets as releaseLabelReference
+     *
+     * A Reference for a label of the Release (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @return \DedexBundle\Entity\Ern42\ReleaseLabelReferenceType[]
+     */
+    public function getReleaseLabelReference()
+    {
+        return $this->releaseLabelReference;
+    }
+
+    /**
+     * Sets a new releaseLabelReference
+     *
+     * A Reference for a label of the Release (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @param \DedexBundle\Entity\Ern42\ReleaseLabelReferenceType[] $releaseLabelReference
+     * @return self
+     */
+    public function setReleaseLabelReference(?array $releaseLabelReference = null)
+    {
+        $this->releaseLabelReference = $releaseLabelReference;
+        return $this;
+    }
+
+    /**
+     * Gets as releaseDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the related Release was or will be first made available for Usage in its current form, whether for physical or electronic/online distribution (in ISO 8601 format: YYYY-MM-DD).
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType
+     */
+    public function getReleaseDate()
+    {
+        return $this->releaseDate;
+    }
+
+    /**
+     * Sets a new releaseDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the related Release was or will be first made available for Usage in its current form, whether for physical or electronic/online distribution (in ISO 8601 format: YYYY-MM-DD).
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $releaseDate
+     * @return self
+     */
+    public function setReleaseDate(?\DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $releaseDate = null)
+    {
+        $this->releaseDate = $releaseDate;
+        return $this;
+    }
+
+    /**
+     * Gets as originalReleaseDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the collection of tracks for the Release (e.g. the equivalent physical album on vinyl) was or will be first made available for Usage, whether for physical or electronic/online distribution (in ISO 8601 format: YYYY-MM-DD).
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType
+     */
+    public function getOriginalReleaseDate()
+    {
+        return $this->originalReleaseDate;
+    }
+
+    /**
+     * Sets a new originalReleaseDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the collection of tracks for the Release (e.g. the equivalent physical album on vinyl) was or will be first made available for Usage, whether for physical or electronic/online distribution (in ISO 8601 format: YYYY-MM-DD).
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $originalReleaseDate
+     * @return self
+     */
+    public function setOriginalReleaseDate(?\DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $originalReleaseDate = null)
+    {
+        $this->originalReleaseDate = $originalReleaseDate;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/RelatedResourceType.php
+++ b/src/Entity/Ern42/RelatedResourceType.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing RelatedResourceType
+ *
+ * A Composite containing details of a ResourceRelatedResourceReference for the case where one Resource is related to another one.
+ * XSD Type: RelatedResource
+ */
+class RelatedResourceType
+{
+    /**
+     * A Type of relationship between two Resources.
+     *
+     * @var string $resourceRelationshipType
+     */
+    private $resourceRelationshipType = null;
+
+    /**
+     * A Reference for a related Resource (specific to this Message). This is a LocalResourceAnchorReference starting with the letter A.
+     *
+     * @var string $resourceRelatedResourceReference
+     */
+    private $resourceRelatedResourceReference = null;
+
+    /**
+     * A Composite containing details of ResourceIds, which allows referencing a related Resource that is not in this message.
+     *
+     * @var \DedexBundle\Entity\Ern42\ResourceIdType $resourceId
+     */
+    private $resourceId = null;
+
+    /**
+     * A Composite containing details of a StartTime and/or a Duration of the related Resource.
+     *
+     * @var \DedexBundle\Entity\Ern42\TimingType[] $timing
+     */
+    private $timing = [
+        
+    ];
+
+    /**
+     * Gets as resourceRelationshipType
+     *
+     * A Type of relationship between two Resources.
+     *
+     * @return string
+     */
+    public function getResourceRelationshipType()
+    {
+        return $this->resourceRelationshipType;
+    }
+
+    /**
+     * Sets a new resourceRelationshipType
+     *
+     * A Type of relationship between two Resources.
+     *
+     * @param string $resourceRelationshipType
+     * @return self
+     */
+    public function setResourceRelationshipType($resourceRelationshipType)
+    {
+        $this->resourceRelationshipType = $resourceRelationshipType;
+        return $this;
+    }
+
+    /**
+     * Gets as resourceRelatedResourceReference
+     *
+     * A Reference for a related Resource (specific to this Message). This is a LocalResourceAnchorReference starting with the letter A.
+     *
+     * @return string
+     */
+    public function getResourceRelatedResourceReference()
+    {
+        return $this->resourceRelatedResourceReference;
+    }
+
+    /**
+     * Sets a new resourceRelatedResourceReference
+     *
+     * A Reference for a related Resource (specific to this Message). This is a LocalResourceAnchorReference starting with the letter A.
+     *
+     * @param string $resourceRelatedResourceReference
+     * @return self
+     */
+    public function setResourceRelatedResourceReference($resourceRelatedResourceReference)
+    {
+        $this->resourceRelatedResourceReference = $resourceRelatedResourceReference;
+        return $this;
+    }
+
+    /**
+     * Gets as resourceId
+     *
+     * A Composite containing details of ResourceIds, which allows referencing a related Resource that is not in this message.
+     *
+     * @return \DedexBundle\Entity\Ern42\ResourceIdType
+     */
+    public function getResourceId()
+    {
+        return $this->resourceId;
+    }
+
+    /**
+     * Sets a new resourceId
+     *
+     * A Composite containing details of ResourceIds, which allows referencing a related Resource that is not in this message.
+     *
+     * @param \DedexBundle\Entity\Ern42\ResourceIdType $resourceId
+     * @return self
+     */
+    public function setResourceId(?\DedexBundle\Entity\Ern42\ResourceIdType $resourceId = null)
+    {
+        $this->resourceId = $resourceId;
+        return $this;
+    }
+
+    /**
+     * Adds as timing
+     *
+     * A Composite containing details of a StartTime and/or a Duration of the related Resource.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\TimingType $timing
+     */
+    public function addToTiming(\DedexBundle\Entity\Ern42\TimingType $timing)
+    {
+        $this->timing[] = $timing;
+        return $this;
+    }
+
+    /**
+     * isset timing
+     *
+     * A Composite containing details of a StartTime and/or a Duration of the related Resource.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetTiming($index)
+    {
+        return isset($this->timing[$index]);
+    }
+
+    /**
+     * unset timing
+     *
+     * A Composite containing details of a StartTime and/or a Duration of the related Resource.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetTiming($index)
+    {
+        unset($this->timing[$index]);
+    }
+
+    /**
+     * Gets as timing
+     *
+     * A Composite containing details of a StartTime and/or a Duration of the related Resource.
+     *
+     * @return \DedexBundle\Entity\Ern42\TimingType[]
+     */
+    public function getTiming()
+    {
+        return $this->timing;
+    }
+
+    /**
+     * Sets a new timing
+     *
+     * A Composite containing details of a StartTime and/or a Duration of the related Resource.
+     *
+     * @param \DedexBundle\Entity\Ern42\TimingType[] $timing
+     * @return self
+     */
+    public function setTiming(?array $timing = null)
+    {
+        $this->timing = $timing;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ReleaseAdminType.php
+++ b/src/Entity/Ern42/ReleaseAdminType.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ReleaseAdminType
+ *
+ * A Composite containing details of Release administration.
+ * XSD Type: ReleaseAdmin
+ */
+class ReleaseAdminType
+{
+    /**
+     * An Identifier specified by the MessageSender that identifies a group of record company personnel to be granted access to the MessageRecipient’s systems to administer the Release. Note that the communication of user access credentials is out of scope for the NewReleaseMessage.
+     *
+     * @var string $releaseAdminId
+     */
+    private $releaseAdminId = null;
+
+    /**
+     * A textual Description of the group of people that are to be given access to the DSP’s system. This information is auxiliary to the ReleaseAdminId element, which is the authoritative source of information for the DSP.
+     *
+     * @var string $personnelDescription
+     */
+    private $personnelDescription = null;
+
+    /**
+     * A textual Description indicating which system a person in the group identified by the Release is allowed to access.
+     *
+     * @var string[] $systemDescription
+     */
+    private $systemDescription = [
+        
+    ];
+
+    /**
+     * Gets as releaseAdminId
+     *
+     * An Identifier specified by the MessageSender that identifies a group of record company personnel to be granted access to the MessageRecipient’s systems to administer the Release. Note that the communication of user access credentials is out of scope for the NewReleaseMessage.
+     *
+     * @return string
+     */
+    public function getReleaseAdminId()
+    {
+        return $this->releaseAdminId;
+    }
+
+    /**
+     * Sets a new releaseAdminId
+     *
+     * An Identifier specified by the MessageSender that identifies a group of record company personnel to be granted access to the MessageRecipient’s systems to administer the Release. Note that the communication of user access credentials is out of scope for the NewReleaseMessage.
+     *
+     * @param string $releaseAdminId
+     * @return self
+     */
+    public function setReleaseAdminId($releaseAdminId)
+    {
+        $this->releaseAdminId = $releaseAdminId;
+        return $this;
+    }
+
+    /**
+     * Gets as personnelDescription
+     *
+     * A textual Description of the group of people that are to be given access to the DSP’s system. This information is auxiliary to the ReleaseAdminId element, which is the authoritative source of information for the DSP.
+     *
+     * @return string
+     */
+    public function getPersonnelDescription()
+    {
+        return $this->personnelDescription;
+    }
+
+    /**
+     * Sets a new personnelDescription
+     *
+     * A textual Description of the group of people that are to be given access to the DSP’s system. This information is auxiliary to the ReleaseAdminId element, which is the authoritative source of information for the DSP.
+     *
+     * @param string $personnelDescription
+     * @return self
+     */
+    public function setPersonnelDescription($personnelDescription)
+    {
+        $this->personnelDescription = $personnelDescription;
+        return $this;
+    }
+
+    /**
+     * Adds as systemDescription
+     *
+     * A textual Description indicating which system a person in the group identified by the Release is allowed to access.
+     *
+     * @return self
+     * @param string $systemDescription
+     */
+    public function addToSystemDescription($systemDescription)
+    {
+        $this->systemDescription[] = $systemDescription;
+        return $this;
+    }
+
+    /**
+     * isset systemDescription
+     *
+     * A textual Description indicating which system a person in the group identified by the Release is allowed to access.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetSystemDescription($index)
+    {
+        return isset($this->systemDescription[$index]);
+    }
+
+    /**
+     * unset systemDescription
+     *
+     * A textual Description indicating which system a person in the group identified by the Release is allowed to access.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetSystemDescription($index)
+    {
+        unset($this->systemDescription[$index]);
+    }
+
+    /**
+     * Gets as systemDescription
+     *
+     * A textual Description indicating which system a person in the group identified by the Release is allowed to access.
+     *
+     * @return string[]
+     */
+    public function getSystemDescription()
+    {
+        return $this->systemDescription;
+    }
+
+    /**
+     * Sets a new systemDescription
+     *
+     * A textual Description indicating which system a person in the group identified by the Release is allowed to access.
+     *
+     * @param string[] $systemDescription
+     * @return self
+     */
+    public function setSystemDescription(?array $systemDescription = null)
+    {
+        $this->systemDescription = $systemDescription;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ReleaseDealType.php
+++ b/src/Entity/Ern42/ReleaseDealType.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ReleaseDealType
+ *
+ * A Composite containing details of one or more Deals pertaining to one or more Releases.
+ * XSD Type: ReleaseDeal
+ */
+class ReleaseDealType
+{
+    /**
+     * The Identifier (specific to the Message) of a Release in the Deal. This is a LocalReleaseAnchorReference starting with the letter R.
+     *
+     * @var string[] $dealReleaseReference
+     */
+    private $dealReleaseReference = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Deal governing the Usage of all Releases identified in the ReleaseDeal Composite.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/no-takedown-in-initial-deal
+     *
+     * @var \DedexBundle\Entity\Ern42\DealType[] $deal
+     */
+    private $deal = [
+        
+    ];
+
+    /**
+     * Adds as dealReleaseReference
+     *
+     * The Identifier (specific to the Message) of a Release in the Deal. This is a LocalReleaseAnchorReference starting with the letter R.
+     *
+     * @return self
+     * @param string $dealReleaseReference
+     */
+    public function addToDealReleaseReference($dealReleaseReference)
+    {
+        $this->dealReleaseReference[] = $dealReleaseReference;
+        return $this;
+    }
+
+    /**
+     * isset dealReleaseReference
+     *
+     * The Identifier (specific to the Message) of a Release in the Deal. This is a LocalReleaseAnchorReference starting with the letter R.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDealReleaseReference($index)
+    {
+        return isset($this->dealReleaseReference[$index]);
+    }
+
+    /**
+     * unset dealReleaseReference
+     *
+     * The Identifier (specific to the Message) of a Release in the Deal. This is a LocalReleaseAnchorReference starting with the letter R.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDealReleaseReference($index)
+    {
+        unset($this->dealReleaseReference[$index]);
+    }
+
+    /**
+     * Gets as dealReleaseReference
+     *
+     * The Identifier (specific to the Message) of a Release in the Deal. This is a LocalReleaseAnchorReference starting with the letter R.
+     *
+     * @return string[]
+     */
+    public function getDealReleaseReference()
+    {
+        return $this->dealReleaseReference;
+    }
+
+    /**
+     * Sets a new dealReleaseReference
+     *
+     * The Identifier (specific to the Message) of a Release in the Deal. This is a LocalReleaseAnchorReference starting with the letter R.
+     *
+     * @param string $dealReleaseReference
+     * @return self
+     */
+    public function setDealReleaseReference(array $dealReleaseReference)
+    {
+        $this->dealReleaseReference = $dealReleaseReference;
+        return $this;
+    }
+
+    /**
+     * Adds as deal
+     *
+     * A Composite containing details of a Deal governing the Usage of all Releases identified in the ReleaseDeal Composite.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/no-takedown-in-initial-deal
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DealType $deal
+     */
+    public function addToDeal(\DedexBundle\Entity\Ern42\DealType $deal)
+    {
+        $this->deal[] = $deal;
+        return $this;
+    }
+
+    /**
+     * isset deal
+     *
+     * A Composite containing details of a Deal governing the Usage of all Releases identified in the ReleaseDeal Composite.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/no-takedown-in-initial-deal
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDeal($index)
+    {
+        return isset($this->deal[$index]);
+    }
+
+    /**
+     * unset deal
+     *
+     * A Composite containing details of a Deal governing the Usage of all Releases identified in the ReleaseDeal Composite.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/no-takedown-in-initial-deal
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDeal($index)
+    {
+        unset($this->deal[$index]);
+    }
+
+    /**
+     * Gets as deal
+     *
+     * A Composite containing details of a Deal governing the Usage of all Releases identified in the ReleaseDeal Composite.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/no-takedown-in-initial-deal
+     *
+     * @return \DedexBundle\Entity\Ern42\DealType[]
+     */
+    public function getDeal()
+    {
+        return $this->deal;
+    }
+
+    /**
+     * Sets a new deal
+     *
+     * A Composite containing details of a Deal governing the Usage of all Releases identified in the ReleaseDeal Composite.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/no-takedown-in-initial-deal
+     *
+     * @param \DedexBundle\Entity\Ern42\DealType[] $deal
+     * @return self
+     */
+    public function setDeal(array $deal)
+    {
+        $this->deal = $deal;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ReleaseIdType.php
+++ b/src/Entity/Ern42/ReleaseIdType.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ReleaseIdType
+ *
+ * A Composite containing details of a ReleaseId. If available, a GRid should always to be used. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.
+ * XSD Type: ReleaseId
+ */
+class ReleaseIdType
+{
+    /**
+     * The GRid identifying the Release. This is the preferred Element and is mandatory if a GRid is available. A GRid comprises four parts: the xs:string 'A1', followed by five alphanumeric characters, ten alphanumeric characters and and one alphanumeric character. DDEX will enforce the syntax [a-zA-Z0-9]{18} using XML Schema in the future.
+     *
+     * @var string $gRid
+     */
+    private $gRid = null;
+
+    /**
+     * An ICPN used as proxy for identification of the Release. Only applicable when the Release is an abstraction of a complete PhysicalProduct. An ICPN comprises 12 or 13 digits, depending whether it is an EAN (13) or a UPC (12). DDEX will enforce the syntax [0-9]{12,13} using XML Schema in the future.
+     *
+     * @var string $iCPN
+     */
+    private $iCPN = null;
+
+    /**
+     * A Composite containing details of the CatalogNumber of the Release.
+     *
+     * @var \DedexBundle\Entity\Ern42\CatalogNumberType $catalogNumber
+     */
+    private $catalogNumber = null;
+
+    /**
+     * A Composite containing details of a ProprietaryIdentifier of the Release.
+     *
+     * @var \DedexBundle\Entity\Ern42\ProprietaryIdType[] $proprietaryId
+     */
+    private $proprietaryId = [
+        
+    ];
+
+    /**
+     * Gets as gRid
+     *
+     * The GRid identifying the Release. This is the preferred Element and is mandatory if a GRid is available. A GRid comprises four parts: the xs:string 'A1', followed by five alphanumeric characters, ten alphanumeric characters and and one alphanumeric character. DDEX will enforce the syntax [a-zA-Z0-9]{18} using XML Schema in the future.
+     *
+     * @return string
+     */
+    public function getGRid()
+    {
+        return $this->gRid;
+    }
+
+    /**
+     * Sets a new gRid
+     *
+     * The GRid identifying the Release. This is the preferred Element and is mandatory if a GRid is available. A GRid comprises four parts: the xs:string 'A1', followed by five alphanumeric characters, ten alphanumeric characters and and one alphanumeric character. DDEX will enforce the syntax [a-zA-Z0-9]{18} using XML Schema in the future.
+     *
+     * @param string $gRid
+     * @return self
+     */
+    public function setGRid($gRid)
+    {
+        $this->gRid = $gRid;
+        return $this;
+    }
+
+    /**
+     * Gets as iCPN
+     *
+     * An ICPN used as proxy for identification of the Release. Only applicable when the Release is an abstraction of a complete PhysicalProduct. An ICPN comprises 12 or 13 digits, depending whether it is an EAN (13) or a UPC (12). DDEX will enforce the syntax [0-9]{12,13} using XML Schema in the future.
+     *
+     * @return string
+     */
+    public function getICPN()
+    {
+        return $this->iCPN;
+    }
+
+    /**
+     * Sets a new iCPN
+     *
+     * An ICPN used as proxy for identification of the Release. Only applicable when the Release is an abstraction of a complete PhysicalProduct. An ICPN comprises 12 or 13 digits, depending whether it is an EAN (13) or a UPC (12). DDEX will enforce the syntax [0-9]{12,13} using XML Schema in the future.
+     *
+     * @param string $iCPN
+     * @return self
+     */
+    public function setICPN($iCPN)
+    {
+        $this->iCPN = $iCPN;
+        return $this;
+    }
+
+    /**
+     * Gets as catalogNumber
+     *
+     * A Composite containing details of the CatalogNumber of the Release.
+     *
+     * @return \DedexBundle\Entity\Ern42\CatalogNumberType
+     */
+    public function getCatalogNumber()
+    {
+        return $this->catalogNumber;
+    }
+
+    /**
+     * Sets a new catalogNumber
+     *
+     * A Composite containing details of the CatalogNumber of the Release.
+     *
+     * @param \DedexBundle\Entity\Ern42\CatalogNumberType $catalogNumber
+     * @return self
+     */
+    public function setCatalogNumber(?\DedexBundle\Entity\Ern42\CatalogNumberType $catalogNumber = null)
+    {
+        $this->catalogNumber = $catalogNumber;
+        return $this;
+    }
+
+    /**
+     * Adds as proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Release.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ProprietaryIdType $proprietaryId
+     */
+    public function addToProprietaryId(\DedexBundle\Entity\Ern42\ProprietaryIdType $proprietaryId)
+    {
+        $this->proprietaryId[] = $proprietaryId;
+        return $this;
+    }
+
+    /**
+     * isset proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Release.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetProprietaryId($index)
+    {
+        return isset($this->proprietaryId[$index]);
+    }
+
+    /**
+     * unset proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Release.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetProprietaryId($index)
+    {
+        unset($this->proprietaryId[$index]);
+    }
+
+    /**
+     * Gets as proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Release.
+     *
+     * @return \DedexBundle\Entity\Ern42\ProprietaryIdType[]
+     */
+    public function getProprietaryId()
+    {
+        return $this->proprietaryId;
+    }
+
+    /**
+     * Sets a new proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Release.
+     *
+     * @param \DedexBundle\Entity\Ern42\ProprietaryIdType[] $proprietaryId
+     * @return self
+     */
+    public function setProprietaryId(?array $proprietaryId = null)
+    {
+        $this->proprietaryId = $proprietaryId;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ReleaseLabelReferenceType.php
+++ b/src/Entity/Ern42/ReleaseLabelReferenceType.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ReleaseLabelReferenceType
+ *
+ * A Composite containing details of a Reference to a label of a specific Release.
+ * XSD Type: ReleaseLabelReference
+ */
+class ReleaseLabelReferenceType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Language and script of the LabelName as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * A Type of Label. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $labelType
+     */
+    private $labelType = null;
+
+    /**
+     * The Namespace of the LabelType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the LabelType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * A Territory to which the LabelName applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script of the LabelName as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script of the LabelName as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+
+    /**
+     * Gets as labelType
+     *
+     * A Type of Label. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLabelType()
+    {
+        return $this->labelType;
+    }
+
+    /**
+     * Sets a new labelType
+     *
+     * A Type of Label. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $labelType
+     * @return self
+     */
+    public function setLabelType($labelType)
+    {
+        $this->labelType = $labelType;
+        return $this;
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the LabelType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the LabelType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the LabelType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the LabelType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the LabelName applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the LabelName applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ReleaseLabelReferenceWithPartyType.php
+++ b/src/Entity/Ern42/ReleaseLabelReferenceWithPartyType.php
@@ -1,0 +1,284 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ReleaseLabelReferenceWithPartyType
+ *
+ * A Composite containing details of a Reference to a label of a specific Release.
+ * Explanatory Note: This Composite is named ReleaseLabelReferenceWithParty to disambiguate it from the basic ReleaseLabelReference Composite.
+ * XSD Type: ReleaseLabelReferenceWithParty
+ */
+class ReleaseLabelReferenceWithPartyType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Language and script of the LabelName as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * A Type of Label. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $labelType
+     */
+    private $labelType = null;
+
+    /**
+     * A Party who is allowed to administer a Release on a ReleaseDistributor’s system. ReleaseCreator and ReleaseDistributor shall agree what the access rules for those people are and the exchange of username and password (or other means of authentication) is left to ReleaseCreator and ReleaseDistributor.
+     *
+     * @var string $accessControlParty
+     */
+    private $accessControlParty = null;
+
+    /**
+     * The Namespace of the LabelType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the LabelType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * A Territory to which the LabelName applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script of the LabelName as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script of the LabelName as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+
+    /**
+     * Gets as labelType
+     *
+     * A Type of Label. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLabelType()
+    {
+        return $this->labelType;
+    }
+
+    /**
+     * Sets a new labelType
+     *
+     * A Type of Label. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $labelType
+     * @return self
+     */
+    public function setLabelType($labelType)
+    {
+        $this->labelType = $labelType;
+        return $this;
+    }
+
+    /**
+     * Gets as accessControlParty
+     *
+     * A Party who is allowed to administer a Release on a ReleaseDistributor’s system. ReleaseCreator and ReleaseDistributor shall agree what the access rules for those people are and the exchange of username and password (or other means of authentication) is left to ReleaseCreator and ReleaseDistributor.
+     *
+     * @return string
+     */
+    public function getAccessControlParty()
+    {
+        return $this->accessControlParty;
+    }
+
+    /**
+     * Sets a new accessControlParty
+     *
+     * A Party who is allowed to administer a Release on a ReleaseDistributor’s system. ReleaseCreator and ReleaseDistributor shall agree what the access rules for those people are and the exchange of username and password (or other means of authentication) is left to ReleaseCreator and ReleaseDistributor.
+     *
+     * @param string $accessControlParty
+     * @return self
+     */
+    public function setAccessControlParty($accessControlParty)
+    {
+        $this->accessControlParty = $accessControlParty;
+        return $this;
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the LabelType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the LabelType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the LabelType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the LabelType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the LabelName applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the LabelName applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ReleaseListType.php
+++ b/src/Entity/Ern42/ReleaseListType.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ReleaseListType
+ *
+ * A Composite containing details of one or more Releases.
+ * XSD Type: ReleaseList
+ */
+class ReleaseListType
+{
+    /**
+     * A Composite containing details of a DDEX Release.
+     *
+     * @var \DedexBundle\Entity\Ern42\ReleaseType $release
+     */
+    private $release = null;
+
+    /**
+     * A Composite containing details of a DDEX TrackRelease.
+     *
+     * @var \DedexBundle\Entity\Ern42\TrackReleaseType[] $trackRelease
+     */
+    private $trackRelease = [
+        
+    ];
+
+    /**
+     * Gets as release
+     *
+     * A Composite containing details of a DDEX Release.
+     *
+     * @return \DedexBundle\Entity\Ern42\ReleaseType
+     */
+    public function getRelease()
+    {
+        return $this->release;
+    }
+
+    /**
+     * Sets a new release
+     *
+     * A Composite containing details of a DDEX Release.
+     *
+     * @param \DedexBundle\Entity\Ern42\ReleaseType $release
+     * @return self
+     */
+    public function setRelease(?\DedexBundle\Entity\Ern42\ReleaseType $release = null)
+    {
+        $this->release = $release;
+        return $this;
+    }
+
+    /**
+     * Adds as trackRelease
+     *
+     * A Composite containing details of a DDEX TrackRelease.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\TrackReleaseType $trackRelease
+     */
+    public function addToTrackRelease(\DedexBundle\Entity\Ern42\TrackReleaseType $trackRelease)
+    {
+        $this->trackRelease[] = $trackRelease;
+        return $this;
+    }
+
+    /**
+     * isset trackRelease
+     *
+     * A Composite containing details of a DDEX TrackRelease.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetTrackRelease($index)
+    {
+        return isset($this->trackRelease[$index]);
+    }
+
+    /**
+     * unset trackRelease
+     *
+     * A Composite containing details of a DDEX TrackRelease.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetTrackRelease($index)
+    {
+        unset($this->trackRelease[$index]);
+    }
+
+    /**
+     * Gets as trackRelease
+     *
+     * A Composite containing details of a DDEX TrackRelease.
+     *
+     * @return \DedexBundle\Entity\Ern42\TrackReleaseType[]
+     */
+    public function getTrackRelease()
+    {
+        return $this->trackRelease;
+    }
+
+    /**
+     * Sets a new trackRelease
+     *
+     * A Composite containing details of a DDEX TrackRelease.
+     *
+     * @param \DedexBundle\Entity\Ern42\TrackReleaseType[] $trackRelease
+     * @return self
+     */
+    public function setTrackRelease(?array $trackRelease = null)
+    {
+        $this->trackRelease = $trackRelease;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ReleaseRelationshipTypeType.php
+++ b/src/Entity/Ern42/ReleaseRelationshipTypeType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ReleaseRelationshipTypeType
+ *
+ * A Composite containing details of a ReleaseRelationshipType, e.g. between an AudioClipRelease and a VideoClipRelease.
+ * XSD Type: ReleaseRelationshipType
+ */
+class ReleaseRelationshipTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the ReleaseRelationshipType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the ReleaseRelationshipType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the ReleaseRelationshipType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the ReleaseRelationshipType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the ReleaseRelationshipType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the ReleaseRelationshipType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ReleaseType.php
+++ b/src/Entity/Ern42/ReleaseType.php
@@ -1,0 +1,2335 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ReleaseType
+ *
+ * A Composite containing details of a DDEX Release.
+ * XSD Type: Release
+ */
+class ReleaseType
+{
+    /**
+     * The Language and script for the Elements of the Release as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * The Identifier (specific to the Message) of the Release. Used to link the Release to one or more Deal(s). This is a LocalReleaseAnchor starting with the letter R.
+     *
+     * @var string $releaseReference
+     */
+    private $releaseReference = null;
+
+    /**
+     * A Composite containing details of the form in which a ReleaseCreator anticipates offering the Release to Consumers. The RelaseType is a marketing term and more than one value may be provided.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/release-types-for-trackreleases
+     *
+     * @var \DedexBundle\Entity\Ern42\ReleaseTypeForReleaseNotificationType[] $releaseType
+     */
+    private $releaseType = [
+        
+    ];
+
+    /**
+     * A Composite containing details of ReleaseIds. If available, a GRid has to be used. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.
+     *
+     * @var \DedexBundle\Entity\Ern42\ReleaseIdType $releaseId
+     */
+    private $releaseId = null;
+
+    /**
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayTitleTextType[] $displayTitleText
+     */
+    private $displayTitleText = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayTitleType[] $displayTitle
+     */
+    private $displayTitle = [
+        
+    ];
+
+    /**
+     * A Composite containing details of an AdditionalTitle of the Release. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @var \DedexBundle\Entity\Ern42\AdditionalTitleType[] $additionalTitle
+     */
+    private $additionalTitle = [
+        
+    ];
+
+    /**
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Release to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType[] $displayArtistName
+     */
+    private $displayArtistName = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the DisplayArtist for the Release. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayArtistType[] $displayArtist
+     */
+    private $displayArtist = [
+        
+    ];
+
+    /**
+     * A Reference for a label of the Release (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @var \DedexBundle\Entity\Ern42\ReleaseLabelReferenceWithPartyType[] $releaseLabelReference
+     */
+    private $releaseLabelReference = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the AdministratingRecordCompany for the Release.
+     *
+     * @var \DedexBundle\Entity\Ern42\AdministratingRecordCompanyWithReferenceType[] $administratingRecordCompany
+     */
+    private $administratingRecordCompany = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the PLine for the Release.
+     *
+     * @var \DedexBundle\Entity\Ern42\PLineWithDefaultType[] $pLine
+     */
+    private $pLine = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the CLine for the Release.
+     *
+     * @var \DedexBundle\Entity\Ern42\CLineWithDefaultType[] $cLine
+     */
+    private $cLine = [
+        
+    ];
+
+    /**
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for guests Artists or others featured on the Release.
+     *
+     * @var \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType[] $courtesyLine
+     */
+    private $courtesyLine = [
+        
+    ];
+
+    /**
+     * The sum of the Durations of all Resources contained in the Release (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @var \DateInterval $duration
+     */
+    private $duration = null;
+
+    /**
+     * A Composite containing details of a Genre to which the Release belongs.
+     *
+     * @var \DedexBundle\Entity\Ern42\GenreWithTerritoryType[] $genre
+     */
+    private $genre = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the Date and Place of the Event in which the Release was or will be first made available for Usage in its current form, whether for physical or electronic/online distribution (in ISO 8601 format: YYYY[-MM[-DD]]). This Element is for display and cataloguing purposes only.
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateWithDefaultType[] $releaseDate
+     */
+    private $releaseDate = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the Date and Place of the Event in which the collection of tracks for the Release (e.g. the equivalent physical album on vinyl) was or will be first made available for Usage, whether for physical or electronic/online distribution (in ISO 8601 format: YYYY[-MM[-DD]]). This Element is for display and cataloguing purposes only.
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateWithDefaultType[] $originalReleaseDate
+     */
+    private $originalReleaseDate = [
+        
+    ];
+
+    /**
+     * A Reference for a set of visibility dates (specific to this Message) that applies to this Release. This defines when the Release can be shown to Consumers, not when a Consumer can get access to the Release. This is a LocalVisibilityAnchorReference starting with the letter V.
+     *
+     * @var string $releaseVisibilityReference
+     */
+    private $releaseVisibilityReference = null;
+
+    /**
+     * A Composite containing details of the classification of the Release according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @var \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType[] $parentalWarningType
+     */
+    private $parentalWarningType = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a rating for the Release.
+     *
+     * @var \DedexBundle\Entity\Ern42\AvRatingType[] $avRating
+     */
+    private $avRating = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to this Release.
+     *
+     * @var \DedexBundle\Entity\Ern42\RelatedReleaseType[] $relatedRelease
+     */
+    private $relatedRelease = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Resource which is related to this Release.
+     *
+     * @var \DedexBundle\Entity\Ern42\RelatedResourceType[] $relatedResource
+     */
+    private $relatedResource = [
+        
+    ];
+
+    /**
+     * A Flag indicating whether the Release is a single-artist Compilation (=true) or not (=false). If this flag is set, the Release would typically be expected to be part of the discography of the main artist of the Release.
+     *
+     * @var bool $isSingleArtistCompilation
+     */
+    private $isSingleArtistCompilation = null;
+
+    /**
+     * The Flag indicating whether the Release is a multiartist Compilation (=true) or not (=false).
+     *
+     * @var bool $isMultiArtistCompilation
+     */
+    private $isMultiArtistCompilation = null;
+
+    /**
+     * A Composite containing details of a group of some or all of the Resources in the Release. ResourceGroups are used to signal groupings or sequences of Resources within a Release. Examples include individual carriers in a multi-carrier Release or classical Work groupings as well as the default order of Resources within a Release. ResourceGroups are typically not used with Releases that contain only one primary Resource such as TrackReleases.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/sequencing-resources
+     *
+     * @var \DedexBundle\Entity\Ern42\ResourceGroupType $resourceGroup
+     */
+    private $resourceGroup = null;
+
+    /**
+     * A Composite containing details of promotional or other material related to the Release.
+     *
+     * @var \DedexBundle\Entity\Ern42\ExternalResourceLinkType[] $externalResourceLink
+     */
+    private $externalResourceLink = [
+        
+    ];
+
+    /**
+     * A URL of a sub-site or channel in the DSP’s system, where the Release should be made available to Consumers.
+     *
+     * @var string $targetURL
+     */
+    private $targetURL = null;
+
+    /**
+     * A Composite containing details of a Description of the Release containing Keywords.
+     *
+     * @var \DedexBundle\Entity\Ern42\KeywordsWithTerritoryType[] $keywords
+     */
+    private $keywords = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Synopsis of the Release.
+     *
+     * @var \DedexBundle\Entity\Ern42\SynopsisWithTerritoryType[] $synopsis
+     */
+    private $synopsis = [
+        
+    ];
+
+    /**
+     * A Description of the melodic mode of a MusicalWork in the Release.
+     *
+     * @var \DedexBundle\Entity\Ern42\RagaType[] $raga
+     */
+    private $raga = [
+        
+    ];
+
+    /**
+     * A Description of the rhythmic pattern of a MusicalWork in the Release.
+     *
+     * @var \DedexBundle\Entity\Ern42\TalaType[] $tala
+     */
+    private $tala = [
+        
+    ];
+
+    /**
+     * A deity name relating to the Release.
+     *
+     * @var \DedexBundle\Entity\Ern42\DeityType[] $deity
+     */
+    private $deity = [
+        
+    ];
+
+    /**
+     * A Description containing an explanation that is required if not all the Tracks are eligible for HiResMusic (e.g. if some tracks were up-sampled to 96 kHz/24 bit from a 44.1 kHz/24 bit source during mastering).
+     *
+     * @var string $hiResMusicDescription
+     */
+    private $hiResMusicDescription = null;
+
+    /**
+     * The Flag indicating whether the Release is a Soundtrack (=true) or not (=false).
+     *
+     * @var bool $isSoundtrack
+     */
+    private $isSoundtrack = null;
+
+    /**
+     * The Flag indicating whether the Release meets the criteria to carry the HiResMusic logo, provided the MessageRecipient meets all the other requirements to use it (note that an album with a majority of tracks being eligible but the remainder not being eligible can still carry the logo) (=true) or not (=false).
+     *
+     * @var bool $isHiResMusic
+     */
+    private $isHiResMusic = null;
+
+    /**
+     * A Composite containing a Comment about the promotion and marketing of the Release.
+     *
+     * @var \DedexBundle\Entity\Ern42\MarketingCommentType[] $marketingComment
+     */
+    private $marketingComment = [
+        
+    ];
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the Elements of the Release as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the Elements of the Release as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as releaseReference
+     *
+     * The Identifier (specific to the Message) of the Release. Used to link the Release to one or more Deal(s). This is a LocalReleaseAnchor starting with the letter R.
+     *
+     * @return string
+     */
+    public function getReleaseReference()
+    {
+        return $this->releaseReference;
+    }
+
+    /**
+     * Sets a new releaseReference
+     *
+     * The Identifier (specific to the Message) of the Release. Used to link the Release to one or more Deal(s). This is a LocalReleaseAnchor starting with the letter R.
+     *
+     * @param string $releaseReference
+     * @return self
+     */
+    public function setReleaseReference($releaseReference)
+    {
+        $this->releaseReference = $releaseReference;
+        return $this;
+    }
+
+    /**
+     * Adds as releaseType
+     *
+     * A Composite containing details of the form in which a ReleaseCreator anticipates offering the Release to Consumers. The RelaseType is a marketing term and more than one value may be provided.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/release-types-for-trackreleases
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ReleaseTypeForReleaseNotificationType $releaseType
+     */
+    public function addToReleaseType(\DedexBundle\Entity\Ern42\ReleaseTypeForReleaseNotificationType $releaseType)
+    {
+        $this->releaseType[] = $releaseType;
+        return $this;
+    }
+
+    /**
+     * isset releaseType
+     *
+     * A Composite containing details of the form in which a ReleaseCreator anticipates offering the Release to Consumers. The RelaseType is a marketing term and more than one value may be provided.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/release-types-for-trackreleases
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetReleaseType($index)
+    {
+        return isset($this->releaseType[$index]);
+    }
+
+    /**
+     * unset releaseType
+     *
+     * A Composite containing details of the form in which a ReleaseCreator anticipates offering the Release to Consumers. The RelaseType is a marketing term and more than one value may be provided.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/release-types-for-trackreleases
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetReleaseType($index)
+    {
+        unset($this->releaseType[$index]);
+    }
+
+    /**
+     * Gets as releaseType
+     *
+     * A Composite containing details of the form in which a ReleaseCreator anticipates offering the Release to Consumers. The RelaseType is a marketing term and more than one value may be provided.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/release-types-for-trackreleases
+     *
+     * @return \DedexBundle\Entity\Ern42\ReleaseTypeForReleaseNotificationType[]
+     */
+    public function getReleaseType()
+    {
+        return $this->releaseType;
+    }
+
+    /**
+     * Sets a new releaseType
+     *
+     * A Composite containing details of the form in which a ReleaseCreator anticipates offering the Release to Consumers. The RelaseType is a marketing term and more than one value may be provided.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/release-types-for-trackreleases
+     *
+     * @param \DedexBundle\Entity\Ern42\ReleaseTypeForReleaseNotificationType[] $releaseType
+     * @return self
+     */
+    public function setReleaseType(array $releaseType)
+    {
+        $this->releaseType = $releaseType;
+        return $this;
+    }
+
+    /**
+     * Gets as releaseId
+     *
+     * A Composite containing details of ReleaseIds. If available, a GRid has to be used. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.
+     *
+     * @return \DedexBundle\Entity\Ern42\ReleaseIdType
+     */
+    public function getReleaseId()
+    {
+        return $this->releaseId;
+    }
+
+    /**
+     * Sets a new releaseId
+     *
+     * A Composite containing details of ReleaseIds. If available, a GRid has to be used. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.
+     *
+     * @param \DedexBundle\Entity\Ern42\ReleaseIdType $releaseId
+     * @return self
+     */
+    public function setReleaseId(\DedexBundle\Entity\Ern42\ReleaseIdType $releaseId)
+    {
+        $this->releaseId = $releaseId;
+        return $this;
+    }
+
+    /**
+     * Adds as displayTitleText
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleTextType $displayTitleText
+     */
+    public function addToDisplayTitleText(\DedexBundle\Entity\Ern42\DisplayTitleTextType $displayTitleText)
+    {
+        $this->displayTitleText[] = $displayTitleText;
+        return $this;
+    }
+
+    /**
+     * isset displayTitleText
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayTitleText($index)
+    {
+        return isset($this->displayTitleText[$index]);
+    }
+
+    /**
+     * unset displayTitleText
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayTitleText($index)
+    {
+        unset($this->displayTitleText[$index]);
+    }
+
+    /**
+     * Gets as displayTitleText
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayTitleTextType[]
+     */
+    public function getDisplayTitleText()
+    {
+        return $this->displayTitleText;
+    }
+
+    /**
+     * Sets a new displayTitleText
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleTextType[] $displayTitleText
+     * @return self
+     */
+    public function setDisplayTitleText(array $displayTitleText)
+    {
+        $this->displayTitleText = $displayTitleText;
+        return $this;
+    }
+
+    /**
+     * Adds as displayTitle
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleType $displayTitle
+     */
+    public function addToDisplayTitle(\DedexBundle\Entity\Ern42\DisplayTitleType $displayTitle)
+    {
+        $this->displayTitle[] = $displayTitle;
+        return $this;
+    }
+
+    /**
+     * isset displayTitle
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayTitle($index)
+    {
+        return isset($this->displayTitle[$index]);
+    }
+
+    /**
+     * unset displayTitle
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayTitle($index)
+    {
+        unset($this->displayTitle[$index]);
+    }
+
+    /**
+     * Gets as displayTitle
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayTitleType[]
+     */
+    public function getDisplayTitle()
+    {
+        return $this->displayTitle;
+    }
+
+    /**
+     * Sets a new displayTitle
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleType[] $displayTitle
+     * @return self
+     */
+    public function setDisplayTitle(array $displayTitle)
+    {
+        $this->displayTitle = $displayTitle;
+        return $this;
+    }
+
+    /**
+     * Adds as additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Release. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\AdditionalTitleType $additionalTitle
+     */
+    public function addToAdditionalTitle(\DedexBundle\Entity\Ern42\AdditionalTitleType $additionalTitle)
+    {
+        $this->additionalTitle[] = $additionalTitle;
+        return $this;
+    }
+
+    /**
+     * isset additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Release. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetAdditionalTitle($index)
+    {
+        return isset($this->additionalTitle[$index]);
+    }
+
+    /**
+     * unset additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Release. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetAdditionalTitle($index)
+    {
+        unset($this->additionalTitle[$index]);
+    }
+
+    /**
+     * Gets as additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Release. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return \DedexBundle\Entity\Ern42\AdditionalTitleType[]
+     */
+    public function getAdditionalTitle()
+    {
+        return $this->additionalTitle;
+    }
+
+    /**
+     * Sets a new additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Release. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param \DedexBundle\Entity\Ern42\AdditionalTitleType[] $additionalTitle
+     * @return self
+     */
+    public function setAdditionalTitle(?array $additionalTitle = null)
+    {
+        $this->additionalTitle = $additionalTitle;
+        return $this;
+    }
+
+    /**
+     * Adds as displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Release to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType $displayArtistName
+     */
+    public function addToDisplayArtistName(\DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType $displayArtistName)
+    {
+        $this->displayArtistName[] = $displayArtistName;
+        return $this;
+    }
+
+    /**
+     * isset displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Release to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayArtistName($index)
+    {
+        return isset($this->displayArtistName[$index]);
+    }
+
+    /**
+     * unset displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Release to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayArtistName($index)
+    {
+        unset($this->displayArtistName[$index]);
+    }
+
+    /**
+     * Gets as displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Release to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType[]
+     */
+    public function getDisplayArtistName()
+    {
+        return $this->displayArtistName;
+    }
+
+    /**
+     * Sets a new displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Release to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType[] $displayArtistName
+     * @return self
+     */
+    public function setDisplayArtistName(array $displayArtistName)
+    {
+        $this->displayArtistName = $displayArtistName;
+        return $this;
+    }
+
+    /**
+     * Adds as displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the Release. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistType $displayArtist
+     */
+    public function addToDisplayArtist(\DedexBundle\Entity\Ern42\DisplayArtistType $displayArtist)
+    {
+        $this->displayArtist[] = $displayArtist;
+        return $this;
+    }
+
+    /**
+     * isset displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the Release. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayArtist($index)
+    {
+        return isset($this->displayArtist[$index]);
+    }
+
+    /**
+     * unset displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the Release. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayArtist($index)
+    {
+        unset($this->displayArtist[$index]);
+    }
+
+    /**
+     * Gets as displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the Release. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayArtistType[]
+     */
+    public function getDisplayArtist()
+    {
+        return $this->displayArtist;
+    }
+
+    /**
+     * Sets a new displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the Release. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistType[] $displayArtist
+     * @return self
+     */
+    public function setDisplayArtist(array $displayArtist)
+    {
+        $this->displayArtist = $displayArtist;
+        return $this;
+    }
+
+    /**
+     * Adds as releaseLabelReference
+     *
+     * A Reference for a label of the Release (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ReleaseLabelReferenceWithPartyType $releaseLabelReference
+     */
+    public function addToReleaseLabelReference(\DedexBundle\Entity\Ern42\ReleaseLabelReferenceWithPartyType $releaseLabelReference)
+    {
+        $this->releaseLabelReference[] = $releaseLabelReference;
+        return $this;
+    }
+
+    /**
+     * isset releaseLabelReference
+     *
+     * A Reference for a label of the Release (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetReleaseLabelReference($index)
+    {
+        return isset($this->releaseLabelReference[$index]);
+    }
+
+    /**
+     * unset releaseLabelReference
+     *
+     * A Reference for a label of the Release (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetReleaseLabelReference($index)
+    {
+        unset($this->releaseLabelReference[$index]);
+    }
+
+    /**
+     * Gets as releaseLabelReference
+     *
+     * A Reference for a label of the Release (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @return \DedexBundle\Entity\Ern42\ReleaseLabelReferenceWithPartyType[]
+     */
+    public function getReleaseLabelReference()
+    {
+        return $this->releaseLabelReference;
+    }
+
+    /**
+     * Sets a new releaseLabelReference
+     *
+     * A Reference for a label of the Release (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @param \DedexBundle\Entity\Ern42\ReleaseLabelReferenceWithPartyType[] $releaseLabelReference
+     * @return self
+     */
+    public function setReleaseLabelReference(array $releaseLabelReference)
+    {
+        $this->releaseLabelReference = $releaseLabelReference;
+        return $this;
+    }
+
+    /**
+     * Adds as administratingRecordCompany
+     *
+     * A Composite containing details of the AdministratingRecordCompany for the Release.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\AdministratingRecordCompanyWithReferenceType $administratingRecordCompany
+     */
+    public function addToAdministratingRecordCompany(\DedexBundle\Entity\Ern42\AdministratingRecordCompanyWithReferenceType $administratingRecordCompany)
+    {
+        $this->administratingRecordCompany[] = $administratingRecordCompany;
+        return $this;
+    }
+
+    /**
+     * isset administratingRecordCompany
+     *
+     * A Composite containing details of the AdministratingRecordCompany for the Release.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetAdministratingRecordCompany($index)
+    {
+        return isset($this->administratingRecordCompany[$index]);
+    }
+
+    /**
+     * unset administratingRecordCompany
+     *
+     * A Composite containing details of the AdministratingRecordCompany for the Release.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetAdministratingRecordCompany($index)
+    {
+        unset($this->administratingRecordCompany[$index]);
+    }
+
+    /**
+     * Gets as administratingRecordCompany
+     *
+     * A Composite containing details of the AdministratingRecordCompany for the Release.
+     *
+     * @return \DedexBundle\Entity\Ern42\AdministratingRecordCompanyWithReferenceType[]
+     */
+    public function getAdministratingRecordCompany()
+    {
+        return $this->administratingRecordCompany;
+    }
+
+    /**
+     * Sets a new administratingRecordCompany
+     *
+     * A Composite containing details of the AdministratingRecordCompany for the Release.
+     *
+     * @param \DedexBundle\Entity\Ern42\AdministratingRecordCompanyWithReferenceType[] $administratingRecordCompany
+     * @return self
+     */
+    public function setAdministratingRecordCompany(?array $administratingRecordCompany = null)
+    {
+        $this->administratingRecordCompany = $administratingRecordCompany;
+        return $this;
+    }
+
+    /**
+     * Adds as pLine
+     *
+     * A Composite containing details of the PLine for the Release.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\PLineWithDefaultType $pLine
+     */
+    public function addToPLine(\DedexBundle\Entity\Ern42\PLineWithDefaultType $pLine)
+    {
+        $this->pLine[] = $pLine;
+        return $this;
+    }
+
+    /**
+     * isset pLine
+     *
+     * A Composite containing details of the PLine for the Release.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetPLine($index)
+    {
+        return isset($this->pLine[$index]);
+    }
+
+    /**
+     * unset pLine
+     *
+     * A Composite containing details of the PLine for the Release.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetPLine($index)
+    {
+        unset($this->pLine[$index]);
+    }
+
+    /**
+     * Gets as pLine
+     *
+     * A Composite containing details of the PLine for the Release.
+     *
+     * @return \DedexBundle\Entity\Ern42\PLineWithDefaultType[]
+     */
+    public function getPLine()
+    {
+        return $this->pLine;
+    }
+
+    /**
+     * Sets a new pLine
+     *
+     * A Composite containing details of the PLine for the Release.
+     *
+     * @param \DedexBundle\Entity\Ern42\PLineWithDefaultType[] $pLine
+     * @return self
+     */
+    public function setPLine(?array $pLine = null)
+    {
+        $this->pLine = $pLine;
+        return $this;
+    }
+
+    /**
+     * Adds as cLine
+     *
+     * A Composite containing details of the CLine for the Release.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\CLineWithDefaultType $cLine
+     */
+    public function addToCLine(\DedexBundle\Entity\Ern42\CLineWithDefaultType $cLine)
+    {
+        $this->cLine[] = $cLine;
+        return $this;
+    }
+
+    /**
+     * isset cLine
+     *
+     * A Composite containing details of the CLine for the Release.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetCLine($index)
+    {
+        return isset($this->cLine[$index]);
+    }
+
+    /**
+     * unset cLine
+     *
+     * A Composite containing details of the CLine for the Release.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetCLine($index)
+    {
+        unset($this->cLine[$index]);
+    }
+
+    /**
+     * Gets as cLine
+     *
+     * A Composite containing details of the CLine for the Release.
+     *
+     * @return \DedexBundle\Entity\Ern42\CLineWithDefaultType[]
+     */
+    public function getCLine()
+    {
+        return $this->cLine;
+    }
+
+    /**
+     * Sets a new cLine
+     *
+     * A Composite containing details of the CLine for the Release.
+     *
+     * @param \DedexBundle\Entity\Ern42\CLineWithDefaultType[] $cLine
+     * @return self
+     */
+    public function setCLine(?array $cLine = null)
+    {
+        $this->cLine = $cLine;
+        return $this;
+    }
+
+    /**
+     * Adds as courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for guests Artists or others featured on the Release.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType $courtesyLine
+     */
+    public function addToCourtesyLine(\DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType $courtesyLine)
+    {
+        $this->courtesyLine[] = $courtesyLine;
+        return $this;
+    }
+
+    /**
+     * isset courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for guests Artists or others featured on the Release.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetCourtesyLine($index)
+    {
+        return isset($this->courtesyLine[$index]);
+    }
+
+    /**
+     * unset courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for guests Artists or others featured on the Release.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetCourtesyLine($index)
+    {
+        unset($this->courtesyLine[$index]);
+    }
+
+    /**
+     * Gets as courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for guests Artists or others featured on the Release.
+     *
+     * @return \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType[]
+     */
+    public function getCourtesyLine()
+    {
+        return $this->courtesyLine;
+    }
+
+    /**
+     * Sets a new courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for guests Artists or others featured on the Release.
+     *
+     * @param \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType[] $courtesyLine
+     * @return self
+     */
+    public function setCourtesyLine(?array $courtesyLine = null)
+    {
+        $this->courtesyLine = $courtesyLine;
+        return $this;
+    }
+
+    /**
+     * Gets as duration
+     *
+     * The sum of the Durations of all Resources contained in the Release (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @return \DateInterval
+     */
+    public function getDuration()
+    {
+        return $this->duration;
+    }
+
+    /**
+     * Sets a new duration
+     *
+     * The sum of the Durations of all Resources contained in the Release (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @param \DateInterval $duration
+     * @return self
+     */
+    public function setDuration(?\DateInterval $duration = null)
+    {
+        $this->duration = $duration;
+        return $this;
+    }
+
+    /**
+     * Adds as genre
+     *
+     * A Composite containing details of a Genre to which the Release belongs.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\GenreWithTerritoryType $genre
+     */
+    public function addToGenre(\DedexBundle\Entity\Ern42\GenreWithTerritoryType $genre)
+    {
+        $this->genre[] = $genre;
+        return $this;
+    }
+
+    /**
+     * isset genre
+     *
+     * A Composite containing details of a Genre to which the Release belongs.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetGenre($index)
+    {
+        return isset($this->genre[$index]);
+    }
+
+    /**
+     * unset genre
+     *
+     * A Composite containing details of a Genre to which the Release belongs.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetGenre($index)
+    {
+        unset($this->genre[$index]);
+    }
+
+    /**
+     * Gets as genre
+     *
+     * A Composite containing details of a Genre to which the Release belongs.
+     *
+     * @return \DedexBundle\Entity\Ern42\GenreWithTerritoryType[]
+     */
+    public function getGenre()
+    {
+        return $this->genre;
+    }
+
+    /**
+     * Sets a new genre
+     *
+     * A Composite containing details of a Genre to which the Release belongs.
+     *
+     * @param \DedexBundle\Entity\Ern42\GenreWithTerritoryType[] $genre
+     * @return self
+     */
+    public function setGenre(array $genre)
+    {
+        $this->genre = $genre;
+        return $this;
+    }
+
+    /**
+     * Adds as releaseDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Release was or will be first made available for Usage in its current form, whether for physical or electronic/online distribution (in ISO 8601 format: YYYY[-MM[-DD]]). This Element is for display and cataloguing purposes only.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\EventDateWithDefaultType $releaseDate
+     */
+    public function addToReleaseDate(\DedexBundle\Entity\Ern42\EventDateWithDefaultType $releaseDate)
+    {
+        $this->releaseDate[] = $releaseDate;
+        return $this;
+    }
+
+    /**
+     * isset releaseDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Release was or will be first made available for Usage in its current form, whether for physical or electronic/online distribution (in ISO 8601 format: YYYY[-MM[-DD]]). This Element is for display and cataloguing purposes only.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetReleaseDate($index)
+    {
+        return isset($this->releaseDate[$index]);
+    }
+
+    /**
+     * unset releaseDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Release was or will be first made available for Usage in its current form, whether for physical or electronic/online distribution (in ISO 8601 format: YYYY[-MM[-DD]]). This Element is for display and cataloguing purposes only.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetReleaseDate($index)
+    {
+        unset($this->releaseDate[$index]);
+    }
+
+    /**
+     * Gets as releaseDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Release was or will be first made available for Usage in its current form, whether for physical or electronic/online distribution (in ISO 8601 format: YYYY[-MM[-DD]]). This Element is for display and cataloguing purposes only.
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateWithDefaultType[]
+     */
+    public function getReleaseDate()
+    {
+        return $this->releaseDate;
+    }
+
+    /**
+     * Sets a new releaseDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Release was or will be first made available for Usage in its current form, whether for physical or electronic/online distribution (in ISO 8601 format: YYYY[-MM[-DD]]). This Element is for display and cataloguing purposes only.
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateWithDefaultType[] $releaseDate
+     * @return self
+     */
+    public function setReleaseDate(?array $releaseDate = null)
+    {
+        $this->releaseDate = $releaseDate;
+        return $this;
+    }
+
+    /**
+     * Adds as originalReleaseDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the collection of tracks for the Release (e.g. the equivalent physical album on vinyl) was or will be first made available for Usage, whether for physical or electronic/online distribution (in ISO 8601 format: YYYY[-MM[-DD]]). This Element is for display and cataloguing purposes only.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\EventDateWithDefaultType $originalReleaseDate
+     */
+    public function addToOriginalReleaseDate(\DedexBundle\Entity\Ern42\EventDateWithDefaultType $originalReleaseDate)
+    {
+        $this->originalReleaseDate[] = $originalReleaseDate;
+        return $this;
+    }
+
+    /**
+     * isset originalReleaseDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the collection of tracks for the Release (e.g. the equivalent physical album on vinyl) was or will be first made available for Usage, whether for physical or electronic/online distribution (in ISO 8601 format: YYYY[-MM[-DD]]). This Element is for display and cataloguing purposes only.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetOriginalReleaseDate($index)
+    {
+        return isset($this->originalReleaseDate[$index]);
+    }
+
+    /**
+     * unset originalReleaseDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the collection of tracks for the Release (e.g. the equivalent physical album on vinyl) was or will be first made available for Usage, whether for physical or electronic/online distribution (in ISO 8601 format: YYYY[-MM[-DD]]). This Element is for display and cataloguing purposes only.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetOriginalReleaseDate($index)
+    {
+        unset($this->originalReleaseDate[$index]);
+    }
+
+    /**
+     * Gets as originalReleaseDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the collection of tracks for the Release (e.g. the equivalent physical album on vinyl) was or will be first made available for Usage, whether for physical or electronic/online distribution (in ISO 8601 format: YYYY[-MM[-DD]]). This Element is for display and cataloguing purposes only.
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateWithDefaultType[]
+     */
+    public function getOriginalReleaseDate()
+    {
+        return $this->originalReleaseDate;
+    }
+
+    /**
+     * Sets a new originalReleaseDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the collection of tracks for the Release (e.g. the equivalent physical album on vinyl) was or will be first made available for Usage, whether for physical or electronic/online distribution (in ISO 8601 format: YYYY[-MM[-DD]]). This Element is for display and cataloguing purposes only.
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateWithDefaultType[] $originalReleaseDate
+     * @return self
+     */
+    public function setOriginalReleaseDate(?array $originalReleaseDate = null)
+    {
+        $this->originalReleaseDate = $originalReleaseDate;
+        return $this;
+    }
+
+    /**
+     * Gets as releaseVisibilityReference
+     *
+     * A Reference for a set of visibility dates (specific to this Message) that applies to this Release. This defines when the Release can be shown to Consumers, not when a Consumer can get access to the Release. This is a LocalVisibilityAnchorReference starting with the letter V.
+     *
+     * @return string
+     */
+    public function getReleaseVisibilityReference()
+    {
+        return $this->releaseVisibilityReference;
+    }
+
+    /**
+     * Sets a new releaseVisibilityReference
+     *
+     * A Reference for a set of visibility dates (specific to this Message) that applies to this Release. This defines when the Release can be shown to Consumers, not when a Consumer can get access to the Release. This is a LocalVisibilityAnchorReference starting with the letter V.
+     *
+     * @param string $releaseVisibilityReference
+     * @return self
+     */
+    public function setReleaseVisibilityReference($releaseVisibilityReference)
+    {
+        $this->releaseVisibilityReference = $releaseVisibilityReference;
+        return $this;
+    }
+
+    /**
+     * Adds as parentalWarningType
+     *
+     * A Composite containing details of the classification of the Release according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType $parentalWarningType
+     */
+    public function addToParentalWarningType(\DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType $parentalWarningType)
+    {
+        $this->parentalWarningType[] = $parentalWarningType;
+        return $this;
+    }
+
+    /**
+     * isset parentalWarningType
+     *
+     * A Composite containing details of the classification of the Release according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetParentalWarningType($index)
+    {
+        return isset($this->parentalWarningType[$index]);
+    }
+
+    /**
+     * unset parentalWarningType
+     *
+     * A Composite containing details of the classification of the Release according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetParentalWarningType($index)
+    {
+        unset($this->parentalWarningType[$index]);
+    }
+
+    /**
+     * Gets as parentalWarningType
+     *
+     * A Composite containing details of the classification of the Release according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @return \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType[]
+     */
+    public function getParentalWarningType()
+    {
+        return $this->parentalWarningType;
+    }
+
+    /**
+     * Sets a new parentalWarningType
+     *
+     * A Composite containing details of the classification of the Release according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @param \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType[] $parentalWarningType
+     * @return self
+     */
+    public function setParentalWarningType(array $parentalWarningType)
+    {
+        $this->parentalWarningType = $parentalWarningType;
+        return $this;
+    }
+
+    /**
+     * Adds as avRating
+     *
+     * A Composite containing details of a rating for the Release.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\AvRatingType $avRating
+     */
+    public function addToAvRating(\DedexBundle\Entity\Ern42\AvRatingType $avRating)
+    {
+        $this->avRating[] = $avRating;
+        return $this;
+    }
+
+    /**
+     * isset avRating
+     *
+     * A Composite containing details of a rating for the Release.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetAvRating($index)
+    {
+        return isset($this->avRating[$index]);
+    }
+
+    /**
+     * unset avRating
+     *
+     * A Composite containing details of a rating for the Release.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetAvRating($index)
+    {
+        unset($this->avRating[$index]);
+    }
+
+    /**
+     * Gets as avRating
+     *
+     * A Composite containing details of a rating for the Release.
+     *
+     * @return \DedexBundle\Entity\Ern42\AvRatingType[]
+     */
+    public function getAvRating()
+    {
+        return $this->avRating;
+    }
+
+    /**
+     * Sets a new avRating
+     *
+     * A Composite containing details of a rating for the Release.
+     *
+     * @param \DedexBundle\Entity\Ern42\AvRatingType[] $avRating
+     * @return self
+     */
+    public function setAvRating(?array $avRating = null)
+    {
+        $this->avRating = $avRating;
+        return $this;
+    }
+
+    /**
+     * Adds as relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to this Release.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\RelatedReleaseType $relatedRelease
+     */
+    public function addToRelatedRelease(\DedexBundle\Entity\Ern42\RelatedReleaseType $relatedRelease)
+    {
+        $this->relatedRelease[] = $relatedRelease;
+        return $this;
+    }
+
+    /**
+     * isset relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to this Release.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRelatedRelease($index)
+    {
+        return isset($this->relatedRelease[$index]);
+    }
+
+    /**
+     * unset relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to this Release.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRelatedRelease($index)
+    {
+        unset($this->relatedRelease[$index]);
+    }
+
+    /**
+     * Gets as relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to this Release.
+     *
+     * @return \DedexBundle\Entity\Ern42\RelatedReleaseType[]
+     */
+    public function getRelatedRelease()
+    {
+        return $this->relatedRelease;
+    }
+
+    /**
+     * Sets a new relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to this Release.
+     *
+     * @param \DedexBundle\Entity\Ern42\RelatedReleaseType[] $relatedRelease
+     * @return self
+     */
+    public function setRelatedRelease(?array $relatedRelease = null)
+    {
+        $this->relatedRelease = $relatedRelease;
+        return $this;
+    }
+
+    /**
+     * Adds as relatedResource
+     *
+     * A Composite containing details of a Resource which is related to this Release.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\RelatedResourceType $relatedResource
+     */
+    public function addToRelatedResource(\DedexBundle\Entity\Ern42\RelatedResourceType $relatedResource)
+    {
+        $this->relatedResource[] = $relatedResource;
+        return $this;
+    }
+
+    /**
+     * isset relatedResource
+     *
+     * A Composite containing details of a Resource which is related to this Release.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRelatedResource($index)
+    {
+        return isset($this->relatedResource[$index]);
+    }
+
+    /**
+     * unset relatedResource
+     *
+     * A Composite containing details of a Resource which is related to this Release.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRelatedResource($index)
+    {
+        unset($this->relatedResource[$index]);
+    }
+
+    /**
+     * Gets as relatedResource
+     *
+     * A Composite containing details of a Resource which is related to this Release.
+     *
+     * @return \DedexBundle\Entity\Ern42\RelatedResourceType[]
+     */
+    public function getRelatedResource()
+    {
+        return $this->relatedResource;
+    }
+
+    /**
+     * Sets a new relatedResource
+     *
+     * A Composite containing details of a Resource which is related to this Release.
+     *
+     * @param \DedexBundle\Entity\Ern42\RelatedResourceType[] $relatedResource
+     * @return self
+     */
+    public function setRelatedResource(?array $relatedResource = null)
+    {
+        $this->relatedResource = $relatedResource;
+        return $this;
+    }
+
+    /**
+     * Gets as isSingleArtistCompilation
+     *
+     * A Flag indicating whether the Release is a single-artist Compilation (=true) or not (=false). If this flag is set, the Release would typically be expected to be part of the discography of the main artist of the Release.
+     *
+     * @return bool
+     */
+    public function getIsSingleArtistCompilation()
+    {
+        return $this->isSingleArtistCompilation;
+    }
+
+    /**
+     * Sets a new isSingleArtistCompilation
+     *
+     * A Flag indicating whether the Release is a single-artist Compilation (=true) or not (=false). If this flag is set, the Release would typically be expected to be part of the discography of the main artist of the Release.
+     *
+     * @param bool $isSingleArtistCompilation
+     * @return self
+     */
+    public function setIsSingleArtistCompilation($isSingleArtistCompilation)
+    {
+        $this->isSingleArtistCompilation = $isSingleArtistCompilation;
+        return $this;
+    }
+
+    /**
+     * Gets as isMultiArtistCompilation
+     *
+     * The Flag indicating whether the Release is a multiartist Compilation (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getIsMultiArtistCompilation()
+    {
+        return $this->isMultiArtistCompilation;
+    }
+
+    /**
+     * Sets a new isMultiArtistCompilation
+     *
+     * The Flag indicating whether the Release is a multiartist Compilation (=true) or not (=false).
+     *
+     * @param bool $isMultiArtistCompilation
+     * @return self
+     */
+    public function setIsMultiArtistCompilation($isMultiArtistCompilation)
+    {
+        $this->isMultiArtistCompilation = $isMultiArtistCompilation;
+        return $this;
+    }
+
+    /**
+     * Gets as resourceGroup
+     *
+     * A Composite containing details of a group of some or all of the Resources in the Release. ResourceGroups are used to signal groupings or sequences of Resources within a Release. Examples include individual carriers in a multi-carrier Release or classical Work groupings as well as the default order of Resources within a Release. ResourceGroups are typically not used with Releases that contain only one primary Resource such as TrackReleases.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/sequencing-resources
+     *
+     * @return \DedexBundle\Entity\Ern42\ResourceGroupType
+     */
+    public function getResourceGroup()
+    {
+        return $this->resourceGroup;
+    }
+
+    /**
+     * Sets a new resourceGroup
+     *
+     * A Composite containing details of a group of some or all of the Resources in the Release. ResourceGroups are used to signal groupings or sequences of Resources within a Release. Examples include individual carriers in a multi-carrier Release or classical Work groupings as well as the default order of Resources within a Release. ResourceGroups are typically not used with Releases that contain only one primary Resource such as TrackReleases.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/sequencing-resources
+     *
+     * @param \DedexBundle\Entity\Ern42\ResourceGroupType $resourceGroup
+     * @return self
+     */
+    public function setResourceGroup(\DedexBundle\Entity\Ern42\ResourceGroupType $resourceGroup)
+    {
+        $this->resourceGroup = $resourceGroup;
+        return $this;
+    }
+
+    /**
+     * Adds as externalResourceLink
+     *
+     * A Composite containing details of promotional or other material related to the Release.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ExternalResourceLinkType $externalResourceLink
+     */
+    public function addToExternalResourceLink(\DedexBundle\Entity\Ern42\ExternalResourceLinkType $externalResourceLink)
+    {
+        $this->externalResourceLink[] = $externalResourceLink;
+        return $this;
+    }
+
+    /**
+     * isset externalResourceLink
+     *
+     * A Composite containing details of promotional or other material related to the Release.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetExternalResourceLink($index)
+    {
+        return isset($this->externalResourceLink[$index]);
+    }
+
+    /**
+     * unset externalResourceLink
+     *
+     * A Composite containing details of promotional or other material related to the Release.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetExternalResourceLink($index)
+    {
+        unset($this->externalResourceLink[$index]);
+    }
+
+    /**
+     * Gets as externalResourceLink
+     *
+     * A Composite containing details of promotional or other material related to the Release.
+     *
+     * @return \DedexBundle\Entity\Ern42\ExternalResourceLinkType[]
+     */
+    public function getExternalResourceLink()
+    {
+        return $this->externalResourceLink;
+    }
+
+    /**
+     * Sets a new externalResourceLink
+     *
+     * A Composite containing details of promotional or other material related to the Release.
+     *
+     * @param \DedexBundle\Entity\Ern42\ExternalResourceLinkType[] $externalResourceLink
+     * @return self
+     */
+    public function setExternalResourceLink(?array $externalResourceLink = null)
+    {
+        $this->externalResourceLink = $externalResourceLink;
+        return $this;
+    }
+
+    /**
+     * Gets as targetURL
+     *
+     * A URL of a sub-site or channel in the DSP’s system, where the Release should be made available to Consumers.
+     *
+     * @return string
+     */
+    public function getTargetURL()
+    {
+        return $this->targetURL;
+    }
+
+    /**
+     * Sets a new targetURL
+     *
+     * A URL of a sub-site or channel in the DSP’s system, where the Release should be made available to Consumers.
+     *
+     * @param string $targetURL
+     * @return self
+     */
+    public function setTargetURL($targetURL)
+    {
+        $this->targetURL = $targetURL;
+        return $this;
+    }
+
+    /**
+     * Adds as keywords
+     *
+     * A Composite containing details of a Description of the Release containing Keywords.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\KeywordsWithTerritoryType $keywords
+     */
+    public function addToKeywords(\DedexBundle\Entity\Ern42\KeywordsWithTerritoryType $keywords)
+    {
+        $this->keywords[] = $keywords;
+        return $this;
+    }
+
+    /**
+     * isset keywords
+     *
+     * A Composite containing details of a Description of the Release containing Keywords.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetKeywords($index)
+    {
+        return isset($this->keywords[$index]);
+    }
+
+    /**
+     * unset keywords
+     *
+     * A Composite containing details of a Description of the Release containing Keywords.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetKeywords($index)
+    {
+        unset($this->keywords[$index]);
+    }
+
+    /**
+     * Gets as keywords
+     *
+     * A Composite containing details of a Description of the Release containing Keywords.
+     *
+     * @return \DedexBundle\Entity\Ern42\KeywordsWithTerritoryType[]
+     */
+    public function getKeywords()
+    {
+        return $this->keywords;
+    }
+
+    /**
+     * Sets a new keywords
+     *
+     * A Composite containing details of a Description of the Release containing Keywords.
+     *
+     * @param \DedexBundle\Entity\Ern42\KeywordsWithTerritoryType[] $keywords
+     * @return self
+     */
+    public function setKeywords(?array $keywords = null)
+    {
+        $this->keywords = $keywords;
+        return $this;
+    }
+
+    /**
+     * Adds as synopsis
+     *
+     * A Composite containing details of a Synopsis of the Release.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\SynopsisWithTerritoryType $synopsis
+     */
+    public function addToSynopsis(\DedexBundle\Entity\Ern42\SynopsisWithTerritoryType $synopsis)
+    {
+        $this->synopsis[] = $synopsis;
+        return $this;
+    }
+
+    /**
+     * isset synopsis
+     *
+     * A Composite containing details of a Synopsis of the Release.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetSynopsis($index)
+    {
+        return isset($this->synopsis[$index]);
+    }
+
+    /**
+     * unset synopsis
+     *
+     * A Composite containing details of a Synopsis of the Release.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetSynopsis($index)
+    {
+        unset($this->synopsis[$index]);
+    }
+
+    /**
+     * Gets as synopsis
+     *
+     * A Composite containing details of a Synopsis of the Release.
+     *
+     * @return \DedexBundle\Entity\Ern42\SynopsisWithTerritoryType[]
+     */
+    public function getSynopsis()
+    {
+        return $this->synopsis;
+    }
+
+    /**
+     * Sets a new synopsis
+     *
+     * A Composite containing details of a Synopsis of the Release.
+     *
+     * @param \DedexBundle\Entity\Ern42\SynopsisWithTerritoryType[] $synopsis
+     * @return self
+     */
+    public function setSynopsis(?array $synopsis = null)
+    {
+        $this->synopsis = $synopsis;
+        return $this;
+    }
+
+    /**
+     * Adds as raga
+     *
+     * A Description of the melodic mode of a MusicalWork in the Release.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\RagaType $raga
+     */
+    public function addToRaga(\DedexBundle\Entity\Ern42\RagaType $raga)
+    {
+        $this->raga[] = $raga;
+        return $this;
+    }
+
+    /**
+     * isset raga
+     *
+     * A Description of the melodic mode of a MusicalWork in the Release.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRaga($index)
+    {
+        return isset($this->raga[$index]);
+    }
+
+    /**
+     * unset raga
+     *
+     * A Description of the melodic mode of a MusicalWork in the Release.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRaga($index)
+    {
+        unset($this->raga[$index]);
+    }
+
+    /**
+     * Gets as raga
+     *
+     * A Description of the melodic mode of a MusicalWork in the Release.
+     *
+     * @return \DedexBundle\Entity\Ern42\RagaType[]
+     */
+    public function getRaga()
+    {
+        return $this->raga;
+    }
+
+    /**
+     * Sets a new raga
+     *
+     * A Description of the melodic mode of a MusicalWork in the Release.
+     *
+     * @param \DedexBundle\Entity\Ern42\RagaType[] $raga
+     * @return self
+     */
+    public function setRaga(?array $raga = null)
+    {
+        $this->raga = $raga;
+        return $this;
+    }
+
+    /**
+     * Adds as tala
+     *
+     * A Description of the rhythmic pattern of a MusicalWork in the Release.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\TalaType $tala
+     */
+    public function addToTala(\DedexBundle\Entity\Ern42\TalaType $tala)
+    {
+        $this->tala[] = $tala;
+        return $this;
+    }
+
+    /**
+     * isset tala
+     *
+     * A Description of the rhythmic pattern of a MusicalWork in the Release.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetTala($index)
+    {
+        return isset($this->tala[$index]);
+    }
+
+    /**
+     * unset tala
+     *
+     * A Description of the rhythmic pattern of a MusicalWork in the Release.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetTala($index)
+    {
+        unset($this->tala[$index]);
+    }
+
+    /**
+     * Gets as tala
+     *
+     * A Description of the rhythmic pattern of a MusicalWork in the Release.
+     *
+     * @return \DedexBundle\Entity\Ern42\TalaType[]
+     */
+    public function getTala()
+    {
+        return $this->tala;
+    }
+
+    /**
+     * Sets a new tala
+     *
+     * A Description of the rhythmic pattern of a MusicalWork in the Release.
+     *
+     * @param \DedexBundle\Entity\Ern42\TalaType[] $tala
+     * @return self
+     */
+    public function setTala(?array $tala = null)
+    {
+        $this->tala = $tala;
+        return $this;
+    }
+
+    /**
+     * Adds as deity
+     *
+     * A deity name relating to the Release.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DeityType $deity
+     */
+    public function addToDeity(\DedexBundle\Entity\Ern42\DeityType $deity)
+    {
+        $this->deity[] = $deity;
+        return $this;
+    }
+
+    /**
+     * isset deity
+     *
+     * A deity name relating to the Release.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDeity($index)
+    {
+        return isset($this->deity[$index]);
+    }
+
+    /**
+     * unset deity
+     *
+     * A deity name relating to the Release.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDeity($index)
+    {
+        unset($this->deity[$index]);
+    }
+
+    /**
+     * Gets as deity
+     *
+     * A deity name relating to the Release.
+     *
+     * @return \DedexBundle\Entity\Ern42\DeityType[]
+     */
+    public function getDeity()
+    {
+        return $this->deity;
+    }
+
+    /**
+     * Sets a new deity
+     *
+     * A deity name relating to the Release.
+     *
+     * @param \DedexBundle\Entity\Ern42\DeityType[] $deity
+     * @return self
+     */
+    public function setDeity(?array $deity = null)
+    {
+        $this->deity = $deity;
+        return $this;
+    }
+
+    /**
+     * Gets as hiResMusicDescription
+     *
+     * A Description containing an explanation that is required if not all the Tracks are eligible for HiResMusic (e.g. if some tracks were up-sampled to 96 kHz/24 bit from a 44.1 kHz/24 bit source during mastering).
+     *
+     * @return string
+     */
+    public function getHiResMusicDescription()
+    {
+        return $this->hiResMusicDescription;
+    }
+
+    /**
+     * Sets a new hiResMusicDescription
+     *
+     * A Description containing an explanation that is required if not all the Tracks are eligible for HiResMusic (e.g. if some tracks were up-sampled to 96 kHz/24 bit from a 44.1 kHz/24 bit source during mastering).
+     *
+     * @param string $hiResMusicDescription
+     * @return self
+     */
+    public function setHiResMusicDescription($hiResMusicDescription)
+    {
+        $this->hiResMusicDescription = $hiResMusicDescription;
+        return $this;
+    }
+
+    /**
+     * Gets as isSoundtrack
+     *
+     * The Flag indicating whether the Release is a Soundtrack (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getIsSoundtrack()
+    {
+        return $this->isSoundtrack;
+    }
+
+    /**
+     * Sets a new isSoundtrack
+     *
+     * The Flag indicating whether the Release is a Soundtrack (=true) or not (=false).
+     *
+     * @param bool $isSoundtrack
+     * @return self
+     */
+    public function setIsSoundtrack($isSoundtrack)
+    {
+        $this->isSoundtrack = $isSoundtrack;
+        return $this;
+    }
+
+    /**
+     * Gets as isHiResMusic
+     *
+     * The Flag indicating whether the Release meets the criteria to carry the HiResMusic logo, provided the MessageRecipient meets all the other requirements to use it (note that an album with a majority of tracks being eligible but the remainder not being eligible can still carry the logo) (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getIsHiResMusic()
+    {
+        return $this->isHiResMusic;
+    }
+
+    /**
+     * Sets a new isHiResMusic
+     *
+     * The Flag indicating whether the Release meets the criteria to carry the HiResMusic logo, provided the MessageRecipient meets all the other requirements to use it (note that an album with a majority of tracks being eligible but the remainder not being eligible can still carry the logo) (=true) or not (=false).
+     *
+     * @param bool $isHiResMusic
+     * @return self
+     */
+    public function setIsHiResMusic($isHiResMusic)
+    {
+        $this->isHiResMusic = $isHiResMusic;
+        return $this;
+    }
+
+    /**
+     * Adds as marketingComment
+     *
+     * A Composite containing a Comment about the promotion and marketing of the Release.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\MarketingCommentType $marketingComment
+     */
+    public function addToMarketingComment(\DedexBundle\Entity\Ern42\MarketingCommentType $marketingComment)
+    {
+        $this->marketingComment[] = $marketingComment;
+        return $this;
+    }
+
+    /**
+     * isset marketingComment
+     *
+     * A Composite containing a Comment about the promotion and marketing of the Release.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetMarketingComment($index)
+    {
+        return isset($this->marketingComment[$index]);
+    }
+
+    /**
+     * unset marketingComment
+     *
+     * A Composite containing a Comment about the promotion and marketing of the Release.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetMarketingComment($index)
+    {
+        unset($this->marketingComment[$index]);
+    }
+
+    /**
+     * Gets as marketingComment
+     *
+     * A Composite containing a Comment about the promotion and marketing of the Release.
+     *
+     * @return \DedexBundle\Entity\Ern42\MarketingCommentType[]
+     */
+    public function getMarketingComment()
+    {
+        return $this->marketingComment;
+    }
+
+    /**
+     * Sets a new marketingComment
+     *
+     * A Composite containing a Comment about the promotion and marketing of the Release.
+     *
+     * @param \DedexBundle\Entity\Ern42\MarketingCommentType[] $marketingComment
+     * @return self
+     */
+    public function setMarketingComment(?array $marketingComment = null)
+    {
+        $this->marketingComment = $marketingComment;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ReleaseTypeForReleaseNotificationType.php
+++ b/src/Entity/Ern42/ReleaseTypeForReleaseNotificationType.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ReleaseTypeForReleaseNotificationType
+ *
+ * A Composite containing details of a ReleaseType.
+ * Explanatory Note: This Composite is named ReleaseTypeForReleaseNotification to disambiguate it from the basic ReleaseType Composite. The name indicates that it is ERN specific.
+ * XSD Type: ReleaseTypeForReleaseNotification
+ */
+class ReleaseTypeForReleaseNotificationType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the ReleaseType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the ReleaseType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the ReleaseType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the ReleaseType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the ReleaseType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the ReleaseType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ReleaseVisibilityType.php
+++ b/src/Entity/Ern42/ReleaseVisibilityType.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ReleaseVisibilityType
+ *
+ * A Composite containing details of Dates specifying when a Release can be shown to Consumers.
+ * XSD Type: ReleaseVisibility
+ */
+class ReleaseVisibilityType
+{
+    /**
+     * The Identifier (specific to the Message) of the visibility date. This is a LocalVisibilityAnchor starting with the letter V.
+     *
+     * @var string $visibilityReference
+     */
+    private $visibilityReference = null;
+
+    /**
+     * A DateTime on which the Release is made first available for display. If no ReleaseDisplayStartDateTime is provided, the StartDate for the Deal is used instead. The ReleaseDisplayStartDateTime may not be later than the StartDate for the Deal. If the MessageRecipient is not able to cater for such granular display policies, the MessageRecipient may be forced to not display any Release information until a much later date. This is a string in ISO 8601 format: YYYY-MM-DDThh:mm:ss.
+     *
+     * @var \DateTime $releaseDisplayStartDateTime
+     */
+    private $releaseDisplayStartDateTime = null;
+
+    /**
+     * A DateTime on which the cover art is made first available for display (it overrides the generic ReleaseDisplayStartDate if supplied). If no CoverArtPreviewStartDateTime is provided, the StartDate for the Deal is used instead. The CoverArtPreviewStartDateTime shall not be later than the StartDate of the Deal allowing the general availability of the referenced Release. This is a string in ISO 8601 format: YYYY-MM-DDThh:mm:ss.
+     *
+     * @var \DateTime $coverArtPreviewStartDateTime
+     */
+    private $coverArtPreviewStartDateTime = null;
+
+    /**
+     * A DateTime on which the full Track list is made first available for display (it overrides the generic ReleaseDisplayStartDate if supplied). If no TrackListingPreviewStartDateTime is provided, the StartDate for the Deal is used instead. The TrackListingPreviewStartDateTime shall not be later than the StartDate of the Deal allowing the general availability of the referenced Release. This element is not applicable on Track Releases. This is a string in ISO 8601 format: YYYY-MM-DDThh:mm:ss.
+     *
+     * @var \DateTime $fullTrackListingPreviewStartDateTime
+     */
+    private $fullTrackListingPreviewStartDateTime = null;
+
+    /**
+     * Gets as visibilityReference
+     *
+     * The Identifier (specific to the Message) of the visibility date. This is a LocalVisibilityAnchor starting with the letter V.
+     *
+     * @return string
+     */
+    public function getVisibilityReference()
+    {
+        return $this->visibilityReference;
+    }
+
+    /**
+     * Sets a new visibilityReference
+     *
+     * The Identifier (specific to the Message) of the visibility date. This is a LocalVisibilityAnchor starting with the letter V.
+     *
+     * @param string $visibilityReference
+     * @return self
+     */
+    public function setVisibilityReference($visibilityReference)
+    {
+        $this->visibilityReference = $visibilityReference;
+        return $this;
+    }
+
+    /**
+     * Gets as releaseDisplayStartDateTime
+     *
+     * A DateTime on which the Release is made first available for display. If no ReleaseDisplayStartDateTime is provided, the StartDate for the Deal is used instead. The ReleaseDisplayStartDateTime may not be later than the StartDate for the Deal. If the MessageRecipient is not able to cater for such granular display policies, the MessageRecipient may be forced to not display any Release information until a much later date. This is a string in ISO 8601 format: YYYY-MM-DDThh:mm:ss.
+     *
+     * @return \DateTime
+     */
+    public function getReleaseDisplayStartDateTime()
+    {
+        return $this->releaseDisplayStartDateTime;
+    }
+
+    /**
+     * Sets a new releaseDisplayStartDateTime
+     *
+     * A DateTime on which the Release is made first available for display. If no ReleaseDisplayStartDateTime is provided, the StartDate for the Deal is used instead. The ReleaseDisplayStartDateTime may not be later than the StartDate for the Deal. If the MessageRecipient is not able to cater for such granular display policies, the MessageRecipient may be forced to not display any Release information until a much later date. This is a string in ISO 8601 format: YYYY-MM-DDThh:mm:ss.
+     *
+     * @param \DateTime $releaseDisplayStartDateTime
+     * @return self
+     */
+    public function setReleaseDisplayStartDateTime(?\DateTime $releaseDisplayStartDateTime = null)
+    {
+        $this->releaseDisplayStartDateTime = $releaseDisplayStartDateTime;
+        return $this;
+    }
+
+    /**
+     * Gets as coverArtPreviewStartDateTime
+     *
+     * A DateTime on which the cover art is made first available for display (it overrides the generic ReleaseDisplayStartDate if supplied). If no CoverArtPreviewStartDateTime is provided, the StartDate for the Deal is used instead. The CoverArtPreviewStartDateTime shall not be later than the StartDate of the Deal allowing the general availability of the referenced Release. This is a string in ISO 8601 format: YYYY-MM-DDThh:mm:ss.
+     *
+     * @return \DateTime
+     */
+    public function getCoverArtPreviewStartDateTime()
+    {
+        return $this->coverArtPreviewStartDateTime;
+    }
+
+    /**
+     * Sets a new coverArtPreviewStartDateTime
+     *
+     * A DateTime on which the cover art is made first available for display (it overrides the generic ReleaseDisplayStartDate if supplied). If no CoverArtPreviewStartDateTime is provided, the StartDate for the Deal is used instead. The CoverArtPreviewStartDateTime shall not be later than the StartDate of the Deal allowing the general availability of the referenced Release. This is a string in ISO 8601 format: YYYY-MM-DDThh:mm:ss.
+     *
+     * @param \DateTime $coverArtPreviewStartDateTime
+     * @return self
+     */
+    public function setCoverArtPreviewStartDateTime(?\DateTime $coverArtPreviewStartDateTime = null)
+    {
+        $this->coverArtPreviewStartDateTime = $coverArtPreviewStartDateTime;
+        return $this;
+    }
+
+    /**
+     * Gets as fullTrackListingPreviewStartDateTime
+     *
+     * A DateTime on which the full Track list is made first available for display (it overrides the generic ReleaseDisplayStartDate if supplied). If no TrackListingPreviewStartDateTime is provided, the StartDate for the Deal is used instead. The TrackListingPreviewStartDateTime shall not be later than the StartDate of the Deal allowing the general availability of the referenced Release. This element is not applicable on Track Releases. This is a string in ISO 8601 format: YYYY-MM-DDThh:mm:ss.
+     *
+     * @return \DateTime
+     */
+    public function getFullTrackListingPreviewStartDateTime()
+    {
+        return $this->fullTrackListingPreviewStartDateTime;
+    }
+
+    /**
+     * Sets a new fullTrackListingPreviewStartDateTime
+     *
+     * A DateTime on which the full Track list is made first available for display (it overrides the generic ReleaseDisplayStartDate if supplied). If no TrackListingPreviewStartDateTime is provided, the StartDate for the Deal is used instead. The TrackListingPreviewStartDateTime shall not be later than the StartDate of the Deal allowing the general availability of the referenced Release. This element is not applicable on Track Releases. This is a string in ISO 8601 format: YYYY-MM-DDThh:mm:ss.
+     *
+     * @param \DateTime $fullTrackListingPreviewStartDateTime
+     * @return self
+     */
+    public function setFullTrackListingPreviewStartDateTime(?\DateTime $fullTrackListingPreviewStartDateTime = null)
+    {
+        $this->fullTrackListingPreviewStartDateTime = $fullTrackListingPreviewStartDateTime;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ResourceContainedResourceReferenceListType.php
+++ b/src/Entity/Ern42/ResourceContainedResourceReferenceListType.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ResourceContainedResourceReferenceListType
+ *
+ * A Composite containing details of one or more ResourceContainedResourceReferences.
+ * XSD Type: ResourceContainedResourceReferenceList
+ */
+class ResourceContainedResourceReferenceListType
+{
+    /**
+     * A Composite containing details of a ResourceContainedResourceReference.
+     *
+     * @var \DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType[] $resourceContainedResourceReference
+     */
+    private $resourceContainedResourceReference = [
+        
+    ];
+
+    /**
+     * Adds as resourceContainedResourceReference
+     *
+     * A Composite containing details of a ResourceContainedResourceReference.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType $resourceContainedResourceReference
+     */
+    public function addToResourceContainedResourceReference(\DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType $resourceContainedResourceReference)
+    {
+        $this->resourceContainedResourceReference[] = $resourceContainedResourceReference;
+        return $this;
+    }
+
+    /**
+     * isset resourceContainedResourceReference
+     *
+     * A Composite containing details of a ResourceContainedResourceReference.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetResourceContainedResourceReference($index)
+    {
+        return isset($this->resourceContainedResourceReference[$index]);
+    }
+
+    /**
+     * unset resourceContainedResourceReference
+     *
+     * A Composite containing details of a ResourceContainedResourceReference.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetResourceContainedResourceReference($index)
+    {
+        unset($this->resourceContainedResourceReference[$index]);
+    }
+
+    /**
+     * Gets as resourceContainedResourceReference
+     *
+     * A Composite containing details of a ResourceContainedResourceReference.
+     *
+     * @return \DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType[]
+     */
+    public function getResourceContainedResourceReference()
+    {
+        return $this->resourceContainedResourceReference;
+    }
+
+    /**
+     * Sets a new resourceContainedResourceReference
+     *
+     * A Composite containing details of a ResourceContainedResourceReference.
+     *
+     * @param \DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType[] $resourceContainedResourceReference
+     * @return self
+     */
+    public function setResourceContainedResourceReference(array $resourceContainedResourceReference)
+    {
+        $this->resourceContainedResourceReference = $resourceContainedResourceReference;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ResourceContainedResourceReferenceType.php
+++ b/src/Entity/Ern42/ResourceContainedResourceReferenceType.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ResourceContainedResourceReferenceType
+ *
+ * A Composite containing details of a ResourceContainedResourceReference for the case where one Resource contains another one.
+ * XSD Type: ResourceContainedResourceReference
+ */
+class ResourceContainedResourceReferenceType
+{
+    /**
+     * A Reference for a Resource (specific to this Message). This is a LocalResourceAnchorReference starting with the letter A.
+     *
+     * @var string $resourceContainedResourceReference
+     */
+    private $resourceContainedResourceReference = null;
+
+    /**
+     * The total Duration of the Resource that has been used in a specified context (this may be less than the total Duration of the Resource) (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @var \DateInterval $durationUsed
+     */
+    private $durationUsed = null;
+
+    /**
+     * The start point of the preview given in seconds from the start of the referenced Resource.
+     *
+     * @var float $startPoint
+     */
+    private $startPoint = null;
+
+    /**
+     * A Composite containing details of the Purpose of the usage.
+     *
+     * @var \DedexBundle\Entity\Ern42\PurposeType $purpose
+     */
+    private $purpose = null;
+
+    /**
+     * Gets as resourceContainedResourceReference
+     *
+     * A Reference for a Resource (specific to this Message). This is a LocalResourceAnchorReference starting with the letter A.
+     *
+     * @return string
+     */
+    public function getResourceContainedResourceReference()
+    {
+        return $this->resourceContainedResourceReference;
+    }
+
+    /**
+     * Sets a new resourceContainedResourceReference
+     *
+     * A Reference for a Resource (specific to this Message). This is a LocalResourceAnchorReference starting with the letter A.
+     *
+     * @param string $resourceContainedResourceReference
+     * @return self
+     */
+    public function setResourceContainedResourceReference($resourceContainedResourceReference)
+    {
+        $this->resourceContainedResourceReference = $resourceContainedResourceReference;
+        return $this;
+    }
+
+    /**
+     * Gets as durationUsed
+     *
+     * The total Duration of the Resource that has been used in a specified context (this may be less than the total Duration of the Resource) (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @return \DateInterval
+     */
+    public function getDurationUsed()
+    {
+        return $this->durationUsed;
+    }
+
+    /**
+     * Sets a new durationUsed
+     *
+     * The total Duration of the Resource that has been used in a specified context (this may be less than the total Duration of the Resource) (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @param \DateInterval $durationUsed
+     * @return self
+     */
+    public function setDurationUsed(?\DateInterval $durationUsed = null)
+    {
+        $this->durationUsed = $durationUsed;
+        return $this;
+    }
+
+    /**
+     * Gets as startPoint
+     *
+     * The start point of the preview given in seconds from the start of the referenced Resource.
+     *
+     * @return float
+     */
+    public function getStartPoint()
+    {
+        return $this->startPoint;
+    }
+
+    /**
+     * Sets a new startPoint
+     *
+     * The start point of the preview given in seconds from the start of the referenced Resource.
+     *
+     * @param float $startPoint
+     * @return self
+     */
+    public function setStartPoint($startPoint)
+    {
+        $this->startPoint = $startPoint;
+        return $this;
+    }
+
+    /**
+     * Gets as purpose
+     *
+     * A Composite containing details of the Purpose of the usage.
+     *
+     * @return \DedexBundle\Entity\Ern42\PurposeType
+     */
+    public function getPurpose()
+    {
+        return $this->purpose;
+    }
+
+    /**
+     * Sets a new purpose
+     *
+     * A Composite containing details of the Purpose of the usage.
+     *
+     * @param \DedexBundle\Entity\Ern42\PurposeType $purpose
+     * @return self
+     */
+    public function setPurpose(?\DedexBundle\Entity\Ern42\PurposeType $purpose = null)
+    {
+        $this->purpose = $purpose;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ResourceContributorRoleType.php
+++ b/src/Entity/Ern42/ResourceContributorRoleType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ResourceContributorRoleType
+ *
+ * A Composite containing details of a StudioRole.
+ * XSD Type: ResourceContributorRole
+ */
+class ResourceContributorRoleType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the StudioRole. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the StudioRole. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the StudioRole. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the StudioRole. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the StudioRole. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the StudioRole. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ResourceGroupContentItemType.php
+++ b/src/Entity/Ern42/ResourceGroupContentItemType.php
@@ -1,0 +1,319 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ResourceGroupContentItemType
+ *
+ * A Composite containing details of a Resource which is a ContentItem of a ResourceGroup.
+ * XSD Type: ResourceGroupContentItem
+ */
+class ResourceGroupContentItemType
+{
+    /**
+     * The number indicating the logical order of the ContentItem in its ResourceGroup.
+     *
+     * @var int $sequenceNumber
+     */
+    private $sequenceNumber = null;
+
+    /**
+     * A Flag indicating whether a display sequence exists (=true) or not (=false).
+     *
+     * @var bool $noDisplaySequence
+     */
+    private $noDisplaySequence = null;
+
+    /**
+     * A sequence Identifier used for display purposes, consisting of a string that corresponds to the SequenceNumber, e.g. 'Side B' corresponding to '2'.
+     *
+     * @var string $displaySequence
+     */
+    private $displaySequence = null;
+
+    /**
+     * A ReleaseResourceReference for the ContentItem (specific to this Message). The LocalAnchorReference in this Composite is a xs:string starting with the letter A.
+     *
+     * @var string $releaseResourceReference
+     */
+    private $releaseResourceReference = null;
+
+    /**
+     * A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this ContentItem. Example: an Image, Text or NonMusicalWorkVideo associated with a SoundRecording. This LocalAnchorReference is a xs:string starting with the letter A.
+     *
+     * @var \DedexBundle\Entity\Ern42\LinkedReleaseResourceReferenceType[] $linkedReleaseResourceReference
+     */
+    private $linkedReleaseResourceReference = [
+        
+    ];
+
+    /**
+     * The Flag indicating whether a Resource in a Release is additional to those on the original Release of which this is a Version (=true) or not (=false). If this Element is not provided, it is assumed that this is False.
+     *
+     * @var bool $isBonusResource
+     */
+    private $isBonusResource = null;
+
+    /**
+     * The Flag indicating whether a Resource in a Release may be made available to consumers despite the distribution of the containing Release not having been permitted (=true) or not (=false). If this Element is not provided, it is assumed that this is False. The actual status of a Resource as an InstantGratificationResource is determined in the relevant Deal.
+     *
+     * @var bool $isInstantGratificationResource
+     */
+    private $isInstantGratificationResource = null;
+
+    /**
+     * A Flag indicating whether a Resource that is only available when the Release is purchased during a pre-order period (delivery is typically at ReleaseDate) (=true) or not (=false). If this Element is not provided, it is assumed that this is False. The actual status of a Resource as an PreOrderIncentiveResource is determined in the relevant Deal.
+     *
+     * @var bool $isPreOrderIncentiveResource
+     */
+    private $isPreOrderIncentiveResource = null;
+
+    /**
+     * Gets as sequenceNumber
+     *
+     * The number indicating the logical order of the ContentItem in its ResourceGroup.
+     *
+     * @return int
+     */
+    public function getSequenceNumber()
+    {
+        return $this->sequenceNumber;
+    }
+
+    /**
+     * Sets a new sequenceNumber
+     *
+     * The number indicating the logical order of the ContentItem in its ResourceGroup.
+     *
+     * @param int $sequenceNumber
+     * @return self
+     */
+    public function setSequenceNumber($sequenceNumber)
+    {
+        $this->sequenceNumber = $sequenceNumber;
+        return $this;
+    }
+
+    /**
+     * Gets as noDisplaySequence
+     *
+     * A Flag indicating whether a display sequence exists (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getNoDisplaySequence()
+    {
+        return $this->noDisplaySequence;
+    }
+
+    /**
+     * Sets a new noDisplaySequence
+     *
+     * A Flag indicating whether a display sequence exists (=true) or not (=false).
+     *
+     * @param bool $noDisplaySequence
+     * @return self
+     */
+    public function setNoDisplaySequence($noDisplaySequence)
+    {
+        $this->noDisplaySequence = $noDisplaySequence;
+        return $this;
+    }
+
+    /**
+     * Gets as displaySequence
+     *
+     * A sequence Identifier used for display purposes, consisting of a string that corresponds to the SequenceNumber, e.g. 'Side B' corresponding to '2'.
+     *
+     * @return string
+     */
+    public function getDisplaySequence()
+    {
+        return $this->displaySequence;
+    }
+
+    /**
+     * Sets a new displaySequence
+     *
+     * A sequence Identifier used for display purposes, consisting of a string that corresponds to the SequenceNumber, e.g. 'Side B' corresponding to '2'.
+     *
+     * @param string $displaySequence
+     * @return self
+     */
+    public function setDisplaySequence($displaySequence)
+    {
+        $this->displaySequence = $displaySequence;
+        return $this;
+    }
+
+    /**
+     * Gets as releaseResourceReference
+     *
+     * A ReleaseResourceReference for the ContentItem (specific to this Message). The LocalAnchorReference in this Composite is a xs:string starting with the letter A.
+     *
+     * @return string
+     */
+    public function getReleaseResourceReference()
+    {
+        return $this->releaseResourceReference;
+    }
+
+    /**
+     * Sets a new releaseResourceReference
+     *
+     * A ReleaseResourceReference for the ContentItem (specific to this Message). The LocalAnchorReference in this Composite is a xs:string starting with the letter A.
+     *
+     * @param string $releaseResourceReference
+     * @return self
+     */
+    public function setReleaseResourceReference($releaseResourceReference)
+    {
+        $this->releaseResourceReference = $releaseResourceReference;
+        return $this;
+    }
+
+    /**
+     * Adds as linkedReleaseResourceReference
+     *
+     * A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this ContentItem. Example: an Image, Text or NonMusicalWorkVideo associated with a SoundRecording. This LocalAnchorReference is a xs:string starting with the letter A.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\LinkedReleaseResourceReferenceType $linkedReleaseResourceReference
+     */
+    public function addToLinkedReleaseResourceReference(\DedexBundle\Entity\Ern42\LinkedReleaseResourceReferenceType $linkedReleaseResourceReference)
+    {
+        $this->linkedReleaseResourceReference[] = $linkedReleaseResourceReference;
+        return $this;
+    }
+
+    /**
+     * isset linkedReleaseResourceReference
+     *
+     * A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this ContentItem. Example: an Image, Text or NonMusicalWorkVideo associated with a SoundRecording. This LocalAnchorReference is a xs:string starting with the letter A.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetLinkedReleaseResourceReference($index)
+    {
+        return isset($this->linkedReleaseResourceReference[$index]);
+    }
+
+    /**
+     * unset linkedReleaseResourceReference
+     *
+     * A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this ContentItem. Example: an Image, Text or NonMusicalWorkVideo associated with a SoundRecording. This LocalAnchorReference is a xs:string starting with the letter A.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetLinkedReleaseResourceReference($index)
+    {
+        unset($this->linkedReleaseResourceReference[$index]);
+    }
+
+    /**
+     * Gets as linkedReleaseResourceReference
+     *
+     * A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this ContentItem. Example: an Image, Text or NonMusicalWorkVideo associated with a SoundRecording. This LocalAnchorReference is a xs:string starting with the letter A.
+     *
+     * @return \DedexBundle\Entity\Ern42\LinkedReleaseResourceReferenceType[]
+     */
+    public function getLinkedReleaseResourceReference()
+    {
+        return $this->linkedReleaseResourceReference;
+    }
+
+    /**
+     * Sets a new linkedReleaseResourceReference
+     *
+     * A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this ContentItem. Example: an Image, Text or NonMusicalWorkVideo associated with a SoundRecording. This LocalAnchorReference is a xs:string starting with the letter A.
+     *
+     * @param \DedexBundle\Entity\Ern42\LinkedReleaseResourceReferenceType[] $linkedReleaseResourceReference
+     * @return self
+     */
+    public function setLinkedReleaseResourceReference(?array $linkedReleaseResourceReference = null)
+    {
+        $this->linkedReleaseResourceReference = $linkedReleaseResourceReference;
+        return $this;
+    }
+
+    /**
+     * Gets as isBonusResource
+     *
+     * The Flag indicating whether a Resource in a Release is additional to those on the original Release of which this is a Version (=true) or not (=false). If this Element is not provided, it is assumed that this is False.
+     *
+     * @return bool
+     */
+    public function getIsBonusResource()
+    {
+        return $this->isBonusResource;
+    }
+
+    /**
+     * Sets a new isBonusResource
+     *
+     * The Flag indicating whether a Resource in a Release is additional to those on the original Release of which this is a Version (=true) or not (=false). If this Element is not provided, it is assumed that this is False.
+     *
+     * @param bool $isBonusResource
+     * @return self
+     */
+    public function setIsBonusResource($isBonusResource)
+    {
+        $this->isBonusResource = $isBonusResource;
+        return $this;
+    }
+
+    /**
+     * Gets as isInstantGratificationResource
+     *
+     * The Flag indicating whether a Resource in a Release may be made available to consumers despite the distribution of the containing Release not having been permitted (=true) or not (=false). If this Element is not provided, it is assumed that this is False. The actual status of a Resource as an InstantGratificationResource is determined in the relevant Deal.
+     *
+     * @return bool
+     */
+    public function getIsInstantGratificationResource()
+    {
+        return $this->isInstantGratificationResource;
+    }
+
+    /**
+     * Sets a new isInstantGratificationResource
+     *
+     * The Flag indicating whether a Resource in a Release may be made available to consumers despite the distribution of the containing Release not having been permitted (=true) or not (=false). If this Element is not provided, it is assumed that this is False. The actual status of a Resource as an InstantGratificationResource is determined in the relevant Deal.
+     *
+     * @param bool $isInstantGratificationResource
+     * @return self
+     */
+    public function setIsInstantGratificationResource($isInstantGratificationResource)
+    {
+        $this->isInstantGratificationResource = $isInstantGratificationResource;
+        return $this;
+    }
+
+    /**
+     * Gets as isPreOrderIncentiveResource
+     *
+     * A Flag indicating whether a Resource that is only available when the Release is purchased during a pre-order period (delivery is typically at ReleaseDate) (=true) or not (=false). If this Element is not provided, it is assumed that this is False. The actual status of a Resource as an PreOrderIncentiveResource is determined in the relevant Deal.
+     *
+     * @return bool
+     */
+    public function getIsPreOrderIncentiveResource()
+    {
+        return $this->isPreOrderIncentiveResource;
+    }
+
+    /**
+     * Sets a new isPreOrderIncentiveResource
+     *
+     * A Flag indicating whether a Resource that is only available when the Release is purchased during a pre-order period (delivery is typically at ReleaseDate) (=true) or not (=false). If this Element is not provided, it is assumed that this is False. The actual status of a Resource as an PreOrderIncentiveResource is determined in the relevant Deal.
+     *
+     * @param bool $isPreOrderIncentiveResource
+     * @return self
+     */
+    public function setIsPreOrderIncentiveResource($isPreOrderIncentiveResource)
+    {
+        $this->isPreOrderIncentiveResource = $isPreOrderIncentiveResource;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ResourceGroupType.php
+++ b/src/Entity/Ern42/ResourceGroupType.php
@@ -1,0 +1,841 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ResourceGroupType
+ *
+ * A Composite containing details of a ResourceGroup. ResourceGroups are used to signal groupings or sequences of Resources within a Release. Examples include individual Carriers in a multi-carrier Release or classical Work groupings as well as the default order of Resources within a Release.
+ * XSD Type: ResourceGroup
+ */
+class ResourceGroupType
+{
+    /**
+     * A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayTitleTextType[] $displayTitleText
+     */
+    private $displayTitleText = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayTitleType[] $displayTitle
+     */
+    private $displayTitle = [
+        
+    ];
+
+    /**
+     * A Composite containing details of an AdditionalTitle of the ResourceGroup. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @var \DedexBundle\Entity\Ern42\AdditionalTitleType[] $additionalTitle
+     */
+    private $additionalTitle = [
+        
+    ];
+
+    /**
+     * The number indicating the logical order of the ResourceGroup within all ResourceGroups at this level. The default value is 1, and the value must be incremented by 1 for each ResourceGroup occurring at a particular level.
+     *
+     * @var int $sequenceNumber
+     */
+    private $sequenceNumber = null;
+
+    /**
+     * A Flag indicating whether a display sequence exists (=true) or not (=false).
+     *
+     * @var bool $noDisplaySequence
+     */
+    private $noDisplaySequence = null;
+
+    /**
+     * A sequence Identifier used for display purposes, consisting of a string that corresponds to the SequenceNumber, e.g. 'Side B' corresponding to '2'.
+     *
+     * @var string $displaySequence
+     */
+    private $displaySequence = null;
+
+    /**
+     * A Composite containing details of the DisplayArtist for the ResourceGroup. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayArtistType[] $displayArtist
+     */
+    private $displayArtist = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Carrier.
+     *
+     * @var \DedexBundle\Entity\Ern42\CarrierTypeType[] $carrierType
+     */
+    private $carrierType = [
+        
+    ];
+
+    /**
+     * The Duration of the ResourceGroup, if it is a SoundRecording or Video (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @var \DateInterval $duration
+     */
+    private $duration = null;
+
+    /**
+     * The Identifier (specific to the Message) of a Release which has the same content as the ResourceGroup. This is a LocalReleaseAnchorReference starting with the letter R.
+     *
+     * @var string $resourceGroupReleaseReference
+     */
+    private $resourceGroupReleaseReference = null;
+
+    /**
+     * A Composite containing details of ReleaseIds of a Release which has the same content as the ResourceGroup. If available, a GRid has to be used. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.
+     *
+     * @var \DedexBundle\Entity\Ern42\ReleaseIdType $releaseId
+     */
+    private $releaseId = null;
+
+    /**
+     * A ResourceGroup contained within this ResourceGroup. ResourceGroups are used to signal groupings or sequences of Resources within a Release. Examples include individual Carriers in a multi-carrier Release or classical Work groupings as well as the default order of Resources within a Release.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/sequencing-resources
+     *
+     * @var \DedexBundle\Entity\Ern42\ResourceSubGroupType[] $resourceGroup
+     */
+    private $resourceGroup = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Resource contained in the ResourceGroup.
+     *
+     * @var \DedexBundle\Entity\Ern42\ResourceGroupContentItemType[] $resourceGroupContentItem
+     */
+    private $resourceGroupContentItem = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this Release. Example:cover art images associated with the ResourceGroup. This LocalAnchorReference is a xs:string starting with the letter A.
+     *
+     * @var \DedexBundle\Entity\Ern42\LinkedReleaseResourceReferenceType[] $linkedReleaseResourceReference
+     */
+    private $linkedReleaseResourceReference = [
+        
+    ];
+
+    /**
+     * Adds as displayTitleText
+     *
+     * A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleTextType $displayTitleText
+     */
+    public function addToDisplayTitleText(\DedexBundle\Entity\Ern42\DisplayTitleTextType $displayTitleText)
+    {
+        $this->displayTitleText[] = $displayTitleText;
+        return $this;
+    }
+
+    /**
+     * isset displayTitleText
+     *
+     * A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayTitleText($index)
+    {
+        return isset($this->displayTitleText[$index]);
+    }
+
+    /**
+     * unset displayTitleText
+     *
+     * A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayTitleText($index)
+    {
+        unset($this->displayTitleText[$index]);
+    }
+
+    /**
+     * Gets as displayTitleText
+     *
+     * A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayTitleTextType[]
+     */
+    public function getDisplayTitleText()
+    {
+        return $this->displayTitleText;
+    }
+
+    /**
+     * Sets a new displayTitleText
+     *
+     * A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleTextType[] $displayTitleText
+     * @return self
+     */
+    public function setDisplayTitleText(?array $displayTitleText = null)
+    {
+        $this->displayTitleText = $displayTitleText;
+        return $this;
+    }
+
+    /**
+     * Adds as displayTitle
+     *
+     * A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleType $displayTitle
+     */
+    public function addToDisplayTitle(\DedexBundle\Entity\Ern42\DisplayTitleType $displayTitle)
+    {
+        $this->displayTitle[] = $displayTitle;
+        return $this;
+    }
+
+    /**
+     * isset displayTitle
+     *
+     * A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayTitle($index)
+    {
+        return isset($this->displayTitle[$index]);
+    }
+
+    /**
+     * unset displayTitle
+     *
+     * A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayTitle($index)
+    {
+        unset($this->displayTitle[$index]);
+    }
+
+    /**
+     * Gets as displayTitle
+     *
+     * A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayTitleType[]
+     */
+    public function getDisplayTitle()
+    {
+        return $this->displayTitle;
+    }
+
+    /**
+     * Sets a new displayTitle
+     *
+     * A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleType[] $displayTitle
+     * @return self
+     */
+    public function setDisplayTitle(?array $displayTitle = null)
+    {
+        $this->displayTitle = $displayTitle;
+        return $this;
+    }
+
+    /**
+     * Adds as additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the ResourceGroup. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\AdditionalTitleType $additionalTitle
+     */
+    public function addToAdditionalTitle(\DedexBundle\Entity\Ern42\AdditionalTitleType $additionalTitle)
+    {
+        $this->additionalTitle[] = $additionalTitle;
+        return $this;
+    }
+
+    /**
+     * isset additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the ResourceGroup. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetAdditionalTitle($index)
+    {
+        return isset($this->additionalTitle[$index]);
+    }
+
+    /**
+     * unset additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the ResourceGroup. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetAdditionalTitle($index)
+    {
+        unset($this->additionalTitle[$index]);
+    }
+
+    /**
+     * Gets as additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the ResourceGroup. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return \DedexBundle\Entity\Ern42\AdditionalTitleType[]
+     */
+    public function getAdditionalTitle()
+    {
+        return $this->additionalTitle;
+    }
+
+    /**
+     * Sets a new additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the ResourceGroup. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param \DedexBundle\Entity\Ern42\AdditionalTitleType[] $additionalTitle
+     * @return self
+     */
+    public function setAdditionalTitle(?array $additionalTitle = null)
+    {
+        $this->additionalTitle = $additionalTitle;
+        return $this;
+    }
+
+    /**
+     * Gets as sequenceNumber
+     *
+     * The number indicating the logical order of the ResourceGroup within all ResourceGroups at this level. The default value is 1, and the value must be incremented by 1 for each ResourceGroup occurring at a particular level.
+     *
+     * @return int
+     */
+    public function getSequenceNumber()
+    {
+        return $this->sequenceNumber;
+    }
+
+    /**
+     * Sets a new sequenceNumber
+     *
+     * The number indicating the logical order of the ResourceGroup within all ResourceGroups at this level. The default value is 1, and the value must be incremented by 1 for each ResourceGroup occurring at a particular level.
+     *
+     * @param int $sequenceNumber
+     * @return self
+     */
+    public function setSequenceNumber($sequenceNumber)
+    {
+        $this->sequenceNumber = $sequenceNumber;
+        return $this;
+    }
+
+    /**
+     * Gets as noDisplaySequence
+     *
+     * A Flag indicating whether a display sequence exists (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getNoDisplaySequence()
+    {
+        return $this->noDisplaySequence;
+    }
+
+    /**
+     * Sets a new noDisplaySequence
+     *
+     * A Flag indicating whether a display sequence exists (=true) or not (=false).
+     *
+     * @param bool $noDisplaySequence
+     * @return self
+     */
+    public function setNoDisplaySequence($noDisplaySequence)
+    {
+        $this->noDisplaySequence = $noDisplaySequence;
+        return $this;
+    }
+
+    /**
+     * Gets as displaySequence
+     *
+     * A sequence Identifier used for display purposes, consisting of a string that corresponds to the SequenceNumber, e.g. 'Side B' corresponding to '2'.
+     *
+     * @return string
+     */
+    public function getDisplaySequence()
+    {
+        return $this->displaySequence;
+    }
+
+    /**
+     * Sets a new displaySequence
+     *
+     * A sequence Identifier used for display purposes, consisting of a string that corresponds to the SequenceNumber, e.g. 'Side B' corresponding to '2'.
+     *
+     * @param string $displaySequence
+     * @return self
+     */
+    public function setDisplaySequence($displaySequence)
+    {
+        $this->displaySequence = $displaySequence;
+        return $this;
+    }
+
+    /**
+     * Adds as displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the ResourceGroup. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistType $displayArtist
+     */
+    public function addToDisplayArtist(\DedexBundle\Entity\Ern42\DisplayArtistType $displayArtist)
+    {
+        $this->displayArtist[] = $displayArtist;
+        return $this;
+    }
+
+    /**
+     * isset displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the ResourceGroup. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayArtist($index)
+    {
+        return isset($this->displayArtist[$index]);
+    }
+
+    /**
+     * unset displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the ResourceGroup. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayArtist($index)
+    {
+        unset($this->displayArtist[$index]);
+    }
+
+    /**
+     * Gets as displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the ResourceGroup. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayArtistType[]
+     */
+    public function getDisplayArtist()
+    {
+        return $this->displayArtist;
+    }
+
+    /**
+     * Sets a new displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the ResourceGroup. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistType[] $displayArtist
+     * @return self
+     */
+    public function setDisplayArtist(?array $displayArtist = null)
+    {
+        $this->displayArtist = $displayArtist;
+        return $this;
+    }
+
+    /**
+     * Adds as carrierType
+     *
+     * A Composite containing details of a Carrier.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\CarrierTypeType $carrierType
+     */
+    public function addToCarrierType(\DedexBundle\Entity\Ern42\CarrierTypeType $carrierType)
+    {
+        $this->carrierType[] = $carrierType;
+        return $this;
+    }
+
+    /**
+     * isset carrierType
+     *
+     * A Composite containing details of a Carrier.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetCarrierType($index)
+    {
+        return isset($this->carrierType[$index]);
+    }
+
+    /**
+     * unset carrierType
+     *
+     * A Composite containing details of a Carrier.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetCarrierType($index)
+    {
+        unset($this->carrierType[$index]);
+    }
+
+    /**
+     * Gets as carrierType
+     *
+     * A Composite containing details of a Carrier.
+     *
+     * @return \DedexBundle\Entity\Ern42\CarrierTypeType[]
+     */
+    public function getCarrierType()
+    {
+        return $this->carrierType;
+    }
+
+    /**
+     * Sets a new carrierType
+     *
+     * A Composite containing details of a Carrier.
+     *
+     * @param \DedexBundle\Entity\Ern42\CarrierTypeType[] $carrierType
+     * @return self
+     */
+    public function setCarrierType(?array $carrierType = null)
+    {
+        $this->carrierType = $carrierType;
+        return $this;
+    }
+
+    /**
+     * Gets as duration
+     *
+     * The Duration of the ResourceGroup, if it is a SoundRecording or Video (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @return \DateInterval
+     */
+    public function getDuration()
+    {
+        return $this->duration;
+    }
+
+    /**
+     * Sets a new duration
+     *
+     * The Duration of the ResourceGroup, if it is a SoundRecording or Video (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @param \DateInterval $duration
+     * @return self
+     */
+    public function setDuration(?\DateInterval $duration = null)
+    {
+        $this->duration = $duration;
+        return $this;
+    }
+
+    /**
+     * Gets as resourceGroupReleaseReference
+     *
+     * The Identifier (specific to the Message) of a Release which has the same content as the ResourceGroup. This is a LocalReleaseAnchorReference starting with the letter R.
+     *
+     * @return string
+     */
+    public function getResourceGroupReleaseReference()
+    {
+        return $this->resourceGroupReleaseReference;
+    }
+
+    /**
+     * Sets a new resourceGroupReleaseReference
+     *
+     * The Identifier (specific to the Message) of a Release which has the same content as the ResourceGroup. This is a LocalReleaseAnchorReference starting with the letter R.
+     *
+     * @param string $resourceGroupReleaseReference
+     * @return self
+     */
+    public function setResourceGroupReleaseReference($resourceGroupReleaseReference)
+    {
+        $this->resourceGroupReleaseReference = $resourceGroupReleaseReference;
+        return $this;
+    }
+
+    /**
+     * Gets as releaseId
+     *
+     * A Composite containing details of ReleaseIds of a Release which has the same content as the ResourceGroup. If available, a GRid has to be used. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.
+     *
+     * @return \DedexBundle\Entity\Ern42\ReleaseIdType
+     */
+    public function getReleaseId()
+    {
+        return $this->releaseId;
+    }
+
+    /**
+     * Sets a new releaseId
+     *
+     * A Composite containing details of ReleaseIds of a Release which has the same content as the ResourceGroup. If available, a GRid has to be used. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.
+     *
+     * @param \DedexBundle\Entity\Ern42\ReleaseIdType $releaseId
+     * @return self
+     */
+    public function setReleaseId(?\DedexBundle\Entity\Ern42\ReleaseIdType $releaseId = null)
+    {
+        $this->releaseId = $releaseId;
+        return $this;
+    }
+
+    /**
+     * Adds as resourceGroup
+     *
+     * A ResourceGroup contained within this ResourceGroup. ResourceGroups are used to signal groupings or sequences of Resources within a Release. Examples include individual Carriers in a multi-carrier Release or classical Work groupings as well as the default order of Resources within a Release.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/sequencing-resources
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ResourceSubGroupType $resourceGroup
+     */
+    public function addToResourceGroup(\DedexBundle\Entity\Ern42\ResourceSubGroupType $resourceGroup)
+    {
+        $this->resourceGroup[] = $resourceGroup;
+        return $this;
+    }
+
+    /**
+     * isset resourceGroup
+     *
+     * A ResourceGroup contained within this ResourceGroup. ResourceGroups are used to signal groupings or sequences of Resources within a Release. Examples include individual Carriers in a multi-carrier Release or classical Work groupings as well as the default order of Resources within a Release.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/sequencing-resources
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetResourceGroup($index)
+    {
+        return isset($this->resourceGroup[$index]);
+    }
+
+    /**
+     * unset resourceGroup
+     *
+     * A ResourceGroup contained within this ResourceGroup. ResourceGroups are used to signal groupings or sequences of Resources within a Release. Examples include individual Carriers in a multi-carrier Release or classical Work groupings as well as the default order of Resources within a Release.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/sequencing-resources
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetResourceGroup($index)
+    {
+        unset($this->resourceGroup[$index]);
+    }
+
+    /**
+     * Gets as resourceGroup
+     *
+     * A ResourceGroup contained within this ResourceGroup. ResourceGroups are used to signal groupings or sequences of Resources within a Release. Examples include individual Carriers in a multi-carrier Release or classical Work groupings as well as the default order of Resources within a Release.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/sequencing-resources
+     *
+     * @return \DedexBundle\Entity\Ern42\ResourceSubGroupType[]
+     */
+    public function getResourceGroup()
+    {
+        return $this->resourceGroup;
+    }
+
+    /**
+     * Sets a new resourceGroup
+     *
+     * A ResourceGroup contained within this ResourceGroup. ResourceGroups are used to signal groupings or sequences of Resources within a Release. Examples include individual Carriers in a multi-carrier Release or classical Work groupings as well as the default order of Resources within a Release.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/sequencing-resources
+     *
+     * @param \DedexBundle\Entity\Ern42\ResourceSubGroupType[] $resourceGroup
+     * @return self
+     */
+    public function setResourceGroup(?array $resourceGroup = null)
+    {
+        $this->resourceGroup = $resourceGroup;
+        return $this;
+    }
+
+    /**
+     * Adds as resourceGroupContentItem
+     *
+     * A Composite containing details of a Resource contained in the ResourceGroup.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ResourceGroupContentItemType $resourceGroupContentItem
+     */
+    public function addToResourceGroupContentItem(\DedexBundle\Entity\Ern42\ResourceGroupContentItemType $resourceGroupContentItem)
+    {
+        $this->resourceGroupContentItem[] = $resourceGroupContentItem;
+        return $this;
+    }
+
+    /**
+     * isset resourceGroupContentItem
+     *
+     * A Composite containing details of a Resource contained in the ResourceGroup.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetResourceGroupContentItem($index)
+    {
+        return isset($this->resourceGroupContentItem[$index]);
+    }
+
+    /**
+     * unset resourceGroupContentItem
+     *
+     * A Composite containing details of a Resource contained in the ResourceGroup.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetResourceGroupContentItem($index)
+    {
+        unset($this->resourceGroupContentItem[$index]);
+    }
+
+    /**
+     * Gets as resourceGroupContentItem
+     *
+     * A Composite containing details of a Resource contained in the ResourceGroup.
+     *
+     * @return \DedexBundle\Entity\Ern42\ResourceGroupContentItemType[]
+     */
+    public function getResourceGroupContentItem()
+    {
+        return $this->resourceGroupContentItem;
+    }
+
+    /**
+     * Sets a new resourceGroupContentItem
+     *
+     * A Composite containing details of a Resource contained in the ResourceGroup.
+     *
+     * @param \DedexBundle\Entity\Ern42\ResourceGroupContentItemType[] $resourceGroupContentItem
+     * @return self
+     */
+    public function setResourceGroupContentItem(?array $resourceGroupContentItem = null)
+    {
+        $this->resourceGroupContentItem = $resourceGroupContentItem;
+        return $this;
+    }
+
+    /**
+     * Adds as linkedReleaseResourceReference
+     *
+     * A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this Release. Example:cover art images associated with the ResourceGroup. This LocalAnchorReference is a xs:string starting with the letter A.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\LinkedReleaseResourceReferenceType $linkedReleaseResourceReference
+     */
+    public function addToLinkedReleaseResourceReference(\DedexBundle\Entity\Ern42\LinkedReleaseResourceReferenceType $linkedReleaseResourceReference)
+    {
+        $this->linkedReleaseResourceReference[] = $linkedReleaseResourceReference;
+        return $this;
+    }
+
+    /**
+     * isset linkedReleaseResourceReference
+     *
+     * A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this Release. Example:cover art images associated with the ResourceGroup. This LocalAnchorReference is a xs:string starting with the letter A.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetLinkedReleaseResourceReference($index)
+    {
+        return isset($this->linkedReleaseResourceReference[$index]);
+    }
+
+    /**
+     * unset linkedReleaseResourceReference
+     *
+     * A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this Release. Example:cover art images associated with the ResourceGroup. This LocalAnchorReference is a xs:string starting with the letter A.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetLinkedReleaseResourceReference($index)
+    {
+        unset($this->linkedReleaseResourceReference[$index]);
+    }
+
+    /**
+     * Gets as linkedReleaseResourceReference
+     *
+     * A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this Release. Example:cover art images associated with the ResourceGroup. This LocalAnchorReference is a xs:string starting with the letter A.
+     *
+     * @return \DedexBundle\Entity\Ern42\LinkedReleaseResourceReferenceType[]
+     */
+    public function getLinkedReleaseResourceReference()
+    {
+        return $this->linkedReleaseResourceReference;
+    }
+
+    /**
+     * Sets a new linkedReleaseResourceReference
+     *
+     * A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this Release. Example:cover art images associated with the ResourceGroup. This LocalAnchorReference is a xs:string starting with the letter A.
+     *
+     * @param \DedexBundle\Entity\Ern42\LinkedReleaseResourceReferenceType[] $linkedReleaseResourceReference
+     * @return self
+     */
+    public function setLinkedReleaseResourceReference(?array $linkedReleaseResourceReference = null)
+    {
+        $this->linkedReleaseResourceReference = $linkedReleaseResourceReference;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ResourceIdType.php
+++ b/src/Entity/Ern42/ResourceIdType.php
@@ -1,0 +1,385 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ResourceIdType
+ *
+ * A Composite containing details of ResourceIds.
+ * XSD Type: ResourceId
+ */
+class ResourceIdType
+{
+    /**
+     * The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.
+     *
+     * @var bool $isReplaced
+     */
+    private $isReplaced = null;
+
+    /**
+     * The ISRC (International Standard Recording Code as defined in ISO 3901) for the Resource. An ISRC comprises four parts: two characters, followed by three alphanumeric characters, then two digits and five digits. DDEX will enforce the syntax [a-zA-Z]{2}[a-zA-Z0-9]{3}[0-9]{7} using XML Schema in the future.
+     *
+     * @var string $iSRC
+     */
+    private $iSRC = null;
+
+    /**
+     * The ISMN (International Standard Music Number defined in ISO 10957) for the Resource. An ISMN is a thirteen-digit number. Pre-2008 ISMNs, which had 10 characters and are now deprecated, are converted by replacing the initial letter ('M') with '979-0'. DDEX will enforce the syntax 979[0-9]{9}[X0-9] using XML Schema in the future.
+     *
+     * @var string $iSMN
+     */
+    private $iSMN = null;
+
+    /**
+     * The ISAN (International Standard Audiovisual Number as defined in ISO 15706) for the Resource. An ISAN comprises four blocks of four hexadecimal charaters followed by a check character. DDEX will enforce the syntax [A-F0-9]{12} using XML Schema in the future.
+     *
+     * @var string $iSAN
+     */
+    private $iSAN = null;
+
+    /**
+     * The V-ISAN (Version Identifier of a International Standard Audiovisual Number as defined in ISO 15706-2) for the Resource. A V-ISAN comprises four blocks of four hexadecimal charaters followed by a check character, followed by two further blocks of four hexadecimal characters, followed by a further check character. DDEX will enforce the syntax [A-F0-9]{24} using XML Schema in the future.
+     *
+     * @var string $vISAN
+     */
+    private $vISAN = null;
+
+    /**
+     * The ISBN (International Standard Book Number defined in ISO 2108) for the Resource. An ISBN is a 13-digit number. Pre-2007, ISBNs, which had 10-digits and are now deprecated, are converted by adding the prefix '978' and re-calculating the check character. DDEX will enforce the syntax 97[8-9][0-9]{9}[X0-9] using XML Schema in the future.
+     *
+     * @var string $iSBN
+     */
+    private $iSBN = null;
+
+    /**
+     * The ISSN (International Standard Serial Number defined in ISO 3297) for the Resource. An ISSN comprises two groups of four digits, separated by a hyphen and a control digit. DDEX will enforce the syntax [0-9]{4}-[0-9]{3}[X0-9] using XML Schema in the future.
+     *
+     * @var string $iSSN
+     */
+    private $iSSN = null;
+
+    /**
+     * The SICI (Serial Item and Contribution Identifier defined in ANSI/NISO Z39.56-199) for the Resource. DDEX will enforce the syntax [0-9]{4}-[0-9]{3}[X0-9].+ using XML Schema in the future.
+     *
+     * @var string $sICI
+     */
+    private $sICI = null;
+
+    /**
+     * A Composite containing details of the CatalogNumber of the Resource.
+     *
+     * @var \DedexBundle\Entity\Ern42\CatalogNumberType $catalogNumber
+     */
+    private $catalogNumber = null;
+
+    /**
+     * A Composite containing details of a ProprietaryIdentifier of the Resource.
+     *
+     * @var \DedexBundle\Entity\Ern42\ProprietaryIdType[] $proprietaryId
+     */
+    private $proprietaryId = [
+        
+    ];
+
+    /**
+     * Gets as isReplaced
+     *
+     * The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.
+     *
+     * @return bool
+     */
+    public function getIsReplaced()
+    {
+        return $this->isReplaced;
+    }
+
+    /**
+     * Sets a new isReplaced
+     *
+     * The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.
+     *
+     * @param bool $isReplaced
+     * @return self
+     */
+    public function setIsReplaced($isReplaced)
+    {
+        $this->isReplaced = $isReplaced;
+        return $this;
+    }
+
+    /**
+     * Gets as iSRC
+     *
+     * The ISRC (International Standard Recording Code as defined in ISO 3901) for the Resource. An ISRC comprises four parts: two characters, followed by three alphanumeric characters, then two digits and five digits. DDEX will enforce the syntax [a-zA-Z]{2}[a-zA-Z0-9]{3}[0-9]{7} using XML Schema in the future.
+     *
+     * @return string
+     */
+    public function getISRC()
+    {
+        return $this->iSRC;
+    }
+
+    /**
+     * Sets a new iSRC
+     *
+     * The ISRC (International Standard Recording Code as defined in ISO 3901) for the Resource. An ISRC comprises four parts: two characters, followed by three alphanumeric characters, then two digits and five digits. DDEX will enforce the syntax [a-zA-Z]{2}[a-zA-Z0-9]{3}[0-9]{7} using XML Schema in the future.
+     *
+     * @param string $iSRC
+     * @return self
+     */
+    public function setISRC($iSRC)
+    {
+        $this->iSRC = $iSRC;
+        return $this;
+    }
+
+    /**
+     * Gets as iSMN
+     *
+     * The ISMN (International Standard Music Number defined in ISO 10957) for the Resource. An ISMN is a thirteen-digit number. Pre-2008 ISMNs, which had 10 characters and are now deprecated, are converted by replacing the initial letter ('M') with '979-0'. DDEX will enforce the syntax 979[0-9]{9}[X0-9] using XML Schema in the future.
+     *
+     * @return string
+     */
+    public function getISMN()
+    {
+        return $this->iSMN;
+    }
+
+    /**
+     * Sets a new iSMN
+     *
+     * The ISMN (International Standard Music Number defined in ISO 10957) for the Resource. An ISMN is a thirteen-digit number. Pre-2008 ISMNs, which had 10 characters and are now deprecated, are converted by replacing the initial letter ('M') with '979-0'. DDEX will enforce the syntax 979[0-9]{9}[X0-9] using XML Schema in the future.
+     *
+     * @param string $iSMN
+     * @return self
+     */
+    public function setISMN($iSMN)
+    {
+        $this->iSMN = $iSMN;
+        return $this;
+    }
+
+    /**
+     * Gets as iSAN
+     *
+     * The ISAN (International Standard Audiovisual Number as defined in ISO 15706) for the Resource. An ISAN comprises four blocks of four hexadecimal charaters followed by a check character. DDEX will enforce the syntax [A-F0-9]{12} using XML Schema in the future.
+     *
+     * @return string
+     */
+    public function getISAN()
+    {
+        return $this->iSAN;
+    }
+
+    /**
+     * Sets a new iSAN
+     *
+     * The ISAN (International Standard Audiovisual Number as defined in ISO 15706) for the Resource. An ISAN comprises four blocks of four hexadecimal charaters followed by a check character. DDEX will enforce the syntax [A-F0-9]{12} using XML Schema in the future.
+     *
+     * @param string $iSAN
+     * @return self
+     */
+    public function setISAN($iSAN)
+    {
+        $this->iSAN = $iSAN;
+        return $this;
+    }
+
+    /**
+     * Gets as vISAN
+     *
+     * The V-ISAN (Version Identifier of a International Standard Audiovisual Number as defined in ISO 15706-2) for the Resource. A V-ISAN comprises four blocks of four hexadecimal charaters followed by a check character, followed by two further blocks of four hexadecimal characters, followed by a further check character. DDEX will enforce the syntax [A-F0-9]{24} using XML Schema in the future.
+     *
+     * @return string
+     */
+    public function getVISAN()
+    {
+        return $this->vISAN;
+    }
+
+    /**
+     * Sets a new vISAN
+     *
+     * The V-ISAN (Version Identifier of a International Standard Audiovisual Number as defined in ISO 15706-2) for the Resource. A V-ISAN comprises four blocks of four hexadecimal charaters followed by a check character, followed by two further blocks of four hexadecimal characters, followed by a further check character. DDEX will enforce the syntax [A-F0-9]{24} using XML Schema in the future.
+     *
+     * @param string $vISAN
+     * @return self
+     */
+    public function setVISAN($vISAN)
+    {
+        $this->vISAN = $vISAN;
+        return $this;
+    }
+
+    /**
+     * Gets as iSBN
+     *
+     * The ISBN (International Standard Book Number defined in ISO 2108) for the Resource. An ISBN is a 13-digit number. Pre-2007, ISBNs, which had 10-digits and are now deprecated, are converted by adding the prefix '978' and re-calculating the check character. DDEX will enforce the syntax 97[8-9][0-9]{9}[X0-9] using XML Schema in the future.
+     *
+     * @return string
+     */
+    public function getISBN()
+    {
+        return $this->iSBN;
+    }
+
+    /**
+     * Sets a new iSBN
+     *
+     * The ISBN (International Standard Book Number defined in ISO 2108) for the Resource. An ISBN is a 13-digit number. Pre-2007, ISBNs, which had 10-digits and are now deprecated, are converted by adding the prefix '978' and re-calculating the check character. DDEX will enforce the syntax 97[8-9][0-9]{9}[X0-9] using XML Schema in the future.
+     *
+     * @param string $iSBN
+     * @return self
+     */
+    public function setISBN($iSBN)
+    {
+        $this->iSBN = $iSBN;
+        return $this;
+    }
+
+    /**
+     * Gets as iSSN
+     *
+     * The ISSN (International Standard Serial Number defined in ISO 3297) for the Resource. An ISSN comprises two groups of four digits, separated by a hyphen and a control digit. DDEX will enforce the syntax [0-9]{4}-[0-9]{3}[X0-9] using XML Schema in the future.
+     *
+     * @return string
+     */
+    public function getISSN()
+    {
+        return $this->iSSN;
+    }
+
+    /**
+     * Sets a new iSSN
+     *
+     * The ISSN (International Standard Serial Number defined in ISO 3297) for the Resource. An ISSN comprises two groups of four digits, separated by a hyphen and a control digit. DDEX will enforce the syntax [0-9]{4}-[0-9]{3}[X0-9] using XML Schema in the future.
+     *
+     * @param string $iSSN
+     * @return self
+     */
+    public function setISSN($iSSN)
+    {
+        $this->iSSN = $iSSN;
+        return $this;
+    }
+
+    /**
+     * Gets as sICI
+     *
+     * The SICI (Serial Item and Contribution Identifier defined in ANSI/NISO Z39.56-199) for the Resource. DDEX will enforce the syntax [0-9]{4}-[0-9]{3}[X0-9].+ using XML Schema in the future.
+     *
+     * @return string
+     */
+    public function getSICI()
+    {
+        return $this->sICI;
+    }
+
+    /**
+     * Sets a new sICI
+     *
+     * The SICI (Serial Item and Contribution Identifier defined in ANSI/NISO Z39.56-199) for the Resource. DDEX will enforce the syntax [0-9]{4}-[0-9]{3}[X0-9].+ using XML Schema in the future.
+     *
+     * @param string $sICI
+     * @return self
+     */
+    public function setSICI($sICI)
+    {
+        $this->sICI = $sICI;
+        return $this;
+    }
+
+    /**
+     * Gets as catalogNumber
+     *
+     * A Composite containing details of the CatalogNumber of the Resource.
+     *
+     * @return \DedexBundle\Entity\Ern42\CatalogNumberType
+     */
+    public function getCatalogNumber()
+    {
+        return $this->catalogNumber;
+    }
+
+    /**
+     * Sets a new catalogNumber
+     *
+     * A Composite containing details of the CatalogNumber of the Resource.
+     *
+     * @param \DedexBundle\Entity\Ern42\CatalogNumberType $catalogNumber
+     * @return self
+     */
+    public function setCatalogNumber(?\DedexBundle\Entity\Ern42\CatalogNumberType $catalogNumber = null)
+    {
+        $this->catalogNumber = $catalogNumber;
+        return $this;
+    }
+
+    /**
+     * Adds as proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Resource.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ProprietaryIdType $proprietaryId
+     */
+    public function addToProprietaryId(\DedexBundle\Entity\Ern42\ProprietaryIdType $proprietaryId)
+    {
+        $this->proprietaryId[] = $proprietaryId;
+        return $this;
+    }
+
+    /**
+     * isset proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Resource.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetProprietaryId($index)
+    {
+        return isset($this->proprietaryId[$index]);
+    }
+
+    /**
+     * unset proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Resource.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetProprietaryId($index)
+    {
+        unset($this->proprietaryId[$index]);
+    }
+
+    /**
+     * Gets as proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Resource.
+     *
+     * @return \DedexBundle\Entity\Ern42\ProprietaryIdType[]
+     */
+    public function getProprietaryId()
+    {
+        return $this->proprietaryId;
+    }
+
+    /**
+     * Sets a new proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Resource.
+     *
+     * @param \DedexBundle\Entity\Ern42\ProprietaryIdType[] $proprietaryId
+     * @return self
+     */
+    public function setProprietaryId(?array $proprietaryId = null)
+    {
+        $this->proprietaryId = $proprietaryId;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ResourceListType.php
+++ b/src/Entity/Ern42/ResourceListType.php
@@ -1,0 +1,463 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ResourceListType
+ *
+ * A Composite containing details of one or more Resources. ResourceList provides a simple means of aggregating Resources without any explicit sequencing or grouping: if that is needed it is provided by the ResourceGroup Composite.
+ * XSD Type: ResourceList
+ */
+class ResourceListType
+{
+    /**
+     * A Composite containing details of a SoundRecording.
+     *
+     * @var \DedexBundle\Entity\Ern42\SoundRecordingType[] $soundRecording
+     */
+    private $soundRecording = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Video.
+     *
+     * @var \DedexBundle\Entity\Ern42\VideoType[] $video
+     */
+    private $video = [
+        
+    ];
+
+    /**
+     * A Composite containing details of an Image.
+     *
+     * @var \DedexBundle\Entity\Ern42\ImageType[] $image
+     */
+    private $image = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Text.
+     *
+     * @var \DedexBundle\Entity\Ern42\TextType[] $text
+     */
+    private $text = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a SheetMusic.
+     *
+     * @var \DedexBundle\Entity\Ern42\SheetMusicType[] $sheetMusic
+     */
+    private $sheetMusic = [
+        
+    ];
+
+    /**
+     * A Composite containing details of an item of Software.
+     *
+     * @var \DedexBundle\Entity\Ern42\SoftwareType[] $software
+     */
+    private $software = [
+        
+    ];
+
+    /**
+     * Adds as soundRecording
+     *
+     * A Composite containing details of a SoundRecording.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\SoundRecordingType $soundRecording
+     */
+    public function addToSoundRecording(\DedexBundle\Entity\Ern42\SoundRecordingType $soundRecording)
+    {
+        $this->soundRecording[] = $soundRecording;
+        return $this;
+    }
+
+    /**
+     * isset soundRecording
+     *
+     * A Composite containing details of a SoundRecording.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetSoundRecording($index)
+    {
+        return isset($this->soundRecording[$index]);
+    }
+
+    /**
+     * unset soundRecording
+     *
+     * A Composite containing details of a SoundRecording.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetSoundRecording($index)
+    {
+        unset($this->soundRecording[$index]);
+    }
+
+    /**
+     * Gets as soundRecording
+     *
+     * A Composite containing details of a SoundRecording.
+     *
+     * @return \DedexBundle\Entity\Ern42\SoundRecordingType[]
+     */
+    public function getSoundRecording()
+    {
+        return $this->soundRecording;
+    }
+
+    /**
+     * Sets a new soundRecording
+     *
+     * A Composite containing details of a SoundRecording.
+     *
+     * @param \DedexBundle\Entity\Ern42\SoundRecordingType[] $soundRecording
+     * @return self
+     */
+    public function setSoundRecording(?array $soundRecording = null)
+    {
+        $this->soundRecording = $soundRecording;
+        return $this;
+    }
+
+    /**
+     * Adds as video
+     *
+     * A Composite containing details of a Video.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\VideoType $video
+     */
+    public function addToVideo(\DedexBundle\Entity\Ern42\VideoType $video)
+    {
+        $this->video[] = $video;
+        return $this;
+    }
+
+    /**
+     * isset video
+     *
+     * A Composite containing details of a Video.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetVideo($index)
+    {
+        return isset($this->video[$index]);
+    }
+
+    /**
+     * unset video
+     *
+     * A Composite containing details of a Video.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetVideo($index)
+    {
+        unset($this->video[$index]);
+    }
+
+    /**
+     * Gets as video
+     *
+     * A Composite containing details of a Video.
+     *
+     * @return \DedexBundle\Entity\Ern42\VideoType[]
+     */
+    public function getVideo()
+    {
+        return $this->video;
+    }
+
+    /**
+     * Sets a new video
+     *
+     * A Composite containing details of a Video.
+     *
+     * @param \DedexBundle\Entity\Ern42\VideoType[] $video
+     * @return self
+     */
+    public function setVideo(?array $video = null)
+    {
+        $this->video = $video;
+        return $this;
+    }
+
+    /**
+     * Adds as image
+     *
+     * A Composite containing details of an Image.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ImageType $image
+     */
+    public function addToImage(\DedexBundle\Entity\Ern42\ImageType $image)
+    {
+        $this->image[] = $image;
+        return $this;
+    }
+
+    /**
+     * isset image
+     *
+     * A Composite containing details of an Image.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetImage($index)
+    {
+        return isset($this->image[$index]);
+    }
+
+    /**
+     * unset image
+     *
+     * A Composite containing details of an Image.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetImage($index)
+    {
+        unset($this->image[$index]);
+    }
+
+    /**
+     * Gets as image
+     *
+     * A Composite containing details of an Image.
+     *
+     * @return \DedexBundle\Entity\Ern42\ImageType[]
+     */
+    public function getImage()
+    {
+        return $this->image;
+    }
+
+    /**
+     * Sets a new image
+     *
+     * A Composite containing details of an Image.
+     *
+     * @param \DedexBundle\Entity\Ern42\ImageType[] $image
+     * @return self
+     */
+    public function setImage(?array $image = null)
+    {
+        $this->image = $image;
+        return $this;
+    }
+
+    /**
+     * Adds as text
+     *
+     * A Composite containing details of a Text.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\TextType $text
+     */
+    public function addToText(\DedexBundle\Entity\Ern42\TextType $text)
+    {
+        $this->text[] = $text;
+        return $this;
+    }
+
+    /**
+     * isset text
+     *
+     * A Composite containing details of a Text.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetText($index)
+    {
+        return isset($this->text[$index]);
+    }
+
+    /**
+     * unset text
+     *
+     * A Composite containing details of a Text.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetText($index)
+    {
+        unset($this->text[$index]);
+    }
+
+    /**
+     * Gets as text
+     *
+     * A Composite containing details of a Text.
+     *
+     * @return \DedexBundle\Entity\Ern42\TextType[]
+     */
+    public function getText()
+    {
+        return $this->text;
+    }
+
+    /**
+     * Sets a new text
+     *
+     * A Composite containing details of a Text.
+     *
+     * @param \DedexBundle\Entity\Ern42\TextType[] $text
+     * @return self
+     */
+    public function setText(?array $text = null)
+    {
+        $this->text = $text;
+        return $this;
+    }
+
+    /**
+     * Adds as sheetMusic
+     *
+     * A Composite containing details of a SheetMusic.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\SheetMusicType $sheetMusic
+     */
+    public function addToSheetMusic(\DedexBundle\Entity\Ern42\SheetMusicType $sheetMusic)
+    {
+        $this->sheetMusic[] = $sheetMusic;
+        return $this;
+    }
+
+    /**
+     * isset sheetMusic
+     *
+     * A Composite containing details of a SheetMusic.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetSheetMusic($index)
+    {
+        return isset($this->sheetMusic[$index]);
+    }
+
+    /**
+     * unset sheetMusic
+     *
+     * A Composite containing details of a SheetMusic.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetSheetMusic($index)
+    {
+        unset($this->sheetMusic[$index]);
+    }
+
+    /**
+     * Gets as sheetMusic
+     *
+     * A Composite containing details of a SheetMusic.
+     *
+     * @return \DedexBundle\Entity\Ern42\SheetMusicType[]
+     */
+    public function getSheetMusic()
+    {
+        return $this->sheetMusic;
+    }
+
+    /**
+     * Sets a new sheetMusic
+     *
+     * A Composite containing details of a SheetMusic.
+     *
+     * @param \DedexBundle\Entity\Ern42\SheetMusicType[] $sheetMusic
+     * @return self
+     */
+    public function setSheetMusic(?array $sheetMusic = null)
+    {
+        $this->sheetMusic = $sheetMusic;
+        return $this;
+    }
+
+    /**
+     * Adds as software
+     *
+     * A Composite containing details of an item of Software.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\SoftwareType $software
+     */
+    public function addToSoftware(\DedexBundle\Entity\Ern42\SoftwareType $software)
+    {
+        $this->software[] = $software;
+        return $this;
+    }
+
+    /**
+     * isset software
+     *
+     * A Composite containing details of an item of Software.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetSoftware($index)
+    {
+        return isset($this->software[$index]);
+    }
+
+    /**
+     * unset software
+     *
+     * A Composite containing details of an item of Software.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetSoftware($index)
+    {
+        unset($this->software[$index]);
+    }
+
+    /**
+     * Gets as software
+     *
+     * A Composite containing details of an item of Software.
+     *
+     * @return \DedexBundle\Entity\Ern42\SoftwareType[]
+     */
+    public function getSoftware()
+    {
+        return $this->software;
+    }
+
+    /**
+     * Sets a new software
+     *
+     * A Composite containing details of an item of Software.
+     *
+     * @param \DedexBundle\Entity\Ern42\SoftwareType[] $software
+     * @return self
+     */
+    public function setSoftware(?array $software = null)
+    {
+        $this->software = $software;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ResourceProprietaryIdType.php
+++ b/src/Entity/Ern42/ResourceProprietaryIdType.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ResourceProprietaryIdType
+ *
+ * A Composite containing details of ProprietaryIdentifiers of a Resource.
+ * XSD Type: ResourceProprietaryId
+ */
+class ResourceProprietaryIdType
+{
+    /**
+     * The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.
+     *
+     * @var bool $isReplaced
+     */
+    private $isReplaced = null;
+
+    /**
+     * A Composite containing details of a ProprietaryIdentifier of the Resource.
+     *
+     * @var \DedexBundle\Entity\Ern42\ProprietaryIdType[] $proprietaryId
+     */
+    private $proprietaryId = [
+        
+    ];
+
+    /**
+     * Gets as isReplaced
+     *
+     * The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.
+     *
+     * @return bool
+     */
+    public function getIsReplaced()
+    {
+        return $this->isReplaced;
+    }
+
+    /**
+     * Sets a new isReplaced
+     *
+     * The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.
+     *
+     * @param bool $isReplaced
+     * @return self
+     */
+    public function setIsReplaced($isReplaced)
+    {
+        $this->isReplaced = $isReplaced;
+        return $this;
+    }
+
+    /**
+     * Adds as proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Resource.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ProprietaryIdType $proprietaryId
+     */
+    public function addToProprietaryId(\DedexBundle\Entity\Ern42\ProprietaryIdType $proprietaryId)
+    {
+        $this->proprietaryId[] = $proprietaryId;
+        return $this;
+    }
+
+    /**
+     * isset proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Resource.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetProprietaryId($index)
+    {
+        return isset($this->proprietaryId[$index]);
+    }
+
+    /**
+     * unset proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Resource.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetProprietaryId($index)
+    {
+        unset($this->proprietaryId[$index]);
+    }
+
+    /**
+     * Gets as proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Resource.
+     *
+     * @return \DedexBundle\Entity\Ern42\ProprietaryIdType[]
+     */
+    public function getProprietaryId()
+    {
+        return $this->proprietaryId;
+    }
+
+    /**
+     * Sets a new proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Resource.
+     *
+     * @param \DedexBundle\Entity\Ern42\ProprietaryIdType[] $proprietaryId
+     * @return self
+     */
+    public function setProprietaryId(array $proprietaryId)
+    {
+        $this->proprietaryId = $proprietaryId;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ResourceRightsControllerType.php
+++ b/src/Entity/Ern42/ResourceRightsControllerType.php
@@ -1,0 +1,298 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ResourceRightsControllerType
+ *
+ * A Composite containing details of a RightsController for a Resource. RightsControllers are typically described by Name, Identifier and Role(s).
+ * XSD Type: ResourceRightsController
+ */
+class ResourceRightsControllerType
+{
+    /**
+     * The number indicating the order of the RightsController in a group of RightsControllers. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var int $sequenceNumber
+     */
+    private $sequenceNumber = null;
+
+    /**
+     * A Reference for a Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @var string $rightsControllerPartyReference
+     */
+    private $rightsControllerPartyReference = null;
+
+    /**
+     * A role that describes the Party involved in the administration of Rights.
+     *
+     * @var string[] $rightsControlType
+     */
+    private $rightsControlType = [
+        
+    ];
+
+    /**
+     * The Flag indicating whether the RightSharePercentage is unknown (=true) or not (=false).
+     *
+     * @var bool $rightShareUnknown
+     */
+    private $rightShareUnknown = null;
+
+    /**
+     * The share of the licensed Rights owned by the RightsController. RightShare information is given as a xs:decimal value with up to 6 digits (e.g. '12.5' represents 12.5%). If no information is given, 100% is assumed.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/communication-of-percentages
+     *
+     * @var \DedexBundle\Entity\Ern42\PercentageType $rightSharePercentage
+     */
+    private $rightSharePercentage = null;
+
+    /**
+     * A Composite containing details of the kinds of usage for which rights have been delegated.
+     *
+     * @var \DedexBundle\Entity\Ern42\DelegatedUsageRightsType[] $delegatedUsageRights
+     */
+    private $delegatedUsageRights = [
+        
+    ];
+
+    /**
+     * Gets as sequenceNumber
+     *
+     * The number indicating the order of the RightsController in a group of RightsControllers. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return int
+     */
+    public function getSequenceNumber()
+    {
+        return $this->sequenceNumber;
+    }
+
+    /**
+     * Sets a new sequenceNumber
+     *
+     * The number indicating the order of the RightsController in a group of RightsControllers. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param int $sequenceNumber
+     * @return self
+     */
+    public function setSequenceNumber($sequenceNumber)
+    {
+        $this->sequenceNumber = $sequenceNumber;
+        return $this;
+    }
+
+    /**
+     * Gets as rightsControllerPartyReference
+     *
+     * A Reference for a Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @return string
+     */
+    public function getRightsControllerPartyReference()
+    {
+        return $this->rightsControllerPartyReference;
+    }
+
+    /**
+     * Sets a new rightsControllerPartyReference
+     *
+     * A Reference for a Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @param string $rightsControllerPartyReference
+     * @return self
+     */
+    public function setRightsControllerPartyReference($rightsControllerPartyReference)
+    {
+        $this->rightsControllerPartyReference = $rightsControllerPartyReference;
+        return $this;
+    }
+
+    /**
+     * Adds as rightsControlType
+     *
+     * A role that describes the Party involved in the administration of Rights.
+     *
+     * @return self
+     * @param string $rightsControlType
+     */
+    public function addToRightsControlType($rightsControlType)
+    {
+        $this->rightsControlType[] = $rightsControlType;
+        return $this;
+    }
+
+    /**
+     * isset rightsControlType
+     *
+     * A role that describes the Party involved in the administration of Rights.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRightsControlType($index)
+    {
+        return isset($this->rightsControlType[$index]);
+    }
+
+    /**
+     * unset rightsControlType
+     *
+     * A role that describes the Party involved in the administration of Rights.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRightsControlType($index)
+    {
+        unset($this->rightsControlType[$index]);
+    }
+
+    /**
+     * Gets as rightsControlType
+     *
+     * A role that describes the Party involved in the administration of Rights.
+     *
+     * @return string[]
+     */
+    public function getRightsControlType()
+    {
+        return $this->rightsControlType;
+    }
+
+    /**
+     * Sets a new rightsControlType
+     *
+     * A role that describes the Party involved in the administration of Rights.
+     *
+     * @param string $rightsControlType
+     * @return self
+     */
+    public function setRightsControlType(?array $rightsControlType = null)
+    {
+        $this->rightsControlType = $rightsControlType;
+        return $this;
+    }
+
+    /**
+     * Gets as rightShareUnknown
+     *
+     * The Flag indicating whether the RightSharePercentage is unknown (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getRightShareUnknown()
+    {
+        return $this->rightShareUnknown;
+    }
+
+    /**
+     * Sets a new rightShareUnknown
+     *
+     * The Flag indicating whether the RightSharePercentage is unknown (=true) or not (=false).
+     *
+     * @param bool $rightShareUnknown
+     * @return self
+     */
+    public function setRightShareUnknown($rightShareUnknown)
+    {
+        $this->rightShareUnknown = $rightShareUnknown;
+        return $this;
+    }
+
+    /**
+     * Gets as rightSharePercentage
+     *
+     * The share of the licensed Rights owned by the RightsController. RightShare information is given as a xs:decimal value with up to 6 digits (e.g. '12.5' represents 12.5%). If no information is given, 100% is assumed.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/communication-of-percentages
+     *
+     * @return \DedexBundle\Entity\Ern42\PercentageType
+     */
+    public function getRightSharePercentage()
+    {
+        return $this->rightSharePercentage;
+    }
+
+    /**
+     * Sets a new rightSharePercentage
+     *
+     * The share of the licensed Rights owned by the RightsController. RightShare information is given as a xs:decimal value with up to 6 digits (e.g. '12.5' represents 12.5%). If no information is given, 100% is assumed.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/communication-of-percentages
+     *
+     * @param \DedexBundle\Entity\Ern42\PercentageType $rightSharePercentage
+     * @return self
+     */
+    public function setRightSharePercentage(?\DedexBundle\Entity\Ern42\PercentageType $rightSharePercentage = null)
+    {
+        $this->rightSharePercentage = $rightSharePercentage;
+        return $this;
+    }
+
+    /**
+     * Adds as delegatedUsageRights
+     *
+     * A Composite containing details of the kinds of usage for which rights have been delegated.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DelegatedUsageRightsType $delegatedUsageRights
+     */
+    public function addToDelegatedUsageRights(\DedexBundle\Entity\Ern42\DelegatedUsageRightsType $delegatedUsageRights)
+    {
+        $this->delegatedUsageRights[] = $delegatedUsageRights;
+        return $this;
+    }
+
+    /**
+     * isset delegatedUsageRights
+     *
+     * A Composite containing details of the kinds of usage for which rights have been delegated.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDelegatedUsageRights($index)
+    {
+        return isset($this->delegatedUsageRights[$index]);
+    }
+
+    /**
+     * unset delegatedUsageRights
+     *
+     * A Composite containing details of the kinds of usage for which rights have been delegated.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDelegatedUsageRights($index)
+    {
+        unset($this->delegatedUsageRights[$index]);
+    }
+
+    /**
+     * Gets as delegatedUsageRights
+     *
+     * A Composite containing details of the kinds of usage for which rights have been delegated.
+     *
+     * @return \DedexBundle\Entity\Ern42\DelegatedUsageRightsType[]
+     */
+    public function getDelegatedUsageRights()
+    {
+        return $this->delegatedUsageRights;
+    }
+
+    /**
+     * Sets a new delegatedUsageRights
+     *
+     * A Composite containing details of the kinds of usage for which rights have been delegated.
+     *
+     * @param \DedexBundle\Entity\Ern42\DelegatedUsageRightsType[] $delegatedUsageRights
+     * @return self
+     */
+    public function setDelegatedUsageRights(array $delegatedUsageRights)
+    {
+        $this->delegatedUsageRights = $delegatedUsageRights;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ResourceSubGroupType.php
+++ b/src/Entity/Ern42/ResourceSubGroupType.php
@@ -1,0 +1,874 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ResourceSubGroupType
+ *
+ * A Composite containing details of a ResourceGroup that is contained in another ResourceGroup.
+ * XSD Type: ResourceSubGroup
+ */
+class ResourceSubGroupType
+{
+    /**
+     * A Type of ResourceGroup.
+     *
+     * @var string $resourceGroupType
+     */
+    private $resourceGroupType = null;
+
+    /**
+     * A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayTitleTextType[] $displayTitleText
+     */
+    private $displayTitleText = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayTitleType[] $displayTitle
+     */
+    private $displayTitle = [
+        
+    ];
+
+    /**
+     * A Composite containing details of an AdditionalTitle of the ResourceGroup. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @var \DedexBundle\Entity\Ern42\AdditionalTitleType[] $additionalTitle
+     */
+    private $additionalTitle = [
+        
+    ];
+
+    /**
+     * The number indicating the logical order of the ResourceGroup within all ResourceGroups at this level. The default value is 1, and the value must be incremented by 1 for each ResourceGroup occurring at a particular level.
+     *
+     * @var int $sequenceNumber
+     */
+    private $sequenceNumber = null;
+
+    /**
+     * A Flag indicating whether a display sequence exists (=true) or not (=false).
+     *
+     * @var bool $noDisplaySequence
+     */
+    private $noDisplaySequence = null;
+
+    /**
+     * A sequence Identifier used for display purposes, consisting of a string that corresponds to the SequenceNumber, e.g. 'Side B' corresponding to '2'.
+     *
+     * @var string $displaySequence
+     */
+    private $displaySequence = null;
+
+    /**
+     * A Composite containing details of the DisplayArtist for the ResourceGroup. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayArtistType[] $displayArtist
+     */
+    private $displayArtist = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Carrier.
+     *
+     * @var \DedexBundle\Entity\Ern42\CarrierTypeType[] $carrierType
+     */
+    private $carrierType = [
+        
+    ];
+
+    /**
+     * The Duration of the ResourceGroup, if it is a SoundRecording or Video (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @var \DateInterval $duration
+     */
+    private $duration = null;
+
+    /**
+     * The Identifier (specific to the Message) of a Release which has the same content as the ResourceGroup. This is a LocalReleaseAnchorReference starting with the letter R.
+     *
+     * @var string $resourceGroupReleaseReference
+     */
+    private $resourceGroupReleaseReference = null;
+
+    /**
+     * A Composite containing details of ReleaseIds of a Release which has the same content as the ResourceGroup. If available, a GRid has to be used. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.
+     *
+     * @var \DedexBundle\Entity\Ern42\ReleaseIdType $releaseId
+     */
+    private $releaseId = null;
+
+    /**
+     * A ResourceGroup contained within this ResourceGroup. ResourceGroups are used to signal groupings or sequences of Resources within a Release. Examples include individual Carriers in a multi-carrier Release or classical Work groupings as well as the default order of Resources within a Release.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/sequencing-resources
+     *
+     * @var \DedexBundle\Entity\Ern42\ResourceSubGroupType[] $resourceGroup
+     */
+    private $resourceGroup = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Resource contained in the ResourceGroup.
+     *
+     * @var \DedexBundle\Entity\Ern42\ResourceGroupContentItemType[] $resourceGroupContentItem
+     */
+    private $resourceGroupContentItem = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this Release. Example:cover art images associated with the ResourceGroup. This LocalAnchorReference is a xs:string starting with the letter A.
+     *
+     * @var \DedexBundle\Entity\Ern42\LinkedReleaseResourceReferenceType[] $linkedReleaseResourceReference
+     */
+    private $linkedReleaseResourceReference = [
+        
+    ];
+
+    /**
+     * Gets as resourceGroupType
+     *
+     * A Type of ResourceGroup.
+     *
+     * @return string
+     */
+    public function getResourceGroupType()
+    {
+        return $this->resourceGroupType;
+    }
+
+    /**
+     * Sets a new resourceGroupType
+     *
+     * A Type of ResourceGroup.
+     *
+     * @param string $resourceGroupType
+     * @return self
+     */
+    public function setResourceGroupType($resourceGroupType)
+    {
+        $this->resourceGroupType = $resourceGroupType;
+        return $this;
+    }
+
+    /**
+     * Adds as displayTitleText
+     *
+     * A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleTextType $displayTitleText
+     */
+    public function addToDisplayTitleText(\DedexBundle\Entity\Ern42\DisplayTitleTextType $displayTitleText)
+    {
+        $this->displayTitleText[] = $displayTitleText;
+        return $this;
+    }
+
+    /**
+     * isset displayTitleText
+     *
+     * A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayTitleText($index)
+    {
+        return isset($this->displayTitleText[$index]);
+    }
+
+    /**
+     * unset displayTitleText
+     *
+     * A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayTitleText($index)
+    {
+        unset($this->displayTitleText[$index]);
+    }
+
+    /**
+     * Gets as displayTitleText
+     *
+     * A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayTitleTextType[]
+     */
+    public function getDisplayTitleText()
+    {
+        return $this->displayTitleText;
+    }
+
+    /**
+     * Sets a new displayTitleText
+     *
+     * A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleTextType[] $displayTitleText
+     * @return self
+     */
+    public function setDisplayTitleText(?array $displayTitleText = null)
+    {
+        $this->displayTitleText = $displayTitleText;
+        return $this;
+    }
+
+    /**
+     * Adds as displayTitle
+     *
+     * A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleType $displayTitle
+     */
+    public function addToDisplayTitle(\DedexBundle\Entity\Ern42\DisplayTitleType $displayTitle)
+    {
+        $this->displayTitle[] = $displayTitle;
+        return $this;
+    }
+
+    /**
+     * isset displayTitle
+     *
+     * A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayTitle($index)
+    {
+        return isset($this->displayTitle[$index]);
+    }
+
+    /**
+     * unset displayTitle
+     *
+     * A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayTitle($index)
+    {
+        unset($this->displayTitle[$index]);
+    }
+
+    /**
+     * Gets as displayTitle
+     *
+     * A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayTitleType[]
+     */
+    public function getDisplayTitle()
+    {
+        return $this->displayTitle;
+    }
+
+    /**
+     * Sets a new displayTitle
+     *
+     * A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleType[] $displayTitle
+     * @return self
+     */
+    public function setDisplayTitle(?array $displayTitle = null)
+    {
+        $this->displayTitle = $displayTitle;
+        return $this;
+    }
+
+    /**
+     * Adds as additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the ResourceGroup. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\AdditionalTitleType $additionalTitle
+     */
+    public function addToAdditionalTitle(\DedexBundle\Entity\Ern42\AdditionalTitleType $additionalTitle)
+    {
+        $this->additionalTitle[] = $additionalTitle;
+        return $this;
+    }
+
+    /**
+     * isset additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the ResourceGroup. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetAdditionalTitle($index)
+    {
+        return isset($this->additionalTitle[$index]);
+    }
+
+    /**
+     * unset additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the ResourceGroup. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetAdditionalTitle($index)
+    {
+        unset($this->additionalTitle[$index]);
+    }
+
+    /**
+     * Gets as additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the ResourceGroup. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return \DedexBundle\Entity\Ern42\AdditionalTitleType[]
+     */
+    public function getAdditionalTitle()
+    {
+        return $this->additionalTitle;
+    }
+
+    /**
+     * Sets a new additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the ResourceGroup. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param \DedexBundle\Entity\Ern42\AdditionalTitleType[] $additionalTitle
+     * @return self
+     */
+    public function setAdditionalTitle(?array $additionalTitle = null)
+    {
+        $this->additionalTitle = $additionalTitle;
+        return $this;
+    }
+
+    /**
+     * Gets as sequenceNumber
+     *
+     * The number indicating the logical order of the ResourceGroup within all ResourceGroups at this level. The default value is 1, and the value must be incremented by 1 for each ResourceGroup occurring at a particular level.
+     *
+     * @return int
+     */
+    public function getSequenceNumber()
+    {
+        return $this->sequenceNumber;
+    }
+
+    /**
+     * Sets a new sequenceNumber
+     *
+     * The number indicating the logical order of the ResourceGroup within all ResourceGroups at this level. The default value is 1, and the value must be incremented by 1 for each ResourceGroup occurring at a particular level.
+     *
+     * @param int $sequenceNumber
+     * @return self
+     */
+    public function setSequenceNumber($sequenceNumber)
+    {
+        $this->sequenceNumber = $sequenceNumber;
+        return $this;
+    }
+
+    /**
+     * Gets as noDisplaySequence
+     *
+     * A Flag indicating whether a display sequence exists (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getNoDisplaySequence()
+    {
+        return $this->noDisplaySequence;
+    }
+
+    /**
+     * Sets a new noDisplaySequence
+     *
+     * A Flag indicating whether a display sequence exists (=true) or not (=false).
+     *
+     * @param bool $noDisplaySequence
+     * @return self
+     */
+    public function setNoDisplaySequence($noDisplaySequence)
+    {
+        $this->noDisplaySequence = $noDisplaySequence;
+        return $this;
+    }
+
+    /**
+     * Gets as displaySequence
+     *
+     * A sequence Identifier used for display purposes, consisting of a string that corresponds to the SequenceNumber, e.g. 'Side B' corresponding to '2'.
+     *
+     * @return string
+     */
+    public function getDisplaySequence()
+    {
+        return $this->displaySequence;
+    }
+
+    /**
+     * Sets a new displaySequence
+     *
+     * A sequence Identifier used for display purposes, consisting of a string that corresponds to the SequenceNumber, e.g. 'Side B' corresponding to '2'.
+     *
+     * @param string $displaySequence
+     * @return self
+     */
+    public function setDisplaySequence($displaySequence)
+    {
+        $this->displaySequence = $displaySequence;
+        return $this;
+    }
+
+    /**
+     * Adds as displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the ResourceGroup. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistType $displayArtist
+     */
+    public function addToDisplayArtist(\DedexBundle\Entity\Ern42\DisplayArtistType $displayArtist)
+    {
+        $this->displayArtist[] = $displayArtist;
+        return $this;
+    }
+
+    /**
+     * isset displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the ResourceGroup. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayArtist($index)
+    {
+        return isset($this->displayArtist[$index]);
+    }
+
+    /**
+     * unset displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the ResourceGroup. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayArtist($index)
+    {
+        unset($this->displayArtist[$index]);
+    }
+
+    /**
+     * Gets as displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the ResourceGroup. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayArtistType[]
+     */
+    public function getDisplayArtist()
+    {
+        return $this->displayArtist;
+    }
+
+    /**
+     * Sets a new displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the ResourceGroup. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistType[] $displayArtist
+     * @return self
+     */
+    public function setDisplayArtist(?array $displayArtist = null)
+    {
+        $this->displayArtist = $displayArtist;
+        return $this;
+    }
+
+    /**
+     * Adds as carrierType
+     *
+     * A Composite containing details of a Carrier.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\CarrierTypeType $carrierType
+     */
+    public function addToCarrierType(\DedexBundle\Entity\Ern42\CarrierTypeType $carrierType)
+    {
+        $this->carrierType[] = $carrierType;
+        return $this;
+    }
+
+    /**
+     * isset carrierType
+     *
+     * A Composite containing details of a Carrier.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetCarrierType($index)
+    {
+        return isset($this->carrierType[$index]);
+    }
+
+    /**
+     * unset carrierType
+     *
+     * A Composite containing details of a Carrier.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetCarrierType($index)
+    {
+        unset($this->carrierType[$index]);
+    }
+
+    /**
+     * Gets as carrierType
+     *
+     * A Composite containing details of a Carrier.
+     *
+     * @return \DedexBundle\Entity\Ern42\CarrierTypeType[]
+     */
+    public function getCarrierType()
+    {
+        return $this->carrierType;
+    }
+
+    /**
+     * Sets a new carrierType
+     *
+     * A Composite containing details of a Carrier.
+     *
+     * @param \DedexBundle\Entity\Ern42\CarrierTypeType[] $carrierType
+     * @return self
+     */
+    public function setCarrierType(?array $carrierType = null)
+    {
+        $this->carrierType = $carrierType;
+        return $this;
+    }
+
+    /**
+     * Gets as duration
+     *
+     * The Duration of the ResourceGroup, if it is a SoundRecording or Video (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @return \DateInterval
+     */
+    public function getDuration()
+    {
+        return $this->duration;
+    }
+
+    /**
+     * Sets a new duration
+     *
+     * The Duration of the ResourceGroup, if it is a SoundRecording or Video (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @param \DateInterval $duration
+     * @return self
+     */
+    public function setDuration(?\DateInterval $duration = null)
+    {
+        $this->duration = $duration;
+        return $this;
+    }
+
+    /**
+     * Gets as resourceGroupReleaseReference
+     *
+     * The Identifier (specific to the Message) of a Release which has the same content as the ResourceGroup. This is a LocalReleaseAnchorReference starting with the letter R.
+     *
+     * @return string
+     */
+    public function getResourceGroupReleaseReference()
+    {
+        return $this->resourceGroupReleaseReference;
+    }
+
+    /**
+     * Sets a new resourceGroupReleaseReference
+     *
+     * The Identifier (specific to the Message) of a Release which has the same content as the ResourceGroup. This is a LocalReleaseAnchorReference starting with the letter R.
+     *
+     * @param string $resourceGroupReleaseReference
+     * @return self
+     */
+    public function setResourceGroupReleaseReference($resourceGroupReleaseReference)
+    {
+        $this->resourceGroupReleaseReference = $resourceGroupReleaseReference;
+        return $this;
+    }
+
+    /**
+     * Gets as releaseId
+     *
+     * A Composite containing details of ReleaseIds of a Release which has the same content as the ResourceGroup. If available, a GRid has to be used. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.
+     *
+     * @return \DedexBundle\Entity\Ern42\ReleaseIdType
+     */
+    public function getReleaseId()
+    {
+        return $this->releaseId;
+    }
+
+    /**
+     * Sets a new releaseId
+     *
+     * A Composite containing details of ReleaseIds of a Release which has the same content as the ResourceGroup. If available, a GRid has to be used. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.
+     *
+     * @param \DedexBundle\Entity\Ern42\ReleaseIdType $releaseId
+     * @return self
+     */
+    public function setReleaseId(?\DedexBundle\Entity\Ern42\ReleaseIdType $releaseId = null)
+    {
+        $this->releaseId = $releaseId;
+        return $this;
+    }
+
+    /**
+     * Adds as resourceGroup
+     *
+     * A ResourceGroup contained within this ResourceGroup. ResourceGroups are used to signal groupings or sequences of Resources within a Release. Examples include individual Carriers in a multi-carrier Release or classical Work groupings as well as the default order of Resources within a Release.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/sequencing-resources
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ResourceSubGroupType $resourceGroup
+     */
+    public function addToResourceGroup(\DedexBundle\Entity\Ern42\ResourceSubGroupType $resourceGroup)
+    {
+        $this->resourceGroup[] = $resourceGroup;
+        return $this;
+    }
+
+    /**
+     * isset resourceGroup
+     *
+     * A ResourceGroup contained within this ResourceGroup. ResourceGroups are used to signal groupings or sequences of Resources within a Release. Examples include individual Carriers in a multi-carrier Release or classical Work groupings as well as the default order of Resources within a Release.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/sequencing-resources
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetResourceGroup($index)
+    {
+        return isset($this->resourceGroup[$index]);
+    }
+
+    /**
+     * unset resourceGroup
+     *
+     * A ResourceGroup contained within this ResourceGroup. ResourceGroups are used to signal groupings or sequences of Resources within a Release. Examples include individual Carriers in a multi-carrier Release or classical Work groupings as well as the default order of Resources within a Release.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/sequencing-resources
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetResourceGroup($index)
+    {
+        unset($this->resourceGroup[$index]);
+    }
+
+    /**
+     * Gets as resourceGroup
+     *
+     * A ResourceGroup contained within this ResourceGroup. ResourceGroups are used to signal groupings or sequences of Resources within a Release. Examples include individual Carriers in a multi-carrier Release or classical Work groupings as well as the default order of Resources within a Release.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/sequencing-resources
+     *
+     * @return \DedexBundle\Entity\Ern42\ResourceSubGroupType[]
+     */
+    public function getResourceGroup()
+    {
+        return $this->resourceGroup;
+    }
+
+    /**
+     * Sets a new resourceGroup
+     *
+     * A ResourceGroup contained within this ResourceGroup. ResourceGroups are used to signal groupings or sequences of Resources within a Release. Examples include individual Carriers in a multi-carrier Release or classical Work groupings as well as the default order of Resources within a Release.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/sequencing-resources
+     *
+     * @param \DedexBundle\Entity\Ern42\ResourceSubGroupType[] $resourceGroup
+     * @return self
+     */
+    public function setResourceGroup(?array $resourceGroup = null)
+    {
+        $this->resourceGroup = $resourceGroup;
+        return $this;
+    }
+
+    /**
+     * Adds as resourceGroupContentItem
+     *
+     * A Composite containing details of a Resource contained in the ResourceGroup.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ResourceGroupContentItemType $resourceGroupContentItem
+     */
+    public function addToResourceGroupContentItem(\DedexBundle\Entity\Ern42\ResourceGroupContentItemType $resourceGroupContentItem)
+    {
+        $this->resourceGroupContentItem[] = $resourceGroupContentItem;
+        return $this;
+    }
+
+    /**
+     * isset resourceGroupContentItem
+     *
+     * A Composite containing details of a Resource contained in the ResourceGroup.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetResourceGroupContentItem($index)
+    {
+        return isset($this->resourceGroupContentItem[$index]);
+    }
+
+    /**
+     * unset resourceGroupContentItem
+     *
+     * A Composite containing details of a Resource contained in the ResourceGroup.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetResourceGroupContentItem($index)
+    {
+        unset($this->resourceGroupContentItem[$index]);
+    }
+
+    /**
+     * Gets as resourceGroupContentItem
+     *
+     * A Composite containing details of a Resource contained in the ResourceGroup.
+     *
+     * @return \DedexBundle\Entity\Ern42\ResourceGroupContentItemType[]
+     */
+    public function getResourceGroupContentItem()
+    {
+        return $this->resourceGroupContentItem;
+    }
+
+    /**
+     * Sets a new resourceGroupContentItem
+     *
+     * A Composite containing details of a Resource contained in the ResourceGroup.
+     *
+     * @param \DedexBundle\Entity\Ern42\ResourceGroupContentItemType[] $resourceGroupContentItem
+     * @return self
+     */
+    public function setResourceGroupContentItem(?array $resourceGroupContentItem = null)
+    {
+        $this->resourceGroupContentItem = $resourceGroupContentItem;
+        return $this;
+    }
+
+    /**
+     * Adds as linkedReleaseResourceReference
+     *
+     * A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this Release. Example:cover art images associated with the ResourceGroup. This LocalAnchorReference is a xs:string starting with the letter A.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\LinkedReleaseResourceReferenceType $linkedReleaseResourceReference
+     */
+    public function addToLinkedReleaseResourceReference(\DedexBundle\Entity\Ern42\LinkedReleaseResourceReferenceType $linkedReleaseResourceReference)
+    {
+        $this->linkedReleaseResourceReference[] = $linkedReleaseResourceReference;
+        return $this;
+    }
+
+    /**
+     * isset linkedReleaseResourceReference
+     *
+     * A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this Release. Example:cover art images associated with the ResourceGroup. This LocalAnchorReference is a xs:string starting with the letter A.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetLinkedReleaseResourceReference($index)
+    {
+        return isset($this->linkedReleaseResourceReference[$index]);
+    }
+
+    /**
+     * unset linkedReleaseResourceReference
+     *
+     * A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this Release. Example:cover art images associated with the ResourceGroup. This LocalAnchorReference is a xs:string starting with the letter A.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetLinkedReleaseResourceReference($index)
+    {
+        unset($this->linkedReleaseResourceReference[$index]);
+    }
+
+    /**
+     * Gets as linkedReleaseResourceReference
+     *
+     * A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this Release. Example:cover art images associated with the ResourceGroup. This LocalAnchorReference is a xs:string starting with the letter A.
+     *
+     * @return \DedexBundle\Entity\Ern42\LinkedReleaseResourceReferenceType[]
+     */
+    public function getLinkedReleaseResourceReference()
+    {
+        return $this->linkedReleaseResourceReference;
+    }
+
+    /**
+     * Sets a new linkedReleaseResourceReference
+     *
+     * A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this Release. Example:cover art images associated with the ResourceGroup. This LocalAnchorReference is a xs:string starting with the letter A.
+     *
+     * @param \DedexBundle\Entity\Ern42\LinkedReleaseResourceReferenceType[] $linkedReleaseResourceReference
+     * @return self
+     */
+    public function setLinkedReleaseResourceReference(?array $linkedReleaseResourceReference = null)
+    {
+        $this->linkedReleaseResourceReference = $linkedReleaseResourceReference;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/RightsClaimPolicyType.php
+++ b/src/Entity/Ern42/RightsClaimPolicyType.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing RightsClaimPolicyType
+ *
+ * A Composite containing details of a rights claim policy.
+ * XSD Type: RightsClaimPolicy
+ */
+class RightsClaimPolicyType
+{
+    /**
+     * A Composite containing details of Conditions. If more than one Condition is specified, then all of them have to be fulfilled (i.e. they are combined using the logical operator AND).
+     *
+     * @var \DedexBundle\Entity\Ern42\ConditionForRightsClaimPolicyType[] $condition
+     */
+    private $condition = [
+        
+    ];
+
+    /**
+     * A Type of rights claim policy.
+     *
+     * @var string $rightsClaimPolicyType
+     */
+    private $rightsClaimPolicyType = null;
+
+    /**
+     * Adds as condition
+     *
+     * A Composite containing details of Conditions. If more than one Condition is specified, then all of them have to be fulfilled (i.e. they are combined using the logical operator AND).
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ConditionForRightsClaimPolicyType $condition
+     */
+    public function addToCondition(\DedexBundle\Entity\Ern42\ConditionForRightsClaimPolicyType $condition)
+    {
+        $this->condition[] = $condition;
+        return $this;
+    }
+
+    /**
+     * isset condition
+     *
+     * A Composite containing details of Conditions. If more than one Condition is specified, then all of them have to be fulfilled (i.e. they are combined using the logical operator AND).
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetCondition($index)
+    {
+        return isset($this->condition[$index]);
+    }
+
+    /**
+     * unset condition
+     *
+     * A Composite containing details of Conditions. If more than one Condition is specified, then all of them have to be fulfilled (i.e. they are combined using the logical operator AND).
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetCondition($index)
+    {
+        unset($this->condition[$index]);
+    }
+
+    /**
+     * Gets as condition
+     *
+     * A Composite containing details of Conditions. If more than one Condition is specified, then all of them have to be fulfilled (i.e. they are combined using the logical operator AND).
+     *
+     * @return \DedexBundle\Entity\Ern42\ConditionForRightsClaimPolicyType[]
+     */
+    public function getCondition()
+    {
+        return $this->condition;
+    }
+
+    /**
+     * Sets a new condition
+     *
+     * A Composite containing details of Conditions. If more than one Condition is specified, then all of them have to be fulfilled (i.e. they are combined using the logical operator AND).
+     *
+     * @param \DedexBundle\Entity\Ern42\ConditionForRightsClaimPolicyType[] $condition
+     * @return self
+     */
+    public function setCondition(?array $condition = null)
+    {
+        $this->condition = $condition;
+        return $this;
+    }
+
+    /**
+     * Gets as rightsClaimPolicyType
+     *
+     * A Type of rights claim policy.
+     *
+     * @return string
+     */
+    public function getRightsClaimPolicyType()
+    {
+        return $this->rightsClaimPolicyType;
+    }
+
+    /**
+     * Sets a new rightsClaimPolicyType
+     *
+     * A Type of rights claim policy.
+     *
+     * @param string $rightsClaimPolicyType
+     * @return self
+     */
+    public function setRightsClaimPolicyType($rightsClaimPolicyType)
+    {
+        $this->rightsClaimPolicyType = $rightsClaimPolicyType;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/SamplingRateType.php
+++ b/src/Entity/Ern42/SamplingRateType.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing SamplingRateType
+ *
+ * A Composite containing a SamplingRate and a UnitOfMeasure.
+ * XSD Type: SamplingRate
+ */
+class SamplingRateType
+{
+    /**
+     * @var float $__value
+     */
+    private $__value = null;
+
+    /**
+     * The UnitOfMeasure of the SamplingRate. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $unitOfMeasure
+     */
+    private $unitOfMeasure = null;
+
+    /**
+     * Construct
+     *
+     * @param float $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param float $value
+     * @return float
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as unitOfMeasure
+     *
+     * The UnitOfMeasure of the SamplingRate. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUnitOfMeasure()
+    {
+        return $this->unitOfMeasure;
+    }
+
+    /**
+     * Sets a new unitOfMeasure
+     *
+     * The UnitOfMeasure of the SamplingRate. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $unitOfMeasure
+     * @return self
+     */
+    public function setUnitOfMeasure($unitOfMeasure)
+    {
+        $this->unitOfMeasure = $unitOfMeasure;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/SessionTypeType.php
+++ b/src/Entity/Ern42/SessionTypeType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing SessionTypeType
+ *
+ * A Composite containing details of a SessionType.
+ * XSD Type: SessionType
+ */
+class SessionTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the SessionType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the SessionType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the SessionType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the SessionType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the SessionType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the SessionType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/SheetMusicCodecTypeType.php
+++ b/src/Entity/Ern42/SheetMusicCodecTypeType.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing SheetMusicCodecTypeType
+ *
+ * A Composite containing details of a SheetMusicCodecType.
+ * XSD Type: SheetMusicCodecType
+ */
+class SheetMusicCodecTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Identifier of the Version of the SheetMusicCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $version
+     */
+    private $version = null;
+
+    /**
+     * The Namespace of the SheetMusicCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the SheetMusicCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as version
+     *
+     * The Identifier of the Version of the SheetMusicCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getVersion()
+    {
+        return $this->version;
+    }
+
+    /**
+     * Sets a new version
+     *
+     * The Identifier of the Version of the SheetMusicCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $version
+     * @return self
+     */
+    public function setVersion($version)
+    {
+        $this->version = $version;
+        return $this;
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the SheetMusicCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the SheetMusicCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the SheetMusicCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the SheetMusicCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/SheetMusicIdType.php
+++ b/src/Entity/Ern42/SheetMusicIdType.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing SheetMusicIdType
+ *
+ * A Composite containing details of Identifiers of a SheetMusic.
+ * XSD Type: SheetMusicId
+ */
+class SheetMusicIdType
+{
+    /**
+     * The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.
+     *
+     * @var bool $isReplaced
+     */
+    private $isReplaced = null;
+
+    /**
+     * The ISMN (International Standard Music Number defined in ISO 10957) for the SheetMusic. An ISMN is a thirteen-digit number. Pre-2008 ISMNs, which had 10 characters and are now deprecated, are converted by replacing the initial letter ('M') with '979-0'. DDEX will enforce the syntax 979[0-9]{9}[X0-9] using XML Schema in the future.
+     *
+     * @var string $iSMN
+     */
+    private $iSMN = null;
+
+    /**
+     * A Composite containing details of a ProprietaryIdentifier of the SheetMusic.
+     *
+     * @var \DedexBundle\Entity\Ern42\ProprietaryIdType[] $proprietaryId
+     */
+    private $proprietaryId = [
+        
+    ];
+
+    /**
+     * Gets as isReplaced
+     *
+     * The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.
+     *
+     * @return bool
+     */
+    public function getIsReplaced()
+    {
+        return $this->isReplaced;
+    }
+
+    /**
+     * Sets a new isReplaced
+     *
+     * The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.
+     *
+     * @param bool $isReplaced
+     * @return self
+     */
+    public function setIsReplaced($isReplaced)
+    {
+        $this->isReplaced = $isReplaced;
+        return $this;
+    }
+
+    /**
+     * Gets as iSMN
+     *
+     * The ISMN (International Standard Music Number defined in ISO 10957) for the SheetMusic. An ISMN is a thirteen-digit number. Pre-2008 ISMNs, which had 10 characters and are now deprecated, are converted by replacing the initial letter ('M') with '979-0'. DDEX will enforce the syntax 979[0-9]{9}[X0-9] using XML Schema in the future.
+     *
+     * @return string
+     */
+    public function getISMN()
+    {
+        return $this->iSMN;
+    }
+
+    /**
+     * Sets a new iSMN
+     *
+     * The ISMN (International Standard Music Number defined in ISO 10957) for the SheetMusic. An ISMN is a thirteen-digit number. Pre-2008 ISMNs, which had 10 characters and are now deprecated, are converted by replacing the initial letter ('M') with '979-0'. DDEX will enforce the syntax 979[0-9]{9}[X0-9] using XML Schema in the future.
+     *
+     * @param string $iSMN
+     * @return self
+     */
+    public function setISMN($iSMN)
+    {
+        $this->iSMN = $iSMN;
+        return $this;
+    }
+
+    /**
+     * Adds as proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the SheetMusic.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ProprietaryIdType $proprietaryId
+     */
+    public function addToProprietaryId(\DedexBundle\Entity\Ern42\ProprietaryIdType $proprietaryId)
+    {
+        $this->proprietaryId[] = $proprietaryId;
+        return $this;
+    }
+
+    /**
+     * isset proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the SheetMusic.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetProprietaryId($index)
+    {
+        return isset($this->proprietaryId[$index]);
+    }
+
+    /**
+     * unset proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the SheetMusic.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetProprietaryId($index)
+    {
+        unset($this->proprietaryId[$index]);
+    }
+
+    /**
+     * Gets as proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the SheetMusic.
+     *
+     * @return \DedexBundle\Entity\Ern42\ProprietaryIdType[]
+     */
+    public function getProprietaryId()
+    {
+        return $this->proprietaryId;
+    }
+
+    /**
+     * Sets a new proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the SheetMusic.
+     *
+     * @param \DedexBundle\Entity\Ern42\ProprietaryIdType[] $proprietaryId
+     * @return self
+     */
+    public function setProprietaryId(?array $proprietaryId = null)
+    {
+        $this->proprietaryId = $proprietaryId;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/SheetMusicType.php
+++ b/src/Entity/Ern42/SheetMusicType.php
@@ -1,0 +1,1715 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing SheetMusicType
+ *
+ * A Composite containing details of a SheetMusic.
+ * XSD Type: SheetMusic
+ */
+class SheetMusicType
+{
+    /**
+     * The Language and script for the Elements of the SheetMusic as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * The Flag indicating whether the SheetMusic is provided in a addition to the Resources that form part of the Release (=true) or not (=false). If the flag is set to false (or absent) the SheetMusic is part of at least one Release in the message. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isSupplemental
+     */
+    private $isSupplemental = null;
+
+    /**
+     * The Identifier (specific to the Message) of the SheetMusic within the Release which contains it. This is a LocalResourceAnchor starting with the letter A.
+     *
+     * @var string $resourceReference
+     */
+    private $resourceReference = null;
+
+    /**
+     * A Composite containing details of the Type of the SheetMusic.
+     *
+     * @var \DedexBundle\Entity\Ern42\SheetMusicTypeType $type
+     */
+    private $type = null;
+
+    /**
+     * A Composite containing details of Identifiers of the SheetMusic.
+     *
+     * @var \DedexBundle\Entity\Ern42\SheetMusicIdType[] $resourceId
+     */
+    private $resourceId = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the SheetMusic.
+     *
+     * @var \DedexBundle\Entity\Ern42\MusicalWorkIdType[] $workId
+     */
+    private $workId = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Title of the SheetMusic as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayTitleTextType[] $displayTitleText
+     */
+    private $displayTitleText = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Title of the SheetMusic as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayTitleType[] $displayTitle
+     */
+    private $displayTitle = [
+        
+    ];
+
+    /**
+     * A Composite containing details of an AdditionalTitle of the SheetMusic. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @var \DedexBundle\Entity\Ern42\AdditionalTitleType[] $additionalTitle
+     */
+    private $additionalTitle = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Type of Version of the SheetMusic.
+     *
+     * @var \DedexBundle\Entity\Ern42\VersionTypeType[] $versionType
+     */
+    private $versionType = [
+        
+    ];
+
+    /**
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType[] $displayArtistName
+     */
+    private $displayArtistName = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the DisplayArtist for the SheetMusic. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayArtistType[] $displayArtist
+     */
+    private $displayArtist = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Contributor to the SheetMusic.
+     *
+     * @var \DedexBundle\Entity\Ern42\ContributorType[] $contributor
+     */
+    private $contributor = [
+        
+    ];
+
+    /**
+     * A Composite containing details of RightsController of Rights in the SheetMusic.
+     *
+     * @var \DedexBundle\Entity\Ern42\ResourceRightsControllerType[] $resourceRightsController
+     */
+    private $resourceRightsController = [
+        
+    ];
+
+    /**
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @var \DedexBundle\Entity\Ern42\WorkRightsControllerType[] $workRightsController
+     */
+    private $workRightsController = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the CLine for the SheetMusic.
+     *
+     * @var \DedexBundle\Entity\Ern42\CLineWithDefaultType[] $cLine
+     */
+    private $cLine = [
+        
+    ];
+
+    /**
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured in the SheetMusic.
+     *
+     * @var \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType[] $courtesyLine
+     */
+    private $courtesyLine = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the Date and Place of the Event in which the SheetMusic was created. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $creationDate
+     */
+    private $creationDate = null;
+
+    /**
+     * A Composite containing details of the Date and Place of the Event in which the SheetMusic was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @var \DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType[] $firstPublicationDate
+     */
+    private $firstPublicationDate = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the classification of the SheetMusic according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @var \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType[] $parentalWarningType
+     */
+    private $parentalWarningType = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current SheetMusic.
+     *
+     * @var \DedexBundle\Entity\Ern42\RelatedReleaseType[] $relatedRelease
+     */
+    private $relatedRelease = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current SheetMusic.
+     *
+     * @var \DedexBundle\Entity\Ern42\RelatedResourceType[] $relatedResource
+     */
+    private $relatedResource = [
+        
+    ];
+
+    /**
+     * The Flag indicating whether the SheetMusic contains content that is hidden in some way from the Consumer (=true) or not (=false).
+     *
+     * @var bool $containsHiddenContent
+     */
+    private $containsHiddenContent = null;
+
+    /**
+     * The Language of the Lyrics of the SheetMusic as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @var string $languageOfLyrics
+     */
+    private $languageOfLyrics = null;
+
+    /**
+     * A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current SheetMusic.
+     *
+     * @var \DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType[] $resourceContainedResourceReferenceList
+     */
+    private $resourceContainedResourceReferenceList = null;
+
+    /**
+     * A Composite containing technical details of the SheetMusic.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @var \DedexBundle\Entity\Ern42\TechnicalSheetMusicDetailsType[] $technicalDetails
+     */
+    private $technicalDetails = [
+        
+    ];
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the Elements of the SheetMusic as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the Elements of the SheetMusic as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isSupplemental
+     *
+     * The Flag indicating whether the SheetMusic is provided in a addition to the Resources that form part of the Release (=true) or not (=false). If the flag is set to false (or absent) the SheetMusic is part of at least one Release in the message. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsSupplemental()
+    {
+        return $this->isSupplemental;
+    }
+
+    /**
+     * Sets a new isSupplemental
+     *
+     * The Flag indicating whether the SheetMusic is provided in a addition to the Resources that form part of the Release (=true) or not (=false). If the flag is set to false (or absent) the SheetMusic is part of at least one Release in the message. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isSupplemental
+     * @return self
+     */
+    public function setIsSupplemental($isSupplemental)
+    {
+        $this->isSupplemental = $isSupplemental;
+        return $this;
+    }
+
+    /**
+     * Gets as resourceReference
+     *
+     * The Identifier (specific to the Message) of the SheetMusic within the Release which contains it. This is a LocalResourceAnchor starting with the letter A.
+     *
+     * @return string
+     */
+    public function getResourceReference()
+    {
+        return $this->resourceReference;
+    }
+
+    /**
+     * Sets a new resourceReference
+     *
+     * The Identifier (specific to the Message) of the SheetMusic within the Release which contains it. This is a LocalResourceAnchor starting with the letter A.
+     *
+     * @param string $resourceReference
+     * @return self
+     */
+    public function setResourceReference($resourceReference)
+    {
+        $this->resourceReference = $resourceReference;
+        return $this;
+    }
+
+    /**
+     * Gets as type
+     *
+     * A Composite containing details of the Type of the SheetMusic.
+     *
+     * @return \DedexBundle\Entity\Ern42\SheetMusicTypeType
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * Sets a new type
+     *
+     * A Composite containing details of the Type of the SheetMusic.
+     *
+     * @param \DedexBundle\Entity\Ern42\SheetMusicTypeType $type
+     * @return self
+     */
+    public function setType(\DedexBundle\Entity\Ern42\SheetMusicTypeType $type)
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    /**
+     * Adds as resourceId
+     *
+     * A Composite containing details of Identifiers of the SheetMusic.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\SheetMusicIdType $resourceId
+     */
+    public function addToResourceId(\DedexBundle\Entity\Ern42\SheetMusicIdType $resourceId)
+    {
+        $this->resourceId[] = $resourceId;
+        return $this;
+    }
+
+    /**
+     * isset resourceId
+     *
+     * A Composite containing details of Identifiers of the SheetMusic.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetResourceId($index)
+    {
+        return isset($this->resourceId[$index]);
+    }
+
+    /**
+     * unset resourceId
+     *
+     * A Composite containing details of Identifiers of the SheetMusic.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetResourceId($index)
+    {
+        unset($this->resourceId[$index]);
+    }
+
+    /**
+     * Gets as resourceId
+     *
+     * A Composite containing details of Identifiers of the SheetMusic.
+     *
+     * @return \DedexBundle\Entity\Ern42\SheetMusicIdType[]
+     */
+    public function getResourceId()
+    {
+        return $this->resourceId;
+    }
+
+    /**
+     * Sets a new resourceId
+     *
+     * A Composite containing details of Identifiers of the SheetMusic.
+     *
+     * @param \DedexBundle\Entity\Ern42\SheetMusicIdType[] $resourceId
+     * @return self
+     */
+    public function setResourceId(array $resourceId)
+    {
+        $this->resourceId = $resourceId;
+        return $this;
+    }
+
+    /**
+     * Adds as workId
+     *
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the SheetMusic.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\MusicalWorkIdType $workId
+     */
+    public function addToWorkId(\DedexBundle\Entity\Ern42\MusicalWorkIdType $workId)
+    {
+        $this->workId[] = $workId;
+        return $this;
+    }
+
+    /**
+     * isset workId
+     *
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the SheetMusic.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetWorkId($index)
+    {
+        return isset($this->workId[$index]);
+    }
+
+    /**
+     * unset workId
+     *
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the SheetMusic.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetWorkId($index)
+    {
+        unset($this->workId[$index]);
+    }
+
+    /**
+     * Gets as workId
+     *
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the SheetMusic.
+     *
+     * @return \DedexBundle\Entity\Ern42\MusicalWorkIdType[]
+     */
+    public function getWorkId()
+    {
+        return $this->workId;
+    }
+
+    /**
+     * Sets a new workId
+     *
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the SheetMusic.
+     *
+     * @param \DedexBundle\Entity\Ern42\MusicalWorkIdType[] $workId
+     * @return self
+     */
+    public function setWorkId(?array $workId = null)
+    {
+        $this->workId = $workId;
+        return $this;
+    }
+
+    /**
+     * Adds as displayTitleText
+     *
+     * A Composite containing details of a Title of the SheetMusic as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleTextType $displayTitleText
+     */
+    public function addToDisplayTitleText(\DedexBundle\Entity\Ern42\DisplayTitleTextType $displayTitleText)
+    {
+        $this->displayTitleText[] = $displayTitleText;
+        return $this;
+    }
+
+    /**
+     * isset displayTitleText
+     *
+     * A Composite containing details of a Title of the SheetMusic as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayTitleText($index)
+    {
+        return isset($this->displayTitleText[$index]);
+    }
+
+    /**
+     * unset displayTitleText
+     *
+     * A Composite containing details of a Title of the SheetMusic as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayTitleText($index)
+    {
+        unset($this->displayTitleText[$index]);
+    }
+
+    /**
+     * Gets as displayTitleText
+     *
+     * A Composite containing details of a Title of the SheetMusic as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayTitleTextType[]
+     */
+    public function getDisplayTitleText()
+    {
+        return $this->displayTitleText;
+    }
+
+    /**
+     * Sets a new displayTitleText
+     *
+     * A Composite containing details of a Title of the SheetMusic as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleTextType[] $displayTitleText
+     * @return self
+     */
+    public function setDisplayTitleText(?array $displayTitleText = null)
+    {
+        $this->displayTitleText = $displayTitleText;
+        return $this;
+    }
+
+    /**
+     * Adds as displayTitle
+     *
+     * A Composite containing details of a Title of the SheetMusic as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleType $displayTitle
+     */
+    public function addToDisplayTitle(\DedexBundle\Entity\Ern42\DisplayTitleType $displayTitle)
+    {
+        $this->displayTitle[] = $displayTitle;
+        return $this;
+    }
+
+    /**
+     * isset displayTitle
+     *
+     * A Composite containing details of a Title of the SheetMusic as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayTitle($index)
+    {
+        return isset($this->displayTitle[$index]);
+    }
+
+    /**
+     * unset displayTitle
+     *
+     * A Composite containing details of a Title of the SheetMusic as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayTitle($index)
+    {
+        unset($this->displayTitle[$index]);
+    }
+
+    /**
+     * Gets as displayTitle
+     *
+     * A Composite containing details of a Title of the SheetMusic as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayTitleType[]
+     */
+    public function getDisplayTitle()
+    {
+        return $this->displayTitle;
+    }
+
+    /**
+     * Sets a new displayTitle
+     *
+     * A Composite containing details of a Title of the SheetMusic as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleType[] $displayTitle
+     * @return self
+     */
+    public function setDisplayTitle(?array $displayTitle = null)
+    {
+        $this->displayTitle = $displayTitle;
+        return $this;
+    }
+
+    /**
+     * Adds as additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the SheetMusic. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\AdditionalTitleType $additionalTitle
+     */
+    public function addToAdditionalTitle(\DedexBundle\Entity\Ern42\AdditionalTitleType $additionalTitle)
+    {
+        $this->additionalTitle[] = $additionalTitle;
+        return $this;
+    }
+
+    /**
+     * isset additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the SheetMusic. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetAdditionalTitle($index)
+    {
+        return isset($this->additionalTitle[$index]);
+    }
+
+    /**
+     * unset additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the SheetMusic. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetAdditionalTitle($index)
+    {
+        unset($this->additionalTitle[$index]);
+    }
+
+    /**
+     * Gets as additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the SheetMusic. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return \DedexBundle\Entity\Ern42\AdditionalTitleType[]
+     */
+    public function getAdditionalTitle()
+    {
+        return $this->additionalTitle;
+    }
+
+    /**
+     * Sets a new additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the SheetMusic. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param \DedexBundle\Entity\Ern42\AdditionalTitleType[] $additionalTitle
+     * @return self
+     */
+    public function setAdditionalTitle(?array $additionalTitle = null)
+    {
+        $this->additionalTitle = $additionalTitle;
+        return $this;
+    }
+
+    /**
+     * Adds as versionType
+     *
+     * A Composite containing details of a Type of Version of the SheetMusic.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\VersionTypeType $versionType
+     */
+    public function addToVersionType(\DedexBundle\Entity\Ern42\VersionTypeType $versionType)
+    {
+        $this->versionType[] = $versionType;
+        return $this;
+    }
+
+    /**
+     * isset versionType
+     *
+     * A Composite containing details of a Type of Version of the SheetMusic.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetVersionType($index)
+    {
+        return isset($this->versionType[$index]);
+    }
+
+    /**
+     * unset versionType
+     *
+     * A Composite containing details of a Type of Version of the SheetMusic.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetVersionType($index)
+    {
+        unset($this->versionType[$index]);
+    }
+
+    /**
+     * Gets as versionType
+     *
+     * A Composite containing details of a Type of Version of the SheetMusic.
+     *
+     * @return \DedexBundle\Entity\Ern42\VersionTypeType[]
+     */
+    public function getVersionType()
+    {
+        return $this->versionType;
+    }
+
+    /**
+     * Sets a new versionType
+     *
+     * A Composite containing details of a Type of Version of the SheetMusic.
+     *
+     * @param \DedexBundle\Entity\Ern42\VersionTypeType[] $versionType
+     * @return self
+     */
+    public function setVersionType(?array $versionType = null)
+    {
+        $this->versionType = $versionType;
+        return $this;
+    }
+
+    /**
+     * Adds as displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType $displayArtistName
+     */
+    public function addToDisplayArtistName(\DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType $displayArtistName)
+    {
+        $this->displayArtistName[] = $displayArtistName;
+        return $this;
+    }
+
+    /**
+     * isset displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayArtistName($index)
+    {
+        return isset($this->displayArtistName[$index]);
+    }
+
+    /**
+     * unset displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayArtistName($index)
+    {
+        unset($this->displayArtistName[$index]);
+    }
+
+    /**
+     * Gets as displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType[]
+     */
+    public function getDisplayArtistName()
+    {
+        return $this->displayArtistName;
+    }
+
+    /**
+     * Sets a new displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType[] $displayArtistName
+     * @return self
+     */
+    public function setDisplayArtistName(array $displayArtistName)
+    {
+        $this->displayArtistName = $displayArtistName;
+        return $this;
+    }
+
+    /**
+     * Adds as displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the SheetMusic. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistType $displayArtist
+     */
+    public function addToDisplayArtist(\DedexBundle\Entity\Ern42\DisplayArtistType $displayArtist)
+    {
+        $this->displayArtist[] = $displayArtist;
+        return $this;
+    }
+
+    /**
+     * isset displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the SheetMusic. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayArtist($index)
+    {
+        return isset($this->displayArtist[$index]);
+    }
+
+    /**
+     * unset displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the SheetMusic. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayArtist($index)
+    {
+        unset($this->displayArtist[$index]);
+    }
+
+    /**
+     * Gets as displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the SheetMusic. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayArtistType[]
+     */
+    public function getDisplayArtist()
+    {
+        return $this->displayArtist;
+    }
+
+    /**
+     * Sets a new displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the SheetMusic. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistType[] $displayArtist
+     * @return self
+     */
+    public function setDisplayArtist(?array $displayArtist = null)
+    {
+        $this->displayArtist = $displayArtist;
+        return $this;
+    }
+
+    /**
+     * Adds as contributor
+     *
+     * A Composite containing details of a Contributor to the SheetMusic.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ContributorType $contributor
+     */
+    public function addToContributor(\DedexBundle\Entity\Ern42\ContributorType $contributor)
+    {
+        $this->contributor[] = $contributor;
+        return $this;
+    }
+
+    /**
+     * isset contributor
+     *
+     * A Composite containing details of a Contributor to the SheetMusic.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetContributor($index)
+    {
+        return isset($this->contributor[$index]);
+    }
+
+    /**
+     * unset contributor
+     *
+     * A Composite containing details of a Contributor to the SheetMusic.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetContributor($index)
+    {
+        unset($this->contributor[$index]);
+    }
+
+    /**
+     * Gets as contributor
+     *
+     * A Composite containing details of a Contributor to the SheetMusic.
+     *
+     * @return \DedexBundle\Entity\Ern42\ContributorType[]
+     */
+    public function getContributor()
+    {
+        return $this->contributor;
+    }
+
+    /**
+     * Sets a new contributor
+     *
+     * A Composite containing details of a Contributor to the SheetMusic.
+     *
+     * @param \DedexBundle\Entity\Ern42\ContributorType[] $contributor
+     * @return self
+     */
+    public function setContributor(?array $contributor = null)
+    {
+        $this->contributor = $contributor;
+        return $this;
+    }
+
+    /**
+     * Adds as resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the SheetMusic.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ResourceRightsControllerType $resourceRightsController
+     */
+    public function addToResourceRightsController(\DedexBundle\Entity\Ern42\ResourceRightsControllerType $resourceRightsController)
+    {
+        $this->resourceRightsController[] = $resourceRightsController;
+        return $this;
+    }
+
+    /**
+     * isset resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the SheetMusic.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetResourceRightsController($index)
+    {
+        return isset($this->resourceRightsController[$index]);
+    }
+
+    /**
+     * unset resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the SheetMusic.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetResourceRightsController($index)
+    {
+        unset($this->resourceRightsController[$index]);
+    }
+
+    /**
+     * Gets as resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the SheetMusic.
+     *
+     * @return \DedexBundle\Entity\Ern42\ResourceRightsControllerType[]
+     */
+    public function getResourceRightsController()
+    {
+        return $this->resourceRightsController;
+    }
+
+    /**
+     * Sets a new resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the SheetMusic.
+     *
+     * @param \DedexBundle\Entity\Ern42\ResourceRightsControllerType[] $resourceRightsController
+     * @return self
+     */
+    public function setResourceRightsController(?array $resourceRightsController = null)
+    {
+        $this->resourceRightsController = $resourceRightsController;
+        return $this;
+    }
+
+    /**
+     * Adds as workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\WorkRightsControllerType $workRightsController
+     */
+    public function addToWorkRightsController(\DedexBundle\Entity\Ern42\WorkRightsControllerType $workRightsController)
+    {
+        $this->workRightsController[] = $workRightsController;
+        return $this;
+    }
+
+    /**
+     * isset workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetWorkRightsController($index)
+    {
+        return isset($this->workRightsController[$index]);
+    }
+
+    /**
+     * unset workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetWorkRightsController($index)
+    {
+        unset($this->workRightsController[$index]);
+    }
+
+    /**
+     * Gets as workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @return \DedexBundle\Entity\Ern42\WorkRightsControllerType[]
+     */
+    public function getWorkRightsController()
+    {
+        return $this->workRightsController;
+    }
+
+    /**
+     * Sets a new workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @param \DedexBundle\Entity\Ern42\WorkRightsControllerType[] $workRightsController
+     * @return self
+     */
+    public function setWorkRightsController(?array $workRightsController = null)
+    {
+        $this->workRightsController = $workRightsController;
+        return $this;
+    }
+
+    /**
+     * Adds as cLine
+     *
+     * A Composite containing details of the CLine for the SheetMusic.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\CLineWithDefaultType $cLine
+     */
+    public function addToCLine(\DedexBundle\Entity\Ern42\CLineWithDefaultType $cLine)
+    {
+        $this->cLine[] = $cLine;
+        return $this;
+    }
+
+    /**
+     * isset cLine
+     *
+     * A Composite containing details of the CLine for the SheetMusic.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetCLine($index)
+    {
+        return isset($this->cLine[$index]);
+    }
+
+    /**
+     * unset cLine
+     *
+     * A Composite containing details of the CLine for the SheetMusic.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetCLine($index)
+    {
+        unset($this->cLine[$index]);
+    }
+
+    /**
+     * Gets as cLine
+     *
+     * A Composite containing details of the CLine for the SheetMusic.
+     *
+     * @return \DedexBundle\Entity\Ern42\CLineWithDefaultType[]
+     */
+    public function getCLine()
+    {
+        return $this->cLine;
+    }
+
+    /**
+     * Sets a new cLine
+     *
+     * A Composite containing details of the CLine for the SheetMusic.
+     *
+     * @param \DedexBundle\Entity\Ern42\CLineWithDefaultType[] $cLine
+     * @return self
+     */
+    public function setCLine(?array $cLine = null)
+    {
+        $this->cLine = $cLine;
+        return $this;
+    }
+
+    /**
+     * Adds as courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured in the SheetMusic.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType $courtesyLine
+     */
+    public function addToCourtesyLine(\DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType $courtesyLine)
+    {
+        $this->courtesyLine[] = $courtesyLine;
+        return $this;
+    }
+
+    /**
+     * isset courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured in the SheetMusic.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetCourtesyLine($index)
+    {
+        return isset($this->courtesyLine[$index]);
+    }
+
+    /**
+     * unset courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured in the SheetMusic.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetCourtesyLine($index)
+    {
+        unset($this->courtesyLine[$index]);
+    }
+
+    /**
+     * Gets as courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured in the SheetMusic.
+     *
+     * @return \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType[]
+     */
+    public function getCourtesyLine()
+    {
+        return $this->courtesyLine;
+    }
+
+    /**
+     * Sets a new courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured in the SheetMusic.
+     *
+     * @param \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType[] $courtesyLine
+     * @return self
+     */
+    public function setCourtesyLine(?array $courtesyLine = null)
+    {
+        $this->courtesyLine = $courtesyLine;
+        return $this;
+    }
+
+    /**
+     * Gets as creationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the SheetMusic was created. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType
+     */
+    public function getCreationDate()
+    {
+        return $this->creationDate;
+    }
+
+    /**
+     * Sets a new creationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the SheetMusic was created. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $creationDate
+     * @return self
+     */
+    public function setCreationDate(?\DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $creationDate = null)
+    {
+        $this->creationDate = $creationDate;
+        return $this;
+    }
+
+    /**
+     * Adds as firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the SheetMusic was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType $firstPublicationDate
+     */
+    public function addToFirstPublicationDate(\DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType $firstPublicationDate)
+    {
+        $this->firstPublicationDate[] = $firstPublicationDate;
+        return $this;
+    }
+
+    /**
+     * isset firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the SheetMusic was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetFirstPublicationDate($index)
+    {
+        return isset($this->firstPublicationDate[$index]);
+    }
+
+    /**
+     * unset firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the SheetMusic was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetFirstPublicationDate($index)
+    {
+        unset($this->firstPublicationDate[$index]);
+    }
+
+    /**
+     * Gets as firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the SheetMusic was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @return \DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType[]
+     */
+    public function getFirstPublicationDate()
+    {
+        return $this->firstPublicationDate;
+    }
+
+    /**
+     * Sets a new firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the SheetMusic was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param \DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType[] $firstPublicationDate
+     * @return self
+     */
+    public function setFirstPublicationDate(?array $firstPublicationDate = null)
+    {
+        $this->firstPublicationDate = $firstPublicationDate;
+        return $this;
+    }
+
+    /**
+     * Adds as parentalWarningType
+     *
+     * A Composite containing details of the classification of the SheetMusic according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType $parentalWarningType
+     */
+    public function addToParentalWarningType(\DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType $parentalWarningType)
+    {
+        $this->parentalWarningType[] = $parentalWarningType;
+        return $this;
+    }
+
+    /**
+     * isset parentalWarningType
+     *
+     * A Composite containing details of the classification of the SheetMusic according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetParentalWarningType($index)
+    {
+        return isset($this->parentalWarningType[$index]);
+    }
+
+    /**
+     * unset parentalWarningType
+     *
+     * A Composite containing details of the classification of the SheetMusic according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetParentalWarningType($index)
+    {
+        unset($this->parentalWarningType[$index]);
+    }
+
+    /**
+     * Gets as parentalWarningType
+     *
+     * A Composite containing details of the classification of the SheetMusic according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @return \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType[]
+     */
+    public function getParentalWarningType()
+    {
+        return $this->parentalWarningType;
+    }
+
+    /**
+     * Sets a new parentalWarningType
+     *
+     * A Composite containing details of the classification of the SheetMusic according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @param \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType[] $parentalWarningType
+     * @return self
+     */
+    public function setParentalWarningType(?array $parentalWarningType = null)
+    {
+        $this->parentalWarningType = $parentalWarningType;
+        return $this;
+    }
+
+    /**
+     * Adds as relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current SheetMusic.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\RelatedReleaseType $relatedRelease
+     */
+    public function addToRelatedRelease(\DedexBundle\Entity\Ern42\RelatedReleaseType $relatedRelease)
+    {
+        $this->relatedRelease[] = $relatedRelease;
+        return $this;
+    }
+
+    /**
+     * isset relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current SheetMusic.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRelatedRelease($index)
+    {
+        return isset($this->relatedRelease[$index]);
+    }
+
+    /**
+     * unset relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current SheetMusic.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRelatedRelease($index)
+    {
+        unset($this->relatedRelease[$index]);
+    }
+
+    /**
+     * Gets as relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current SheetMusic.
+     *
+     * @return \DedexBundle\Entity\Ern42\RelatedReleaseType[]
+     */
+    public function getRelatedRelease()
+    {
+        return $this->relatedRelease;
+    }
+
+    /**
+     * Sets a new relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current SheetMusic.
+     *
+     * @param \DedexBundle\Entity\Ern42\RelatedReleaseType[] $relatedRelease
+     * @return self
+     */
+    public function setRelatedRelease(?array $relatedRelease = null)
+    {
+        $this->relatedRelease = $relatedRelease;
+        return $this;
+    }
+
+    /**
+     * Adds as relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current SheetMusic.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\RelatedResourceType $relatedResource
+     */
+    public function addToRelatedResource(\DedexBundle\Entity\Ern42\RelatedResourceType $relatedResource)
+    {
+        $this->relatedResource[] = $relatedResource;
+        return $this;
+    }
+
+    /**
+     * isset relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current SheetMusic.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRelatedResource($index)
+    {
+        return isset($this->relatedResource[$index]);
+    }
+
+    /**
+     * unset relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current SheetMusic.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRelatedResource($index)
+    {
+        unset($this->relatedResource[$index]);
+    }
+
+    /**
+     * Gets as relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current SheetMusic.
+     *
+     * @return \DedexBundle\Entity\Ern42\RelatedResourceType[]
+     */
+    public function getRelatedResource()
+    {
+        return $this->relatedResource;
+    }
+
+    /**
+     * Sets a new relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current SheetMusic.
+     *
+     * @param \DedexBundle\Entity\Ern42\RelatedResourceType[] $relatedResource
+     * @return self
+     */
+    public function setRelatedResource(?array $relatedResource = null)
+    {
+        $this->relatedResource = $relatedResource;
+        return $this;
+    }
+
+    /**
+     * Gets as containsHiddenContent
+     *
+     * The Flag indicating whether the SheetMusic contains content that is hidden in some way from the Consumer (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getContainsHiddenContent()
+    {
+        return $this->containsHiddenContent;
+    }
+
+    /**
+     * Sets a new containsHiddenContent
+     *
+     * The Flag indicating whether the SheetMusic contains content that is hidden in some way from the Consumer (=true) or not (=false).
+     *
+     * @param bool $containsHiddenContent
+     * @return self
+     */
+    public function setContainsHiddenContent($containsHiddenContent)
+    {
+        $this->containsHiddenContent = $containsHiddenContent;
+        return $this;
+    }
+
+    /**
+     * Gets as languageOfLyrics
+     *
+     * The Language of the Lyrics of the SheetMusic as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @return string
+     */
+    public function getLanguageOfLyrics()
+    {
+        return $this->languageOfLyrics;
+    }
+
+    /**
+     * Sets a new languageOfLyrics
+     *
+     * The Language of the Lyrics of the SheetMusic as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @param string $languageOfLyrics
+     * @return self
+     */
+    public function setLanguageOfLyrics($languageOfLyrics)
+    {
+        $this->languageOfLyrics = $languageOfLyrics;
+        return $this;
+    }
+
+    /**
+     * Adds as resourceContainedResourceReference
+     *
+     * A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current SheetMusic.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType $resourceContainedResourceReference
+     */
+    public function addToResourceContainedResourceReferenceList(\DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType $resourceContainedResourceReference)
+    {
+        $this->resourceContainedResourceReferenceList[] = $resourceContainedResourceReference;
+        return $this;
+    }
+
+    /**
+     * isset resourceContainedResourceReferenceList
+     *
+     * A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current SheetMusic.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetResourceContainedResourceReferenceList($index)
+    {
+        return isset($this->resourceContainedResourceReferenceList[$index]);
+    }
+
+    /**
+     * unset resourceContainedResourceReferenceList
+     *
+     * A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current SheetMusic.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetResourceContainedResourceReferenceList($index)
+    {
+        unset($this->resourceContainedResourceReferenceList[$index]);
+    }
+
+    /**
+     * Gets as resourceContainedResourceReferenceList
+     *
+     * A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current SheetMusic.
+     *
+     * @return \DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType[]
+     */
+    public function getResourceContainedResourceReferenceList()
+    {
+        return $this->resourceContainedResourceReferenceList;
+    }
+
+    /**
+     * Sets a new resourceContainedResourceReferenceList
+     *
+     * A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current SheetMusic.
+     *
+     * @param \DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType[] $resourceContainedResourceReferenceList
+     * @return self
+     */
+    public function setResourceContainedResourceReferenceList(?array $resourceContainedResourceReferenceList = null)
+    {
+        $this->resourceContainedResourceReferenceList = $resourceContainedResourceReferenceList;
+        return $this;
+    }
+
+    /**
+     * Adds as technicalDetails
+     *
+     * A Composite containing technical details of the SheetMusic.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\TechnicalSheetMusicDetailsType $technicalDetails
+     */
+    public function addToTechnicalDetails(\DedexBundle\Entity\Ern42\TechnicalSheetMusicDetailsType $technicalDetails)
+    {
+        $this->technicalDetails[] = $technicalDetails;
+        return $this;
+    }
+
+    /**
+     * isset technicalDetails
+     *
+     * A Composite containing technical details of the SheetMusic.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetTechnicalDetails($index)
+    {
+        return isset($this->technicalDetails[$index]);
+    }
+
+    /**
+     * unset technicalDetails
+     *
+     * A Composite containing technical details of the SheetMusic.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetTechnicalDetails($index)
+    {
+        unset($this->technicalDetails[$index]);
+    }
+
+    /**
+     * Gets as technicalDetails
+     *
+     * A Composite containing technical details of the SheetMusic.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @return \DedexBundle\Entity\Ern42\TechnicalSheetMusicDetailsType[]
+     */
+    public function getTechnicalDetails()
+    {
+        return $this->technicalDetails;
+    }
+
+    /**
+     * Sets a new technicalDetails
+     *
+     * A Composite containing technical details of the SheetMusic.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @param \DedexBundle\Entity\Ern42\TechnicalSheetMusicDetailsType[] $technicalDetails
+     * @return self
+     */
+    public function setTechnicalDetails(?array $technicalDetails = null)
+    {
+        $this->technicalDetails = $technicalDetails;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/SheetMusicTypeType.php
+++ b/src/Entity/Ern42/SheetMusicTypeType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing SheetMusicTypeType
+ *
+ * A Composite containing details of a SheetMusicType.
+ * XSD Type: SheetMusicType
+ */
+class SheetMusicTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the SheetMusicType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the SheetMusicType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the SheetMusicType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the SheetMusicType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the SheetMusicType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the SheetMusicType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/SimpleRightsTypeType.php
+++ b/src/Entity/Ern42/SimpleRightsTypeType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing SimpleRightsTypeType
+ *
+ * A Composite containing details of a RightsType.
+ * XSD Type: SimpleRightsType
+ */
+class SimpleRightsTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the RightsType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the RightsType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the RightsType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the RightsType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the RightsType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the RightsType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/SoftwareType.php
+++ b/src/Entity/Ern42/SoftwareType.php
@@ -1,0 +1,1757 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing SoftwareType
+ *
+ * A Composite containing details of an item of Software.
+ * XSD Type: Software
+ */
+class SoftwareType
+{
+    /**
+     * The Language and script for the Elements of the Software as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * The Flag indicating whether the Software is provided in a addition to the Resources that form part of the Release (=true) or not (=false). If the flag is set to false (or absent) the Software is part of at least one Release in the message. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isSupplemental
+     */
+    private $isSupplemental = null;
+
+    /**
+     * The Identifier (specific to the Message) of the Software within the Release which contains it. This is a LocalResourceAnchor starting with the letter A.
+     *
+     * @var string $resourceReference
+     */
+    private $resourceReference = null;
+
+    /**
+     * A Composite containing details of the Type of the Software.
+     *
+     * @var \DedexBundle\Entity\Ern42\SoftwareTypeType $type
+     */
+    private $type = null;
+
+    /**
+     * A Composite containing details of Identifiers of the Software.
+     *
+     * @var \DedexBundle\Entity\Ern42\ResourceProprietaryIdType[] $resourceId
+     */
+    private $resourceId = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the Software.
+     *
+     * @var \DedexBundle\Entity\Ern42\MusicalWorkIdType[] $workId
+     */
+    private $workId = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Title of the Software as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayTitleTextType[] $displayTitleText
+     */
+    private $displayTitleText = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Title of the Software as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayTitleType[] $displayTitle
+     */
+    private $displayTitle = [
+        
+    ];
+
+    /**
+     * A Composite containing details of an AdditionalTitle of the Software. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @var \DedexBundle\Entity\Ern42\AdditionalTitleType[] $additionalTitle
+     */
+    private $additionalTitle = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Type of Version of the Software.
+     *
+     * @var \DedexBundle\Entity\Ern42\VersionTypeType[] $versionType
+     */
+    private $versionType = [
+        
+    ];
+
+    /**
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType[] $displayArtistName
+     */
+    private $displayArtistName = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the DisplayArtist for the Software. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayArtistType[] $displayArtist
+     */
+    private $displayArtist = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Contributor to the Software.
+     *
+     * @var \DedexBundle\Entity\Ern42\ContributorType[] $contributor
+     */
+    private $contributor = [
+        
+    ];
+
+    /**
+     * A Composite containing details of RightsController of Rights in the Software.
+     *
+     * @var \DedexBundle\Entity\Ern42\ResourceRightsControllerType[] $resourceRightsController
+     */
+    private $resourceRightsController = [
+        
+    ];
+
+    /**
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @var \DedexBundle\Entity\Ern42\WorkRightsControllerType[] $workRightsController
+     */
+    private $workRightsController = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the PLine for the Software.
+     *
+     * @var \DedexBundle\Entity\Ern42\PLineWithDefaultType[] $pLine
+     */
+    private $pLine = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the CLine for the Software.
+     *
+     * @var \DedexBundle\Entity\Ern42\CLineWithDefaultType[] $cLine
+     */
+    private $cLine = [
+        
+    ];
+
+    /**
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured in the Software.
+     *
+     * @var \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType[] $courtesyLine
+     */
+    private $courtesyLine = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the Date and Place of the Event in which the Software was created. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $creationDate
+     */
+    private $creationDate = null;
+
+    /**
+     * A Composite containing details of the Date and Place of the Event in which the Software was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @var \DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType[] $firstPublicationDate
+     */
+    private $firstPublicationDate = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the classification of the Software according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @var \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType[] $parentalWarningType
+     */
+    private $parentalWarningType = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Software.
+     *
+     * @var \DedexBundle\Entity\Ern42\RelatedReleaseType[] $relatedRelease
+     */
+    private $relatedRelease = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Software.
+     *
+     * @var \DedexBundle\Entity\Ern42\RelatedResourceType[] $relatedResource
+     */
+    private $relatedResource = [
+        
+    ];
+
+    /**
+     * The Flag indicating whether the Software contains content that is hidden in some way from the Consumer (=true) or not (=false).
+     *
+     * @var bool $containsHiddenContent
+     */
+    private $containsHiddenContent = null;
+
+    /**
+     * A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current Software.
+     *
+     * @var \DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType[] $resourceContainedResourceReferenceList
+     */
+    private $resourceContainedResourceReferenceList = null;
+
+    /**
+     * A Composite containing technical details of the Software.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @var \DedexBundle\Entity\Ern42\TechnicalSoftwareDetailsType[] $technicalDetails
+     */
+    private $technicalDetails = [
+        
+    ];
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the Elements of the Software as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the Elements of the Software as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isSupplemental
+     *
+     * The Flag indicating whether the Software is provided in a addition to the Resources that form part of the Release (=true) or not (=false). If the flag is set to false (or absent) the Software is part of at least one Release in the message. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsSupplemental()
+    {
+        return $this->isSupplemental;
+    }
+
+    /**
+     * Sets a new isSupplemental
+     *
+     * The Flag indicating whether the Software is provided in a addition to the Resources that form part of the Release (=true) or not (=false). If the flag is set to false (or absent) the Software is part of at least one Release in the message. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isSupplemental
+     * @return self
+     */
+    public function setIsSupplemental($isSupplemental)
+    {
+        $this->isSupplemental = $isSupplemental;
+        return $this;
+    }
+
+    /**
+     * Gets as resourceReference
+     *
+     * The Identifier (specific to the Message) of the Software within the Release which contains it. This is a LocalResourceAnchor starting with the letter A.
+     *
+     * @return string
+     */
+    public function getResourceReference()
+    {
+        return $this->resourceReference;
+    }
+
+    /**
+     * Sets a new resourceReference
+     *
+     * The Identifier (specific to the Message) of the Software within the Release which contains it. This is a LocalResourceAnchor starting with the letter A.
+     *
+     * @param string $resourceReference
+     * @return self
+     */
+    public function setResourceReference($resourceReference)
+    {
+        $this->resourceReference = $resourceReference;
+        return $this;
+    }
+
+    /**
+     * Gets as type
+     *
+     * A Composite containing details of the Type of the Software.
+     *
+     * @return \DedexBundle\Entity\Ern42\SoftwareTypeType
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * Sets a new type
+     *
+     * A Composite containing details of the Type of the Software.
+     *
+     * @param \DedexBundle\Entity\Ern42\SoftwareTypeType $type
+     * @return self
+     */
+    public function setType(\DedexBundle\Entity\Ern42\SoftwareTypeType $type)
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    /**
+     * Adds as resourceId
+     *
+     * A Composite containing details of Identifiers of the Software.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ResourceProprietaryIdType $resourceId
+     */
+    public function addToResourceId(\DedexBundle\Entity\Ern42\ResourceProprietaryIdType $resourceId)
+    {
+        $this->resourceId[] = $resourceId;
+        return $this;
+    }
+
+    /**
+     * isset resourceId
+     *
+     * A Composite containing details of Identifiers of the Software.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetResourceId($index)
+    {
+        return isset($this->resourceId[$index]);
+    }
+
+    /**
+     * unset resourceId
+     *
+     * A Composite containing details of Identifiers of the Software.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetResourceId($index)
+    {
+        unset($this->resourceId[$index]);
+    }
+
+    /**
+     * Gets as resourceId
+     *
+     * A Composite containing details of Identifiers of the Software.
+     *
+     * @return \DedexBundle\Entity\Ern42\ResourceProprietaryIdType[]
+     */
+    public function getResourceId()
+    {
+        return $this->resourceId;
+    }
+
+    /**
+     * Sets a new resourceId
+     *
+     * A Composite containing details of Identifiers of the Software.
+     *
+     * @param \DedexBundle\Entity\Ern42\ResourceProprietaryIdType[] $resourceId
+     * @return self
+     */
+    public function setResourceId(array $resourceId)
+    {
+        $this->resourceId = $resourceId;
+        return $this;
+    }
+
+    /**
+     * Adds as workId
+     *
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the Software.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\MusicalWorkIdType $workId
+     */
+    public function addToWorkId(\DedexBundle\Entity\Ern42\MusicalWorkIdType $workId)
+    {
+        $this->workId[] = $workId;
+        return $this;
+    }
+
+    /**
+     * isset workId
+     *
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the Software.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetWorkId($index)
+    {
+        return isset($this->workId[$index]);
+    }
+
+    /**
+     * unset workId
+     *
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the Software.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetWorkId($index)
+    {
+        unset($this->workId[$index]);
+    }
+
+    /**
+     * Gets as workId
+     *
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the Software.
+     *
+     * @return \DedexBundle\Entity\Ern42\MusicalWorkIdType[]
+     */
+    public function getWorkId()
+    {
+        return $this->workId;
+    }
+
+    /**
+     * Sets a new workId
+     *
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the Software.
+     *
+     * @param \DedexBundle\Entity\Ern42\MusicalWorkIdType[] $workId
+     * @return self
+     */
+    public function setWorkId(?array $workId = null)
+    {
+        $this->workId = $workId;
+        return $this;
+    }
+
+    /**
+     * Adds as displayTitleText
+     *
+     * A Composite containing details of a Title of the Software as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleTextType $displayTitleText
+     */
+    public function addToDisplayTitleText(\DedexBundle\Entity\Ern42\DisplayTitleTextType $displayTitleText)
+    {
+        $this->displayTitleText[] = $displayTitleText;
+        return $this;
+    }
+
+    /**
+     * isset displayTitleText
+     *
+     * A Composite containing details of a Title of the Software as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayTitleText($index)
+    {
+        return isset($this->displayTitleText[$index]);
+    }
+
+    /**
+     * unset displayTitleText
+     *
+     * A Composite containing details of a Title of the Software as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayTitleText($index)
+    {
+        unset($this->displayTitleText[$index]);
+    }
+
+    /**
+     * Gets as displayTitleText
+     *
+     * A Composite containing details of a Title of the Software as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayTitleTextType[]
+     */
+    public function getDisplayTitleText()
+    {
+        return $this->displayTitleText;
+    }
+
+    /**
+     * Sets a new displayTitleText
+     *
+     * A Composite containing details of a Title of the Software as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleTextType[] $displayTitleText
+     * @return self
+     */
+    public function setDisplayTitleText(?array $displayTitleText = null)
+    {
+        $this->displayTitleText = $displayTitleText;
+        return $this;
+    }
+
+    /**
+     * Adds as displayTitle
+     *
+     * A Composite containing details of a Title of the Software as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleType $displayTitle
+     */
+    public function addToDisplayTitle(\DedexBundle\Entity\Ern42\DisplayTitleType $displayTitle)
+    {
+        $this->displayTitle[] = $displayTitle;
+        return $this;
+    }
+
+    /**
+     * isset displayTitle
+     *
+     * A Composite containing details of a Title of the Software as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayTitle($index)
+    {
+        return isset($this->displayTitle[$index]);
+    }
+
+    /**
+     * unset displayTitle
+     *
+     * A Composite containing details of a Title of the Software as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayTitle($index)
+    {
+        unset($this->displayTitle[$index]);
+    }
+
+    /**
+     * Gets as displayTitle
+     *
+     * A Composite containing details of a Title of the Software as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayTitleType[]
+     */
+    public function getDisplayTitle()
+    {
+        return $this->displayTitle;
+    }
+
+    /**
+     * Sets a new displayTitle
+     *
+     * A Composite containing details of a Title of the Software as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleType[] $displayTitle
+     * @return self
+     */
+    public function setDisplayTitle(?array $displayTitle = null)
+    {
+        $this->displayTitle = $displayTitle;
+        return $this;
+    }
+
+    /**
+     * Adds as additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Software. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\AdditionalTitleType $additionalTitle
+     */
+    public function addToAdditionalTitle(\DedexBundle\Entity\Ern42\AdditionalTitleType $additionalTitle)
+    {
+        $this->additionalTitle[] = $additionalTitle;
+        return $this;
+    }
+
+    /**
+     * isset additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Software. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetAdditionalTitle($index)
+    {
+        return isset($this->additionalTitle[$index]);
+    }
+
+    /**
+     * unset additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Software. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetAdditionalTitle($index)
+    {
+        unset($this->additionalTitle[$index]);
+    }
+
+    /**
+     * Gets as additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Software. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return \DedexBundle\Entity\Ern42\AdditionalTitleType[]
+     */
+    public function getAdditionalTitle()
+    {
+        return $this->additionalTitle;
+    }
+
+    /**
+     * Sets a new additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Software. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param \DedexBundle\Entity\Ern42\AdditionalTitleType[] $additionalTitle
+     * @return self
+     */
+    public function setAdditionalTitle(?array $additionalTitle = null)
+    {
+        $this->additionalTitle = $additionalTitle;
+        return $this;
+    }
+
+    /**
+     * Adds as versionType
+     *
+     * A Composite containing details of a Type of Version of the Software.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\VersionTypeType $versionType
+     */
+    public function addToVersionType(\DedexBundle\Entity\Ern42\VersionTypeType $versionType)
+    {
+        $this->versionType[] = $versionType;
+        return $this;
+    }
+
+    /**
+     * isset versionType
+     *
+     * A Composite containing details of a Type of Version of the Software.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetVersionType($index)
+    {
+        return isset($this->versionType[$index]);
+    }
+
+    /**
+     * unset versionType
+     *
+     * A Composite containing details of a Type of Version of the Software.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetVersionType($index)
+    {
+        unset($this->versionType[$index]);
+    }
+
+    /**
+     * Gets as versionType
+     *
+     * A Composite containing details of a Type of Version of the Software.
+     *
+     * @return \DedexBundle\Entity\Ern42\VersionTypeType[]
+     */
+    public function getVersionType()
+    {
+        return $this->versionType;
+    }
+
+    /**
+     * Sets a new versionType
+     *
+     * A Composite containing details of a Type of Version of the Software.
+     *
+     * @param \DedexBundle\Entity\Ern42\VersionTypeType[] $versionType
+     * @return self
+     */
+    public function setVersionType(?array $versionType = null)
+    {
+        $this->versionType = $versionType;
+        return $this;
+    }
+
+    /**
+     * Adds as displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType $displayArtistName
+     */
+    public function addToDisplayArtistName(\DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType $displayArtistName)
+    {
+        $this->displayArtistName[] = $displayArtistName;
+        return $this;
+    }
+
+    /**
+     * isset displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayArtistName($index)
+    {
+        return isset($this->displayArtistName[$index]);
+    }
+
+    /**
+     * unset displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayArtistName($index)
+    {
+        unset($this->displayArtistName[$index]);
+    }
+
+    /**
+     * Gets as displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType[]
+     */
+    public function getDisplayArtistName()
+    {
+        return $this->displayArtistName;
+    }
+
+    /**
+     * Sets a new displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType[] $displayArtistName
+     * @return self
+     */
+    public function setDisplayArtistName(?array $displayArtistName = null)
+    {
+        $this->displayArtistName = $displayArtistName;
+        return $this;
+    }
+
+    /**
+     * Adds as displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the Software. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistType $displayArtist
+     */
+    public function addToDisplayArtist(\DedexBundle\Entity\Ern42\DisplayArtistType $displayArtist)
+    {
+        $this->displayArtist[] = $displayArtist;
+        return $this;
+    }
+
+    /**
+     * isset displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the Software. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayArtist($index)
+    {
+        return isset($this->displayArtist[$index]);
+    }
+
+    /**
+     * unset displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the Software. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayArtist($index)
+    {
+        unset($this->displayArtist[$index]);
+    }
+
+    /**
+     * Gets as displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the Software. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayArtistType[]
+     */
+    public function getDisplayArtist()
+    {
+        return $this->displayArtist;
+    }
+
+    /**
+     * Sets a new displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the Software. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistType[] $displayArtist
+     * @return self
+     */
+    public function setDisplayArtist(?array $displayArtist = null)
+    {
+        $this->displayArtist = $displayArtist;
+        return $this;
+    }
+
+    /**
+     * Adds as contributor
+     *
+     * A Composite containing details of a Contributor to the Software.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ContributorType $contributor
+     */
+    public function addToContributor(\DedexBundle\Entity\Ern42\ContributorType $contributor)
+    {
+        $this->contributor[] = $contributor;
+        return $this;
+    }
+
+    /**
+     * isset contributor
+     *
+     * A Composite containing details of a Contributor to the Software.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetContributor($index)
+    {
+        return isset($this->contributor[$index]);
+    }
+
+    /**
+     * unset contributor
+     *
+     * A Composite containing details of a Contributor to the Software.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetContributor($index)
+    {
+        unset($this->contributor[$index]);
+    }
+
+    /**
+     * Gets as contributor
+     *
+     * A Composite containing details of a Contributor to the Software.
+     *
+     * @return \DedexBundle\Entity\Ern42\ContributorType[]
+     */
+    public function getContributor()
+    {
+        return $this->contributor;
+    }
+
+    /**
+     * Sets a new contributor
+     *
+     * A Composite containing details of a Contributor to the Software.
+     *
+     * @param \DedexBundle\Entity\Ern42\ContributorType[] $contributor
+     * @return self
+     */
+    public function setContributor(?array $contributor = null)
+    {
+        $this->contributor = $contributor;
+        return $this;
+    }
+
+    /**
+     * Adds as resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Software.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ResourceRightsControllerType $resourceRightsController
+     */
+    public function addToResourceRightsController(\DedexBundle\Entity\Ern42\ResourceRightsControllerType $resourceRightsController)
+    {
+        $this->resourceRightsController[] = $resourceRightsController;
+        return $this;
+    }
+
+    /**
+     * isset resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Software.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetResourceRightsController($index)
+    {
+        return isset($this->resourceRightsController[$index]);
+    }
+
+    /**
+     * unset resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Software.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetResourceRightsController($index)
+    {
+        unset($this->resourceRightsController[$index]);
+    }
+
+    /**
+     * Gets as resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Software.
+     *
+     * @return \DedexBundle\Entity\Ern42\ResourceRightsControllerType[]
+     */
+    public function getResourceRightsController()
+    {
+        return $this->resourceRightsController;
+    }
+
+    /**
+     * Sets a new resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Software.
+     *
+     * @param \DedexBundle\Entity\Ern42\ResourceRightsControllerType[] $resourceRightsController
+     * @return self
+     */
+    public function setResourceRightsController(?array $resourceRightsController = null)
+    {
+        $this->resourceRightsController = $resourceRightsController;
+        return $this;
+    }
+
+    /**
+     * Adds as workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\WorkRightsControllerType $workRightsController
+     */
+    public function addToWorkRightsController(\DedexBundle\Entity\Ern42\WorkRightsControllerType $workRightsController)
+    {
+        $this->workRightsController[] = $workRightsController;
+        return $this;
+    }
+
+    /**
+     * isset workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetWorkRightsController($index)
+    {
+        return isset($this->workRightsController[$index]);
+    }
+
+    /**
+     * unset workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetWorkRightsController($index)
+    {
+        unset($this->workRightsController[$index]);
+    }
+
+    /**
+     * Gets as workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @return \DedexBundle\Entity\Ern42\WorkRightsControllerType[]
+     */
+    public function getWorkRightsController()
+    {
+        return $this->workRightsController;
+    }
+
+    /**
+     * Sets a new workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @param \DedexBundle\Entity\Ern42\WorkRightsControllerType[] $workRightsController
+     * @return self
+     */
+    public function setWorkRightsController(?array $workRightsController = null)
+    {
+        $this->workRightsController = $workRightsController;
+        return $this;
+    }
+
+    /**
+     * Adds as pLine
+     *
+     * A Composite containing details of the PLine for the Software.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\PLineWithDefaultType $pLine
+     */
+    public function addToPLine(\DedexBundle\Entity\Ern42\PLineWithDefaultType $pLine)
+    {
+        $this->pLine[] = $pLine;
+        return $this;
+    }
+
+    /**
+     * isset pLine
+     *
+     * A Composite containing details of the PLine for the Software.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetPLine($index)
+    {
+        return isset($this->pLine[$index]);
+    }
+
+    /**
+     * unset pLine
+     *
+     * A Composite containing details of the PLine for the Software.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetPLine($index)
+    {
+        unset($this->pLine[$index]);
+    }
+
+    /**
+     * Gets as pLine
+     *
+     * A Composite containing details of the PLine for the Software.
+     *
+     * @return \DedexBundle\Entity\Ern42\PLineWithDefaultType[]
+     */
+    public function getPLine()
+    {
+        return $this->pLine;
+    }
+
+    /**
+     * Sets a new pLine
+     *
+     * A Composite containing details of the PLine for the Software.
+     *
+     * @param \DedexBundle\Entity\Ern42\PLineWithDefaultType[] $pLine
+     * @return self
+     */
+    public function setPLine(?array $pLine = null)
+    {
+        $this->pLine = $pLine;
+        return $this;
+    }
+
+    /**
+     * Adds as cLine
+     *
+     * A Composite containing details of the CLine for the Software.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\CLineWithDefaultType $cLine
+     */
+    public function addToCLine(\DedexBundle\Entity\Ern42\CLineWithDefaultType $cLine)
+    {
+        $this->cLine[] = $cLine;
+        return $this;
+    }
+
+    /**
+     * isset cLine
+     *
+     * A Composite containing details of the CLine for the Software.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetCLine($index)
+    {
+        return isset($this->cLine[$index]);
+    }
+
+    /**
+     * unset cLine
+     *
+     * A Composite containing details of the CLine for the Software.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetCLine($index)
+    {
+        unset($this->cLine[$index]);
+    }
+
+    /**
+     * Gets as cLine
+     *
+     * A Composite containing details of the CLine for the Software.
+     *
+     * @return \DedexBundle\Entity\Ern42\CLineWithDefaultType[]
+     */
+    public function getCLine()
+    {
+        return $this->cLine;
+    }
+
+    /**
+     * Sets a new cLine
+     *
+     * A Composite containing details of the CLine for the Software.
+     *
+     * @param \DedexBundle\Entity\Ern42\CLineWithDefaultType[] $cLine
+     * @return self
+     */
+    public function setCLine(?array $cLine = null)
+    {
+        $this->cLine = $cLine;
+        return $this;
+    }
+
+    /**
+     * Adds as courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured in the Software.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType $courtesyLine
+     */
+    public function addToCourtesyLine(\DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType $courtesyLine)
+    {
+        $this->courtesyLine[] = $courtesyLine;
+        return $this;
+    }
+
+    /**
+     * isset courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured in the Software.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetCourtesyLine($index)
+    {
+        return isset($this->courtesyLine[$index]);
+    }
+
+    /**
+     * unset courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured in the Software.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetCourtesyLine($index)
+    {
+        unset($this->courtesyLine[$index]);
+    }
+
+    /**
+     * Gets as courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured in the Software.
+     *
+     * @return \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType[]
+     */
+    public function getCourtesyLine()
+    {
+        return $this->courtesyLine;
+    }
+
+    /**
+     * Sets a new courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured in the Software.
+     *
+     * @param \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType[] $courtesyLine
+     * @return self
+     */
+    public function setCourtesyLine(?array $courtesyLine = null)
+    {
+        $this->courtesyLine = $courtesyLine;
+        return $this;
+    }
+
+    /**
+     * Gets as creationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Software was created. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType
+     */
+    public function getCreationDate()
+    {
+        return $this->creationDate;
+    }
+
+    /**
+     * Sets a new creationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Software was created. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $creationDate
+     * @return self
+     */
+    public function setCreationDate(?\DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $creationDate = null)
+    {
+        $this->creationDate = $creationDate;
+        return $this;
+    }
+
+    /**
+     * Adds as firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Software was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType $firstPublicationDate
+     */
+    public function addToFirstPublicationDate(\DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType $firstPublicationDate)
+    {
+        $this->firstPublicationDate[] = $firstPublicationDate;
+        return $this;
+    }
+
+    /**
+     * isset firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Software was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetFirstPublicationDate($index)
+    {
+        return isset($this->firstPublicationDate[$index]);
+    }
+
+    /**
+     * unset firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Software was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetFirstPublicationDate($index)
+    {
+        unset($this->firstPublicationDate[$index]);
+    }
+
+    /**
+     * Gets as firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Software was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @return \DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType[]
+     */
+    public function getFirstPublicationDate()
+    {
+        return $this->firstPublicationDate;
+    }
+
+    /**
+     * Sets a new firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Software was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param \DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType[] $firstPublicationDate
+     * @return self
+     */
+    public function setFirstPublicationDate(?array $firstPublicationDate = null)
+    {
+        $this->firstPublicationDate = $firstPublicationDate;
+        return $this;
+    }
+
+    /**
+     * Adds as parentalWarningType
+     *
+     * A Composite containing details of the classification of the Software according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType $parentalWarningType
+     */
+    public function addToParentalWarningType(\DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType $parentalWarningType)
+    {
+        $this->parentalWarningType[] = $parentalWarningType;
+        return $this;
+    }
+
+    /**
+     * isset parentalWarningType
+     *
+     * A Composite containing details of the classification of the Software according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetParentalWarningType($index)
+    {
+        return isset($this->parentalWarningType[$index]);
+    }
+
+    /**
+     * unset parentalWarningType
+     *
+     * A Composite containing details of the classification of the Software according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetParentalWarningType($index)
+    {
+        unset($this->parentalWarningType[$index]);
+    }
+
+    /**
+     * Gets as parentalWarningType
+     *
+     * A Composite containing details of the classification of the Software according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @return \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType[]
+     */
+    public function getParentalWarningType()
+    {
+        return $this->parentalWarningType;
+    }
+
+    /**
+     * Sets a new parentalWarningType
+     *
+     * A Composite containing details of the classification of the Software according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @param \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType[] $parentalWarningType
+     * @return self
+     */
+    public function setParentalWarningType(?array $parentalWarningType = null)
+    {
+        $this->parentalWarningType = $parentalWarningType;
+        return $this;
+    }
+
+    /**
+     * Adds as relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Software.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\RelatedReleaseType $relatedRelease
+     */
+    public function addToRelatedRelease(\DedexBundle\Entity\Ern42\RelatedReleaseType $relatedRelease)
+    {
+        $this->relatedRelease[] = $relatedRelease;
+        return $this;
+    }
+
+    /**
+     * isset relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Software.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRelatedRelease($index)
+    {
+        return isset($this->relatedRelease[$index]);
+    }
+
+    /**
+     * unset relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Software.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRelatedRelease($index)
+    {
+        unset($this->relatedRelease[$index]);
+    }
+
+    /**
+     * Gets as relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Software.
+     *
+     * @return \DedexBundle\Entity\Ern42\RelatedReleaseType[]
+     */
+    public function getRelatedRelease()
+    {
+        return $this->relatedRelease;
+    }
+
+    /**
+     * Sets a new relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Software.
+     *
+     * @param \DedexBundle\Entity\Ern42\RelatedReleaseType[] $relatedRelease
+     * @return self
+     */
+    public function setRelatedRelease(?array $relatedRelease = null)
+    {
+        $this->relatedRelease = $relatedRelease;
+        return $this;
+    }
+
+    /**
+     * Adds as relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Software.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\RelatedResourceType $relatedResource
+     */
+    public function addToRelatedResource(\DedexBundle\Entity\Ern42\RelatedResourceType $relatedResource)
+    {
+        $this->relatedResource[] = $relatedResource;
+        return $this;
+    }
+
+    /**
+     * isset relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Software.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRelatedResource($index)
+    {
+        return isset($this->relatedResource[$index]);
+    }
+
+    /**
+     * unset relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Software.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRelatedResource($index)
+    {
+        unset($this->relatedResource[$index]);
+    }
+
+    /**
+     * Gets as relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Software.
+     *
+     * @return \DedexBundle\Entity\Ern42\RelatedResourceType[]
+     */
+    public function getRelatedResource()
+    {
+        return $this->relatedResource;
+    }
+
+    /**
+     * Sets a new relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Software.
+     *
+     * @param \DedexBundle\Entity\Ern42\RelatedResourceType[] $relatedResource
+     * @return self
+     */
+    public function setRelatedResource(?array $relatedResource = null)
+    {
+        $this->relatedResource = $relatedResource;
+        return $this;
+    }
+
+    /**
+     * Gets as containsHiddenContent
+     *
+     * The Flag indicating whether the Software contains content that is hidden in some way from the Consumer (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getContainsHiddenContent()
+    {
+        return $this->containsHiddenContent;
+    }
+
+    /**
+     * Sets a new containsHiddenContent
+     *
+     * The Flag indicating whether the Software contains content that is hidden in some way from the Consumer (=true) or not (=false).
+     *
+     * @param bool $containsHiddenContent
+     * @return self
+     */
+    public function setContainsHiddenContent($containsHiddenContent)
+    {
+        $this->containsHiddenContent = $containsHiddenContent;
+        return $this;
+    }
+
+    /**
+     * Adds as resourceContainedResourceReference
+     *
+     * A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current Software.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType $resourceContainedResourceReference
+     */
+    public function addToResourceContainedResourceReferenceList(\DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType $resourceContainedResourceReference)
+    {
+        $this->resourceContainedResourceReferenceList[] = $resourceContainedResourceReference;
+        return $this;
+    }
+
+    /**
+     * isset resourceContainedResourceReferenceList
+     *
+     * A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current Software.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetResourceContainedResourceReferenceList($index)
+    {
+        return isset($this->resourceContainedResourceReferenceList[$index]);
+    }
+
+    /**
+     * unset resourceContainedResourceReferenceList
+     *
+     * A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current Software.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetResourceContainedResourceReferenceList($index)
+    {
+        unset($this->resourceContainedResourceReferenceList[$index]);
+    }
+
+    /**
+     * Gets as resourceContainedResourceReferenceList
+     *
+     * A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current Software.
+     *
+     * @return \DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType[]
+     */
+    public function getResourceContainedResourceReferenceList()
+    {
+        return $this->resourceContainedResourceReferenceList;
+    }
+
+    /**
+     * Sets a new resourceContainedResourceReferenceList
+     *
+     * A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current Software.
+     *
+     * @param \DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType[] $resourceContainedResourceReferenceList
+     * @return self
+     */
+    public function setResourceContainedResourceReferenceList(?array $resourceContainedResourceReferenceList = null)
+    {
+        $this->resourceContainedResourceReferenceList = $resourceContainedResourceReferenceList;
+        return $this;
+    }
+
+    /**
+     * Adds as technicalDetails
+     *
+     * A Composite containing technical details of the Software.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\TechnicalSoftwareDetailsType $technicalDetails
+     */
+    public function addToTechnicalDetails(\DedexBundle\Entity\Ern42\TechnicalSoftwareDetailsType $technicalDetails)
+    {
+        $this->technicalDetails[] = $technicalDetails;
+        return $this;
+    }
+
+    /**
+     * isset technicalDetails
+     *
+     * A Composite containing technical details of the Software.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetTechnicalDetails($index)
+    {
+        return isset($this->technicalDetails[$index]);
+    }
+
+    /**
+     * unset technicalDetails
+     *
+     * A Composite containing technical details of the Software.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetTechnicalDetails($index)
+    {
+        unset($this->technicalDetails[$index]);
+    }
+
+    /**
+     * Gets as technicalDetails
+     *
+     * A Composite containing technical details of the Software.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @return \DedexBundle\Entity\Ern42\TechnicalSoftwareDetailsType[]
+     */
+    public function getTechnicalDetails()
+    {
+        return $this->technicalDetails;
+    }
+
+    /**
+     * Sets a new technicalDetails
+     *
+     * A Composite containing technical details of the Software.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @param \DedexBundle\Entity\Ern42\TechnicalSoftwareDetailsType[] $technicalDetails
+     * @return self
+     */
+    public function setTechnicalDetails(?array $technicalDetails = null)
+    {
+        $this->technicalDetails = $technicalDetails;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/SoftwareTypeType.php
+++ b/src/Entity/Ern42/SoftwareTypeType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing SoftwareTypeType
+ *
+ * A Composite containing details of a SoftwareType.
+ * XSD Type: SoftwareType
+ */
+class SoftwareTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the SoftwareType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the SoftwareType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the SoftwareType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the SoftwareType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the SoftwareType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the SoftwareType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/SoundRecordingIdType.php
+++ b/src/Entity/Ern42/SoundRecordingIdType.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing SoundRecordingIdType
+ *
+ * A Composite containing details of SoundRecordingIds.
+ * XSD Type: SoundRecordingId
+ */
+class SoundRecordingIdType
+{
+    /**
+     * The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.
+     *
+     * @var bool $isReplaced
+     */
+    private $isReplaced = null;
+
+    /**
+     * The ISRC (International Standard Recording Code as defined in ISO 3901) for the SoundRecording. An ISRC comprises four parts: two characters, followed by three alphanumeric characters, then two digits and five digits. DDEX will enforce the syntax [a-zA-Z]{2}[a-zA-Z0-9]{3}[0-9]{7} using XML Schema in the future.
+     *
+     * @var string $iSRC
+     */
+    private $iSRC = null;
+
+    /**
+     * A Composite containing details of the CatalogNumber of the SoundRecording.
+     *
+     * @var \DedexBundle\Entity\Ern42\CatalogNumberType $catalogNumber
+     */
+    private $catalogNumber = null;
+
+    /**
+     * A Composite containing details of a ProprietaryIdentifier of the SoundRecording (usually one per society involved in the messaging).
+     *
+     * @var \DedexBundle\Entity\Ern42\ProprietaryIdType[] $proprietaryId
+     */
+    private $proprietaryId = [
+        
+    ];
+
+    /**
+     * Gets as isReplaced
+     *
+     * The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.
+     *
+     * @return bool
+     */
+    public function getIsReplaced()
+    {
+        return $this->isReplaced;
+    }
+
+    /**
+     * Sets a new isReplaced
+     *
+     * The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.
+     *
+     * @param bool $isReplaced
+     * @return self
+     */
+    public function setIsReplaced($isReplaced)
+    {
+        $this->isReplaced = $isReplaced;
+        return $this;
+    }
+
+    /**
+     * Gets as iSRC
+     *
+     * The ISRC (International Standard Recording Code as defined in ISO 3901) for the SoundRecording. An ISRC comprises four parts: two characters, followed by three alphanumeric characters, then two digits and five digits. DDEX will enforce the syntax [a-zA-Z]{2}[a-zA-Z0-9]{3}[0-9]{7} using XML Schema in the future.
+     *
+     * @return string
+     */
+    public function getISRC()
+    {
+        return $this->iSRC;
+    }
+
+    /**
+     * Sets a new iSRC
+     *
+     * The ISRC (International Standard Recording Code as defined in ISO 3901) for the SoundRecording. An ISRC comprises four parts: two characters, followed by three alphanumeric characters, then two digits and five digits. DDEX will enforce the syntax [a-zA-Z]{2}[a-zA-Z0-9]{3}[0-9]{7} using XML Schema in the future.
+     *
+     * @param string $iSRC
+     * @return self
+     */
+    public function setISRC($iSRC)
+    {
+        $this->iSRC = $iSRC;
+        return $this;
+    }
+
+    /**
+     * Gets as catalogNumber
+     *
+     * A Composite containing details of the CatalogNumber of the SoundRecording.
+     *
+     * @return \DedexBundle\Entity\Ern42\CatalogNumberType
+     */
+    public function getCatalogNumber()
+    {
+        return $this->catalogNumber;
+    }
+
+    /**
+     * Sets a new catalogNumber
+     *
+     * A Composite containing details of the CatalogNumber of the SoundRecording.
+     *
+     * @param \DedexBundle\Entity\Ern42\CatalogNumberType $catalogNumber
+     * @return self
+     */
+    public function setCatalogNumber(?\DedexBundle\Entity\Ern42\CatalogNumberType $catalogNumber = null)
+    {
+        $this->catalogNumber = $catalogNumber;
+        return $this;
+    }
+
+    /**
+     * Adds as proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the SoundRecording (usually one per society involved in the messaging).
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ProprietaryIdType $proprietaryId
+     */
+    public function addToProprietaryId(\DedexBundle\Entity\Ern42\ProprietaryIdType $proprietaryId)
+    {
+        $this->proprietaryId[] = $proprietaryId;
+        return $this;
+    }
+
+    /**
+     * isset proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the SoundRecording (usually one per society involved in the messaging).
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetProprietaryId($index)
+    {
+        return isset($this->proprietaryId[$index]);
+    }
+
+    /**
+     * unset proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the SoundRecording (usually one per society involved in the messaging).
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetProprietaryId($index)
+    {
+        unset($this->proprietaryId[$index]);
+    }
+
+    /**
+     * Gets as proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the SoundRecording (usually one per society involved in the messaging).
+     *
+     * @return \DedexBundle\Entity\Ern42\ProprietaryIdType[]
+     */
+    public function getProprietaryId()
+    {
+        return $this->proprietaryId;
+    }
+
+    /**
+     * Sets a new proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the SoundRecording (usually one per society involved in the messaging).
+     *
+     * @param \DedexBundle\Entity\Ern42\ProprietaryIdType[] $proprietaryId
+     * @return self
+     */
+    public function setProprietaryId(?array $proprietaryId = null)
+    {
+        $this->proprietaryId = $proprietaryId;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/SoundRecordingPreviewDetailsType.php
+++ b/src/Entity/Ern42/SoundRecordingPreviewDetailsType.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing SoundRecordingPreviewDetailsType
+ *
+ * A Composite containing details of a preview.
+ * XSD Type: SoundRecordingPreviewDetails
+ */
+class SoundRecordingPreviewDetailsType
+{
+    /**
+     * The start point of the preview given in seconds from the start of the Resource.
+     *
+     * @var float $startPoint
+     */
+    private $startPoint = null;
+
+    /**
+     * The end point of the preview given in seconds from the start of the Resource.
+     *
+     * @var float $endPoint
+     */
+    private $endPoint = null;
+
+    /**
+     * The Duration of the preview, measured from the StartPoint.
+     *
+     * @var \DateInterval $duration
+     */
+    private $duration = null;
+
+    /**
+     * The position of the top left corner of the preview measured in Pixels from the top left corner of the Resource. The position is given as two coordinate values separated by a comma, the top left pixel being 0,0.
+     *
+     * @var string $topLeftCorner
+     */
+    private $topLeftCorner = null;
+
+    /**
+     * The position of the bottom right corner of the preview measured in Pixels from the top left corner of the Resource. The position is given as two coordinate values separated by a comma, the top left pixel being 0,0.
+     *
+     * @var string $bottomRightCorner
+     */
+    private $bottomRightCorner = null;
+
+    /**
+     * A Type of expression indicating how this should be perceived, e.g. as instruction (meaning that this has to be done to create the preview) or as information (meaning that this has been done to craete the preview).
+     *
+     * @var string $expressionType
+     */
+    private $expressionType = null;
+
+    /**
+     * Gets as startPoint
+     *
+     * The start point of the preview given in seconds from the start of the Resource.
+     *
+     * @return float
+     */
+    public function getStartPoint()
+    {
+        return $this->startPoint;
+    }
+
+    /**
+     * Sets a new startPoint
+     *
+     * The start point of the preview given in seconds from the start of the Resource.
+     *
+     * @param float $startPoint
+     * @return self
+     */
+    public function setStartPoint($startPoint)
+    {
+        $this->startPoint = $startPoint;
+        return $this;
+    }
+
+    /**
+     * Gets as endPoint
+     *
+     * The end point of the preview given in seconds from the start of the Resource.
+     *
+     * @return float
+     */
+    public function getEndPoint()
+    {
+        return $this->endPoint;
+    }
+
+    /**
+     * Sets a new endPoint
+     *
+     * The end point of the preview given in seconds from the start of the Resource.
+     *
+     * @param float $endPoint
+     * @return self
+     */
+    public function setEndPoint($endPoint)
+    {
+        $this->endPoint = $endPoint;
+        return $this;
+    }
+
+    /**
+     * Gets as duration
+     *
+     * The Duration of the preview, measured from the StartPoint.
+     *
+     * @return \DateInterval
+     */
+    public function getDuration()
+    {
+        return $this->duration;
+    }
+
+    /**
+     * Sets a new duration
+     *
+     * The Duration of the preview, measured from the StartPoint.
+     *
+     * @param \DateInterval $duration
+     * @return self
+     */
+    public function setDuration(?\DateInterval $duration = null)
+    {
+        $this->duration = $duration;
+        return $this;
+    }
+
+    /**
+     * Gets as topLeftCorner
+     *
+     * The position of the top left corner of the preview measured in Pixels from the top left corner of the Resource. The position is given as two coordinate values separated by a comma, the top left pixel being 0,0.
+     *
+     * @return string
+     */
+    public function getTopLeftCorner()
+    {
+        return $this->topLeftCorner;
+    }
+
+    /**
+     * Sets a new topLeftCorner
+     *
+     * The position of the top left corner of the preview measured in Pixels from the top left corner of the Resource. The position is given as two coordinate values separated by a comma, the top left pixel being 0,0.
+     *
+     * @param string $topLeftCorner
+     * @return self
+     */
+    public function setTopLeftCorner($topLeftCorner)
+    {
+        $this->topLeftCorner = $topLeftCorner;
+        return $this;
+    }
+
+    /**
+     * Gets as bottomRightCorner
+     *
+     * The position of the bottom right corner of the preview measured in Pixels from the top left corner of the Resource. The position is given as two coordinate values separated by a comma, the top left pixel being 0,0.
+     *
+     * @return string
+     */
+    public function getBottomRightCorner()
+    {
+        return $this->bottomRightCorner;
+    }
+
+    /**
+     * Sets a new bottomRightCorner
+     *
+     * The position of the bottom right corner of the preview measured in Pixels from the top left corner of the Resource. The position is given as two coordinate values separated by a comma, the top left pixel being 0,0.
+     *
+     * @param string $bottomRightCorner
+     * @return self
+     */
+    public function setBottomRightCorner($bottomRightCorner)
+    {
+        $this->bottomRightCorner = $bottomRightCorner;
+        return $this;
+    }
+
+    /**
+     * Gets as expressionType
+     *
+     * A Type of expression indicating how this should be perceived, e.g. as instruction (meaning that this has to be done to create the preview) or as information (meaning that this has been done to craete the preview).
+     *
+     * @return string
+     */
+    public function getExpressionType()
+    {
+        return $this->expressionType;
+    }
+
+    /**
+     * Sets a new expressionType
+     *
+     * A Type of expression indicating how this should be perceived, e.g. as instruction (meaning that this has to be done to create the preview) or as information (meaning that this has been done to craete the preview).
+     *
+     * @param string $expressionType
+     * @return self
+     */
+    public function setExpressionType($expressionType)
+    {
+        $this->expressionType = $expressionType;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/SoundRecordingType.php
+++ b/src/Entity/Ern42/SoundRecordingType.php
@@ -1,0 +1,2572 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing SoundRecordingType
+ *
+ * A Composite containing details of a SoundRecording.
+ * XSD Type: SoundRecording
+ */
+class SoundRecordingType
+{
+    /**
+     * The Language and script for the Elements of the SoundRecording as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * The Flag indicating whether the SoundRecording is provided in a addition to the Resources that form part of the Release (=true) or not (=false). If the flag is set to false (or absent) the SoundRecording is part of at least one Release in the message. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isSupplemental
+     */
+    private $isSupplemental = null;
+
+    /**
+     * The Identifier (specific to the Message) of the SoundRecording within the Release which contains it. This is a LocalResourceAnchor starting with the letter A.
+     *
+     * @var string $resourceReference
+     */
+    private $resourceReference = null;
+
+    /**
+     * A Composite containing details of the Type of the SoundRecording.
+     *
+     * @var \DedexBundle\Entity\Ern42\SoundRecordingTypeType $type
+     */
+    private $type = null;
+
+    /**
+     * A Composite containing details of a SoundRecordingId.
+     *
+     * @var \DedexBundle\Entity\Ern42\SoundRecordingIdType[] $resourceId
+     */
+    private $resourceId = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the SoundRecording.
+     *
+     * @var \DedexBundle\Entity\Ern42\MusicalWorkIdType[] $workId
+     */
+    private $workId = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Title of the SoundRecording as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayTitleTextType[] $displayTitleText
+     */
+    private $displayTitleText = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Title of the SoundRecording as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayTitleType[] $displayTitle
+     */
+    private $displayTitle = [
+        
+    ];
+
+    /**
+     * A Composite containing details of an AdditionalTitle of the SoundRecording. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @var \DedexBundle\Entity\Ern42\AdditionalTitleType[] $additionalTitle
+     */
+    private $additionalTitle = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Type of Version of the SoundRecording.
+     *
+     * @var \DedexBundle\Entity\Ern42\VersionTypeType[] $versionType
+     */
+    private $versionType = [
+        
+    ];
+
+    /**
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType[] $displayArtistName
+     */
+    private $displayArtistName = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the DisplayArtist for the SoundRecording. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayArtistType[] $displayArtist
+     */
+    private $displayArtist = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Contributor to the SoundRecording.
+     *
+     * @var \DedexBundle\Entity\Ern42\ContributorType[] $contributor
+     */
+    private $contributor = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Character in the SoundRecording. A Character may be described through Name, Identifier and Roles.
+     *
+     * @var \DedexBundle\Entity\Ern42\CharacterType[] $character
+     */
+    private $character = [
+        
+    ];
+
+    /**
+     * A Composite containing details of RightsController of Rights in the SoundRecording.
+     *
+     * @var \DedexBundle\Entity\Ern42\ResourceRightsControllerType[] $resourceRightsController
+     */
+    private $resourceRightsController = [
+        
+    ];
+
+    /**
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @var \DedexBundle\Entity\Ern42\WorkRightsControllerType[] $workRightsController
+     */
+    private $workRightsController = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the PLine for the SoundRecording.
+     *
+     * @var \DedexBundle\Entity\Ern42\PLineWithDefaultType[] $pLine
+     */
+    private $pLine = [
+        
+    ];
+
+    /**
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for guests Artists or others featured on the SoundRecording.
+     *
+     * @var \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType[] $courtesyLine
+     */
+    private $courtesyLine = [
+        
+    ];
+
+    /**
+     * The Duration of the SoundRecording (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @var \DateInterval $duration
+     */
+    private $duration = null;
+
+    /**
+     * A Composite containing details of the Date and Place of the Event in which the SoundRecording was created. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $creationDate
+     */
+    private $creationDate = null;
+
+    /**
+     * A Composite containing details of the Date and Place of the Event in which the SoundRecording was originally mastered (in either analogue or digital form). This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $masteredDate
+     */
+    private $masteredDate = null;
+
+    /**
+     * A Composite containing details of the Date and Place of the Event in which the SoundRecording was re-mastered (usually digitally). This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $remasteredDate
+     */
+    private $remasteredDate = null;
+
+    /**
+     * A Composite containing details of the Date and Place of the Event in which the SoundRecording was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @var \DedexBundle\Entity\Ern42\FirstPublicationDateType[] $firstPublicationDate
+     */
+    private $firstPublicationDate = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a RecordingSession.
+     *
+     * @var \DedexBundle\Entity\Ern42\LocationAndDateOfSessionType[] $locationAndDateOfSession
+     */
+    private $locationAndDateOfSession = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the classification of the SoundRecording according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @var \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType[] $parentalWarningType
+     */
+    private $parentalWarningType = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current SoundRecording.
+     *
+     * @var \DedexBundle\Entity\Ern42\RelatedReleaseType[] $relatedRelease
+     */
+    private $relatedRelease = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current SoundRecording.
+     *
+     * @var \DedexBundle\Entity\Ern42\RelatedResourceType[] $relatedResource
+     */
+    private $relatedResource = [
+        
+    ];
+
+    /**
+     * A Type of the SoundRecording indicating whether it is a Medley or a Potpourri.
+     *
+     * @var string $compositeMusicalWorkType
+     */
+    private $compositeMusicalWorkType = null;
+
+    /**
+     * A Flag indicating whether the SoundRecording is a Cover (=true) or not (=false). This is not legal information, but meant to help consumers to differentiate originals from covers.
+     *
+     * @var bool $isCover
+     */
+    private $isCover = null;
+
+    /**
+     * The Flag indicating whether the SoundRecording is instrumental (=true) or not (=false).
+     *
+     * @var bool $isInstrumental
+     */
+    private $isInstrumental = null;
+
+    /**
+     * The Flag indicating whether the SoundRecording contains content that is hidden in some way from the Consumer (=true) or not (=false).
+     *
+     * @var bool $containsHiddenContent
+     */
+    private $containsHiddenContent = null;
+
+    /**
+     * The Flag indicating whether the SoundRecording is remastered (=true) or not (=false).
+     *
+     * @var bool $isRemastered
+     */
+    private $isRemastered = null;
+
+    /**
+     * The Flag indicating whether the SoundRecording meets the criteria to carry the HiResMusic logo, provided the MessageRecipient meets all the other requirements to use it (=true) or not (=false).
+     *
+     * @var bool $isHiResMusic
+     */
+    private $isHiResMusic = null;
+
+    /**
+     * A Flag indicating to a DSP whether the SoundRecording should not be crossfaded from/into another SoundRecording (=true) or not (=false).
+     *
+     * @var bool $disableCrossfade
+     */
+    private $disableCrossfade = null;
+
+    /**
+     * A Flag indicating to a DSP whether the SoundRecording should not be included in any search results (=true) or not (=false). Note that exclusion from search results implies that the SoundRecording should not appear in any recommendations.
+     *
+     * @var bool $disableSearch
+     */
+    private $disableSearch = null;
+
+    /**
+     * A Role and instrumentation for which a Party is credited.
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayCreditsType[] $displayCredits
+     */
+    private $displayCredits = [
+        
+    ];
+
+    /**
+     * The Language of the Performance recorded in the SoundRecording as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @var string[] $languageOfPerformance
+     */
+    private $languageOfPerformance = [
+        
+    ];
+
+    /**
+     * A configuration of audio channels.
+     *
+     * @var string $audioChannelConfiguration
+     */
+    private $audioChannelConfiguration = null;
+
+    /**
+     * A Composite containing technical details of the SoundRecording.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @var \DedexBundle\Entity\Ern42\TechnicalSoundRecordingDetailsType[] $technicalDetails
+     */
+    private $technicalDetails = [
+        
+    ];
+
+    /**
+     * A Description of the melodic mode of a MusicalWork in the SoundRecording.
+     *
+     * @var \DedexBundle\Entity\Ern42\RagaType[] $raga
+     */
+    private $raga = [
+        
+    ];
+
+    /**
+     * A Description of the rhythmic pattern of a MusicalWork in the SoundRecording.
+     *
+     * @var \DedexBundle\Entity\Ern42\TalaType[] $tala
+     */
+    private $tala = [
+        
+    ];
+
+    /**
+     * A deity name relating to the SoundRecording.
+     *
+     * @var \DedexBundle\Entity\Ern42\DeityType[] $deity
+     */
+    private $deity = [
+        
+    ];
+
+    /**
+     * A Reference for a Chapter (specific to this Message). This is a LocalCollectionAnchorReference starting with the letter X.
+     *
+     * @var string[] $audioChapterReference
+     */
+    private $audioChapterReference = [
+        
+    ];
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the Elements of the SoundRecording as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the Elements of the SoundRecording as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isSupplemental
+     *
+     * The Flag indicating whether the SoundRecording is provided in a addition to the Resources that form part of the Release (=true) or not (=false). If the flag is set to false (or absent) the SoundRecording is part of at least one Release in the message. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsSupplemental()
+    {
+        return $this->isSupplemental;
+    }
+
+    /**
+     * Sets a new isSupplemental
+     *
+     * The Flag indicating whether the SoundRecording is provided in a addition to the Resources that form part of the Release (=true) or not (=false). If the flag is set to false (or absent) the SoundRecording is part of at least one Release in the message. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isSupplemental
+     * @return self
+     */
+    public function setIsSupplemental($isSupplemental)
+    {
+        $this->isSupplemental = $isSupplemental;
+        return $this;
+    }
+
+    /**
+     * Gets as resourceReference
+     *
+     * The Identifier (specific to the Message) of the SoundRecording within the Release which contains it. This is a LocalResourceAnchor starting with the letter A.
+     *
+     * @return string
+     */
+    public function getResourceReference()
+    {
+        return $this->resourceReference;
+    }
+
+    /**
+     * Sets a new resourceReference
+     *
+     * The Identifier (specific to the Message) of the SoundRecording within the Release which contains it. This is a LocalResourceAnchor starting with the letter A.
+     *
+     * @param string $resourceReference
+     * @return self
+     */
+    public function setResourceReference($resourceReference)
+    {
+        $this->resourceReference = $resourceReference;
+        return $this;
+    }
+
+    /**
+     * Gets as type
+     *
+     * A Composite containing details of the Type of the SoundRecording.
+     *
+     * @return \DedexBundle\Entity\Ern42\SoundRecordingTypeType
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * Sets a new type
+     *
+     * A Composite containing details of the Type of the SoundRecording.
+     *
+     * @param \DedexBundle\Entity\Ern42\SoundRecordingTypeType $type
+     * @return self
+     */
+    public function setType(\DedexBundle\Entity\Ern42\SoundRecordingTypeType $type)
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    /**
+     * Adds as resourceId
+     *
+     * A Composite containing details of a SoundRecordingId.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\SoundRecordingIdType $resourceId
+     */
+    public function addToResourceId(\DedexBundle\Entity\Ern42\SoundRecordingIdType $resourceId)
+    {
+        $this->resourceId[] = $resourceId;
+        return $this;
+    }
+
+    /**
+     * isset resourceId
+     *
+     * A Composite containing details of a SoundRecordingId.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetResourceId($index)
+    {
+        return isset($this->resourceId[$index]);
+    }
+
+    /**
+     * unset resourceId
+     *
+     * A Composite containing details of a SoundRecordingId.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetResourceId($index)
+    {
+        unset($this->resourceId[$index]);
+    }
+
+    /**
+     * Gets as resourceId
+     *
+     * A Composite containing details of a SoundRecordingId.
+     *
+     * @return \DedexBundle\Entity\Ern42\SoundRecordingIdType[]
+     */
+    public function getResourceId()
+    {
+        return $this->resourceId;
+    }
+
+    /**
+     * Sets a new resourceId
+     *
+     * A Composite containing details of a SoundRecordingId.
+     *
+     * @param \DedexBundle\Entity\Ern42\SoundRecordingIdType[] $resourceId
+     * @return self
+     */
+    public function setResourceId(array $resourceId)
+    {
+        $this->resourceId = $resourceId;
+        return $this;
+    }
+
+    /**
+     * Adds as workId
+     *
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the SoundRecording.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\MusicalWorkIdType $workId
+     */
+    public function addToWorkId(\DedexBundle\Entity\Ern42\MusicalWorkIdType $workId)
+    {
+        $this->workId[] = $workId;
+        return $this;
+    }
+
+    /**
+     * isset workId
+     *
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the SoundRecording.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetWorkId($index)
+    {
+        return isset($this->workId[$index]);
+    }
+
+    /**
+     * unset workId
+     *
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the SoundRecording.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetWorkId($index)
+    {
+        unset($this->workId[$index]);
+    }
+
+    /**
+     * Gets as workId
+     *
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the SoundRecording.
+     *
+     * @return \DedexBundle\Entity\Ern42\MusicalWorkIdType[]
+     */
+    public function getWorkId()
+    {
+        return $this->workId;
+    }
+
+    /**
+     * Sets a new workId
+     *
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the SoundRecording.
+     *
+     * @param \DedexBundle\Entity\Ern42\MusicalWorkIdType[] $workId
+     * @return self
+     */
+    public function setWorkId(?array $workId = null)
+    {
+        $this->workId = $workId;
+        return $this;
+    }
+
+    /**
+     * Adds as displayTitleText
+     *
+     * A Composite containing details of a Title of the SoundRecording as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleTextType $displayTitleText
+     */
+    public function addToDisplayTitleText(\DedexBundle\Entity\Ern42\DisplayTitleTextType $displayTitleText)
+    {
+        $this->displayTitleText[] = $displayTitleText;
+        return $this;
+    }
+
+    /**
+     * isset displayTitleText
+     *
+     * A Composite containing details of a Title of the SoundRecording as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayTitleText($index)
+    {
+        return isset($this->displayTitleText[$index]);
+    }
+
+    /**
+     * unset displayTitleText
+     *
+     * A Composite containing details of a Title of the SoundRecording as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayTitleText($index)
+    {
+        unset($this->displayTitleText[$index]);
+    }
+
+    /**
+     * Gets as displayTitleText
+     *
+     * A Composite containing details of a Title of the SoundRecording as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayTitleTextType[]
+     */
+    public function getDisplayTitleText()
+    {
+        return $this->displayTitleText;
+    }
+
+    /**
+     * Sets a new displayTitleText
+     *
+     * A Composite containing details of a Title of the SoundRecording as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleTextType[] $displayTitleText
+     * @return self
+     */
+    public function setDisplayTitleText(array $displayTitleText)
+    {
+        $this->displayTitleText = $displayTitleText;
+        return $this;
+    }
+
+    /**
+     * Adds as displayTitle
+     *
+     * A Composite containing details of a Title of the SoundRecording as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleType $displayTitle
+     */
+    public function addToDisplayTitle(\DedexBundle\Entity\Ern42\DisplayTitleType $displayTitle)
+    {
+        $this->displayTitle[] = $displayTitle;
+        return $this;
+    }
+
+    /**
+     * isset displayTitle
+     *
+     * A Composite containing details of a Title of the SoundRecording as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayTitle($index)
+    {
+        return isset($this->displayTitle[$index]);
+    }
+
+    /**
+     * unset displayTitle
+     *
+     * A Composite containing details of a Title of the SoundRecording as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayTitle($index)
+    {
+        unset($this->displayTitle[$index]);
+    }
+
+    /**
+     * Gets as displayTitle
+     *
+     * A Composite containing details of a Title of the SoundRecording as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayTitleType[]
+     */
+    public function getDisplayTitle()
+    {
+        return $this->displayTitle;
+    }
+
+    /**
+     * Sets a new displayTitle
+     *
+     * A Composite containing details of a Title of the SoundRecording as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleType[] $displayTitle
+     * @return self
+     */
+    public function setDisplayTitle(array $displayTitle)
+    {
+        $this->displayTitle = $displayTitle;
+        return $this;
+    }
+
+    /**
+     * Adds as additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the SoundRecording. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\AdditionalTitleType $additionalTitle
+     */
+    public function addToAdditionalTitle(\DedexBundle\Entity\Ern42\AdditionalTitleType $additionalTitle)
+    {
+        $this->additionalTitle[] = $additionalTitle;
+        return $this;
+    }
+
+    /**
+     * isset additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the SoundRecording. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetAdditionalTitle($index)
+    {
+        return isset($this->additionalTitle[$index]);
+    }
+
+    /**
+     * unset additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the SoundRecording. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetAdditionalTitle($index)
+    {
+        unset($this->additionalTitle[$index]);
+    }
+
+    /**
+     * Gets as additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the SoundRecording. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return \DedexBundle\Entity\Ern42\AdditionalTitleType[]
+     */
+    public function getAdditionalTitle()
+    {
+        return $this->additionalTitle;
+    }
+
+    /**
+     * Sets a new additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the SoundRecording. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param \DedexBundle\Entity\Ern42\AdditionalTitleType[] $additionalTitle
+     * @return self
+     */
+    public function setAdditionalTitle(?array $additionalTitle = null)
+    {
+        $this->additionalTitle = $additionalTitle;
+        return $this;
+    }
+
+    /**
+     * Adds as versionType
+     *
+     * A Composite containing details of a Type of Version of the SoundRecording.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\VersionTypeType $versionType
+     */
+    public function addToVersionType(\DedexBundle\Entity\Ern42\VersionTypeType $versionType)
+    {
+        $this->versionType[] = $versionType;
+        return $this;
+    }
+
+    /**
+     * isset versionType
+     *
+     * A Composite containing details of a Type of Version of the SoundRecording.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetVersionType($index)
+    {
+        return isset($this->versionType[$index]);
+    }
+
+    /**
+     * unset versionType
+     *
+     * A Composite containing details of a Type of Version of the SoundRecording.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetVersionType($index)
+    {
+        unset($this->versionType[$index]);
+    }
+
+    /**
+     * Gets as versionType
+     *
+     * A Composite containing details of a Type of Version of the SoundRecording.
+     *
+     * @return \DedexBundle\Entity\Ern42\VersionTypeType[]
+     */
+    public function getVersionType()
+    {
+        return $this->versionType;
+    }
+
+    /**
+     * Sets a new versionType
+     *
+     * A Composite containing details of a Type of Version of the SoundRecording.
+     *
+     * @param \DedexBundle\Entity\Ern42\VersionTypeType[] $versionType
+     * @return self
+     */
+    public function setVersionType(?array $versionType = null)
+    {
+        $this->versionType = $versionType;
+        return $this;
+    }
+
+    /**
+     * Adds as displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType $displayArtistName
+     */
+    public function addToDisplayArtistName(\DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType $displayArtistName)
+    {
+        $this->displayArtistName[] = $displayArtistName;
+        return $this;
+    }
+
+    /**
+     * isset displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayArtistName($index)
+    {
+        return isset($this->displayArtistName[$index]);
+    }
+
+    /**
+     * unset displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayArtistName($index)
+    {
+        unset($this->displayArtistName[$index]);
+    }
+
+    /**
+     * Gets as displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType[]
+     */
+    public function getDisplayArtistName()
+    {
+        return $this->displayArtistName;
+    }
+
+    /**
+     * Sets a new displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType[] $displayArtistName
+     * @return self
+     */
+    public function setDisplayArtistName(array $displayArtistName)
+    {
+        $this->displayArtistName = $displayArtistName;
+        return $this;
+    }
+
+    /**
+     * Adds as displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the SoundRecording. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistType $displayArtist
+     */
+    public function addToDisplayArtist(\DedexBundle\Entity\Ern42\DisplayArtistType $displayArtist)
+    {
+        $this->displayArtist[] = $displayArtist;
+        return $this;
+    }
+
+    /**
+     * isset displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the SoundRecording. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayArtist($index)
+    {
+        return isset($this->displayArtist[$index]);
+    }
+
+    /**
+     * unset displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the SoundRecording. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayArtist($index)
+    {
+        unset($this->displayArtist[$index]);
+    }
+
+    /**
+     * Gets as displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the SoundRecording. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayArtistType[]
+     */
+    public function getDisplayArtist()
+    {
+        return $this->displayArtist;
+    }
+
+    /**
+     * Sets a new displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the SoundRecording. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistType[] $displayArtist
+     * @return self
+     */
+    public function setDisplayArtist(array $displayArtist)
+    {
+        $this->displayArtist = $displayArtist;
+        return $this;
+    }
+
+    /**
+     * Adds as contributor
+     *
+     * A Composite containing details of a Contributor to the SoundRecording.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ContributorType $contributor
+     */
+    public function addToContributor(\DedexBundle\Entity\Ern42\ContributorType $contributor)
+    {
+        $this->contributor[] = $contributor;
+        return $this;
+    }
+
+    /**
+     * isset contributor
+     *
+     * A Composite containing details of a Contributor to the SoundRecording.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetContributor($index)
+    {
+        return isset($this->contributor[$index]);
+    }
+
+    /**
+     * unset contributor
+     *
+     * A Composite containing details of a Contributor to the SoundRecording.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetContributor($index)
+    {
+        unset($this->contributor[$index]);
+    }
+
+    /**
+     * Gets as contributor
+     *
+     * A Composite containing details of a Contributor to the SoundRecording.
+     *
+     * @return \DedexBundle\Entity\Ern42\ContributorType[]
+     */
+    public function getContributor()
+    {
+        return $this->contributor;
+    }
+
+    /**
+     * Sets a new contributor
+     *
+     * A Composite containing details of a Contributor to the SoundRecording.
+     *
+     * @param \DedexBundle\Entity\Ern42\ContributorType[] $contributor
+     * @return self
+     */
+    public function setContributor(?array $contributor = null)
+    {
+        $this->contributor = $contributor;
+        return $this;
+    }
+
+    /**
+     * Adds as character
+     *
+     * A Composite containing details of a Character in the SoundRecording. A Character may be described through Name, Identifier and Roles.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\CharacterType $character
+     */
+    public function addToCharacter(\DedexBundle\Entity\Ern42\CharacterType $character)
+    {
+        $this->character[] = $character;
+        return $this;
+    }
+
+    /**
+     * isset character
+     *
+     * A Composite containing details of a Character in the SoundRecording. A Character may be described through Name, Identifier and Roles.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetCharacter($index)
+    {
+        return isset($this->character[$index]);
+    }
+
+    /**
+     * unset character
+     *
+     * A Composite containing details of a Character in the SoundRecording. A Character may be described through Name, Identifier and Roles.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetCharacter($index)
+    {
+        unset($this->character[$index]);
+    }
+
+    /**
+     * Gets as character
+     *
+     * A Composite containing details of a Character in the SoundRecording. A Character may be described through Name, Identifier and Roles.
+     *
+     * @return \DedexBundle\Entity\Ern42\CharacterType[]
+     */
+    public function getCharacter()
+    {
+        return $this->character;
+    }
+
+    /**
+     * Sets a new character
+     *
+     * A Composite containing details of a Character in the SoundRecording. A Character may be described through Name, Identifier and Roles.
+     *
+     * @param \DedexBundle\Entity\Ern42\CharacterType[] $character
+     * @return self
+     */
+    public function setCharacter(?array $character = null)
+    {
+        $this->character = $character;
+        return $this;
+    }
+
+    /**
+     * Adds as resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the SoundRecording.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ResourceRightsControllerType $resourceRightsController
+     */
+    public function addToResourceRightsController(\DedexBundle\Entity\Ern42\ResourceRightsControllerType $resourceRightsController)
+    {
+        $this->resourceRightsController[] = $resourceRightsController;
+        return $this;
+    }
+
+    /**
+     * isset resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the SoundRecording.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetResourceRightsController($index)
+    {
+        return isset($this->resourceRightsController[$index]);
+    }
+
+    /**
+     * unset resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the SoundRecording.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetResourceRightsController($index)
+    {
+        unset($this->resourceRightsController[$index]);
+    }
+
+    /**
+     * Gets as resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the SoundRecording.
+     *
+     * @return \DedexBundle\Entity\Ern42\ResourceRightsControllerType[]
+     */
+    public function getResourceRightsController()
+    {
+        return $this->resourceRightsController;
+    }
+
+    /**
+     * Sets a new resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the SoundRecording.
+     *
+     * @param \DedexBundle\Entity\Ern42\ResourceRightsControllerType[] $resourceRightsController
+     * @return self
+     */
+    public function setResourceRightsController(?array $resourceRightsController = null)
+    {
+        $this->resourceRightsController = $resourceRightsController;
+        return $this;
+    }
+
+    /**
+     * Adds as workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\WorkRightsControllerType $workRightsController
+     */
+    public function addToWorkRightsController(\DedexBundle\Entity\Ern42\WorkRightsControllerType $workRightsController)
+    {
+        $this->workRightsController[] = $workRightsController;
+        return $this;
+    }
+
+    /**
+     * isset workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetWorkRightsController($index)
+    {
+        return isset($this->workRightsController[$index]);
+    }
+
+    /**
+     * unset workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetWorkRightsController($index)
+    {
+        unset($this->workRightsController[$index]);
+    }
+
+    /**
+     * Gets as workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @return \DedexBundle\Entity\Ern42\WorkRightsControllerType[]
+     */
+    public function getWorkRightsController()
+    {
+        return $this->workRightsController;
+    }
+
+    /**
+     * Sets a new workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @param \DedexBundle\Entity\Ern42\WorkRightsControllerType[] $workRightsController
+     * @return self
+     */
+    public function setWorkRightsController(?array $workRightsController = null)
+    {
+        $this->workRightsController = $workRightsController;
+        return $this;
+    }
+
+    /**
+     * Adds as pLine
+     *
+     * A Composite containing details of the PLine for the SoundRecording.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\PLineWithDefaultType $pLine
+     */
+    public function addToPLine(\DedexBundle\Entity\Ern42\PLineWithDefaultType $pLine)
+    {
+        $this->pLine[] = $pLine;
+        return $this;
+    }
+
+    /**
+     * isset pLine
+     *
+     * A Composite containing details of the PLine for the SoundRecording.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetPLine($index)
+    {
+        return isset($this->pLine[$index]);
+    }
+
+    /**
+     * unset pLine
+     *
+     * A Composite containing details of the PLine for the SoundRecording.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetPLine($index)
+    {
+        unset($this->pLine[$index]);
+    }
+
+    /**
+     * Gets as pLine
+     *
+     * A Composite containing details of the PLine for the SoundRecording.
+     *
+     * @return \DedexBundle\Entity\Ern42\PLineWithDefaultType[]
+     */
+    public function getPLine()
+    {
+        return $this->pLine;
+    }
+
+    /**
+     * Sets a new pLine
+     *
+     * A Composite containing details of the PLine for the SoundRecording.
+     *
+     * @param \DedexBundle\Entity\Ern42\PLineWithDefaultType[] $pLine
+     * @return self
+     */
+    public function setPLine(?array $pLine = null)
+    {
+        $this->pLine = $pLine;
+        return $this;
+    }
+
+    /**
+     * Adds as courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for guests Artists or others featured on the SoundRecording.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType $courtesyLine
+     */
+    public function addToCourtesyLine(\DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType $courtesyLine)
+    {
+        $this->courtesyLine[] = $courtesyLine;
+        return $this;
+    }
+
+    /**
+     * isset courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for guests Artists or others featured on the SoundRecording.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetCourtesyLine($index)
+    {
+        return isset($this->courtesyLine[$index]);
+    }
+
+    /**
+     * unset courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for guests Artists or others featured on the SoundRecording.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetCourtesyLine($index)
+    {
+        unset($this->courtesyLine[$index]);
+    }
+
+    /**
+     * Gets as courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for guests Artists or others featured on the SoundRecording.
+     *
+     * @return \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType[]
+     */
+    public function getCourtesyLine()
+    {
+        return $this->courtesyLine;
+    }
+
+    /**
+     * Sets a new courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for guests Artists or others featured on the SoundRecording.
+     *
+     * @param \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType[] $courtesyLine
+     * @return self
+     */
+    public function setCourtesyLine(?array $courtesyLine = null)
+    {
+        $this->courtesyLine = $courtesyLine;
+        return $this;
+    }
+
+    /**
+     * Gets as duration
+     *
+     * The Duration of the SoundRecording (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @return \DateInterval
+     */
+    public function getDuration()
+    {
+        return $this->duration;
+    }
+
+    /**
+     * Sets a new duration
+     *
+     * The Duration of the SoundRecording (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @param \DateInterval $duration
+     * @return self
+     */
+    public function setDuration(\DateInterval $duration)
+    {
+        $this->duration = $duration;
+        return $this;
+    }
+
+    /**
+     * Gets as creationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the SoundRecording was created. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType
+     */
+    public function getCreationDate()
+    {
+        return $this->creationDate;
+    }
+
+    /**
+     * Sets a new creationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the SoundRecording was created. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $creationDate
+     * @return self
+     */
+    public function setCreationDate(?\DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $creationDate = null)
+    {
+        $this->creationDate = $creationDate;
+        return $this;
+    }
+
+    /**
+     * Gets as masteredDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the SoundRecording was originally mastered (in either analogue or digital form). This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType
+     */
+    public function getMasteredDate()
+    {
+        return $this->masteredDate;
+    }
+
+    /**
+     * Sets a new masteredDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the SoundRecording was originally mastered (in either analogue or digital form). This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $masteredDate
+     * @return self
+     */
+    public function setMasteredDate(?\DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $masteredDate = null)
+    {
+        $this->masteredDate = $masteredDate;
+        return $this;
+    }
+
+    /**
+     * Gets as remasteredDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the SoundRecording was re-mastered (usually digitally). This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType
+     */
+    public function getRemasteredDate()
+    {
+        return $this->remasteredDate;
+    }
+
+    /**
+     * Sets a new remasteredDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the SoundRecording was re-mastered (usually digitally). This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $remasteredDate
+     * @return self
+     */
+    public function setRemasteredDate(?\DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $remasteredDate = null)
+    {
+        $this->remasteredDate = $remasteredDate;
+        return $this;
+    }
+
+    /**
+     * Adds as firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the SoundRecording was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\FirstPublicationDateType $firstPublicationDate
+     */
+    public function addToFirstPublicationDate(\DedexBundle\Entity\Ern42\FirstPublicationDateType $firstPublicationDate)
+    {
+        $this->firstPublicationDate[] = $firstPublicationDate;
+        return $this;
+    }
+
+    /**
+     * isset firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the SoundRecording was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetFirstPublicationDate($index)
+    {
+        return isset($this->firstPublicationDate[$index]);
+    }
+
+    /**
+     * unset firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the SoundRecording was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetFirstPublicationDate($index)
+    {
+        unset($this->firstPublicationDate[$index]);
+    }
+
+    /**
+     * Gets as firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the SoundRecording was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @return \DedexBundle\Entity\Ern42\FirstPublicationDateType[]
+     */
+    public function getFirstPublicationDate()
+    {
+        return $this->firstPublicationDate;
+    }
+
+    /**
+     * Sets a new firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the SoundRecording was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param \DedexBundle\Entity\Ern42\FirstPublicationDateType[] $firstPublicationDate
+     * @return self
+     */
+    public function setFirstPublicationDate(?array $firstPublicationDate = null)
+    {
+        $this->firstPublicationDate = $firstPublicationDate;
+        return $this;
+    }
+
+    /**
+     * Adds as locationAndDateOfSession
+     *
+     * A Composite containing details of a RecordingSession.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\LocationAndDateOfSessionType $locationAndDateOfSession
+     */
+    public function addToLocationAndDateOfSession(\DedexBundle\Entity\Ern42\LocationAndDateOfSessionType $locationAndDateOfSession)
+    {
+        $this->locationAndDateOfSession[] = $locationAndDateOfSession;
+        return $this;
+    }
+
+    /**
+     * isset locationAndDateOfSession
+     *
+     * A Composite containing details of a RecordingSession.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetLocationAndDateOfSession($index)
+    {
+        return isset($this->locationAndDateOfSession[$index]);
+    }
+
+    /**
+     * unset locationAndDateOfSession
+     *
+     * A Composite containing details of a RecordingSession.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetLocationAndDateOfSession($index)
+    {
+        unset($this->locationAndDateOfSession[$index]);
+    }
+
+    /**
+     * Gets as locationAndDateOfSession
+     *
+     * A Composite containing details of a RecordingSession.
+     *
+     * @return \DedexBundle\Entity\Ern42\LocationAndDateOfSessionType[]
+     */
+    public function getLocationAndDateOfSession()
+    {
+        return $this->locationAndDateOfSession;
+    }
+
+    /**
+     * Sets a new locationAndDateOfSession
+     *
+     * A Composite containing details of a RecordingSession.
+     *
+     * @param \DedexBundle\Entity\Ern42\LocationAndDateOfSessionType[] $locationAndDateOfSession
+     * @return self
+     */
+    public function setLocationAndDateOfSession(?array $locationAndDateOfSession = null)
+    {
+        $this->locationAndDateOfSession = $locationAndDateOfSession;
+        return $this;
+    }
+
+    /**
+     * Adds as parentalWarningType
+     *
+     * A Composite containing details of the classification of the SoundRecording according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType $parentalWarningType
+     */
+    public function addToParentalWarningType(\DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType $parentalWarningType)
+    {
+        $this->parentalWarningType[] = $parentalWarningType;
+        return $this;
+    }
+
+    /**
+     * isset parentalWarningType
+     *
+     * A Composite containing details of the classification of the SoundRecording according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetParentalWarningType($index)
+    {
+        return isset($this->parentalWarningType[$index]);
+    }
+
+    /**
+     * unset parentalWarningType
+     *
+     * A Composite containing details of the classification of the SoundRecording according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetParentalWarningType($index)
+    {
+        unset($this->parentalWarningType[$index]);
+    }
+
+    /**
+     * Gets as parentalWarningType
+     *
+     * A Composite containing details of the classification of the SoundRecording according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @return \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType[]
+     */
+    public function getParentalWarningType()
+    {
+        return $this->parentalWarningType;
+    }
+
+    /**
+     * Sets a new parentalWarningType
+     *
+     * A Composite containing details of the classification of the SoundRecording according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @param \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType[] $parentalWarningType
+     * @return self
+     */
+    public function setParentalWarningType(array $parentalWarningType)
+    {
+        $this->parentalWarningType = $parentalWarningType;
+        return $this;
+    }
+
+    /**
+     * Adds as relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current SoundRecording.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\RelatedReleaseType $relatedRelease
+     */
+    public function addToRelatedRelease(\DedexBundle\Entity\Ern42\RelatedReleaseType $relatedRelease)
+    {
+        $this->relatedRelease[] = $relatedRelease;
+        return $this;
+    }
+
+    /**
+     * isset relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current SoundRecording.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRelatedRelease($index)
+    {
+        return isset($this->relatedRelease[$index]);
+    }
+
+    /**
+     * unset relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current SoundRecording.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRelatedRelease($index)
+    {
+        unset($this->relatedRelease[$index]);
+    }
+
+    /**
+     * Gets as relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current SoundRecording.
+     *
+     * @return \DedexBundle\Entity\Ern42\RelatedReleaseType[]
+     */
+    public function getRelatedRelease()
+    {
+        return $this->relatedRelease;
+    }
+
+    /**
+     * Sets a new relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current SoundRecording.
+     *
+     * @param \DedexBundle\Entity\Ern42\RelatedReleaseType[] $relatedRelease
+     * @return self
+     */
+    public function setRelatedRelease(?array $relatedRelease = null)
+    {
+        $this->relatedRelease = $relatedRelease;
+        return $this;
+    }
+
+    /**
+     * Adds as relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current SoundRecording.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\RelatedResourceType $relatedResource
+     */
+    public function addToRelatedResource(\DedexBundle\Entity\Ern42\RelatedResourceType $relatedResource)
+    {
+        $this->relatedResource[] = $relatedResource;
+        return $this;
+    }
+
+    /**
+     * isset relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current SoundRecording.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRelatedResource($index)
+    {
+        return isset($this->relatedResource[$index]);
+    }
+
+    /**
+     * unset relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current SoundRecording.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRelatedResource($index)
+    {
+        unset($this->relatedResource[$index]);
+    }
+
+    /**
+     * Gets as relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current SoundRecording.
+     *
+     * @return \DedexBundle\Entity\Ern42\RelatedResourceType[]
+     */
+    public function getRelatedResource()
+    {
+        return $this->relatedResource;
+    }
+
+    /**
+     * Sets a new relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current SoundRecording.
+     *
+     * @param \DedexBundle\Entity\Ern42\RelatedResourceType[] $relatedResource
+     * @return self
+     */
+    public function setRelatedResource(?array $relatedResource = null)
+    {
+        $this->relatedResource = $relatedResource;
+        return $this;
+    }
+
+    /**
+     * Gets as compositeMusicalWorkType
+     *
+     * A Type of the SoundRecording indicating whether it is a Medley or a Potpourri.
+     *
+     * @return string
+     */
+    public function getCompositeMusicalWorkType()
+    {
+        return $this->compositeMusicalWorkType;
+    }
+
+    /**
+     * Sets a new compositeMusicalWorkType
+     *
+     * A Type of the SoundRecording indicating whether it is a Medley or a Potpourri.
+     *
+     * @param string $compositeMusicalWorkType
+     * @return self
+     */
+    public function setCompositeMusicalWorkType($compositeMusicalWorkType)
+    {
+        $this->compositeMusicalWorkType = $compositeMusicalWorkType;
+        return $this;
+    }
+
+    /**
+     * Gets as isCover
+     *
+     * A Flag indicating whether the SoundRecording is a Cover (=true) or not (=false). This is not legal information, but meant to help consumers to differentiate originals from covers.
+     *
+     * @return bool
+     */
+    public function getIsCover()
+    {
+        return $this->isCover;
+    }
+
+    /**
+     * Sets a new isCover
+     *
+     * A Flag indicating whether the SoundRecording is a Cover (=true) or not (=false). This is not legal information, but meant to help consumers to differentiate originals from covers.
+     *
+     * @param bool $isCover
+     * @return self
+     */
+    public function setIsCover($isCover)
+    {
+        $this->isCover = $isCover;
+        return $this;
+    }
+
+    /**
+     * Gets as isInstrumental
+     *
+     * The Flag indicating whether the SoundRecording is instrumental (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getIsInstrumental()
+    {
+        return $this->isInstrumental;
+    }
+
+    /**
+     * Sets a new isInstrumental
+     *
+     * The Flag indicating whether the SoundRecording is instrumental (=true) or not (=false).
+     *
+     * @param bool $isInstrumental
+     * @return self
+     */
+    public function setIsInstrumental($isInstrumental)
+    {
+        $this->isInstrumental = $isInstrumental;
+        return $this;
+    }
+
+    /**
+     * Gets as containsHiddenContent
+     *
+     * The Flag indicating whether the SoundRecording contains content that is hidden in some way from the Consumer (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getContainsHiddenContent()
+    {
+        return $this->containsHiddenContent;
+    }
+
+    /**
+     * Sets a new containsHiddenContent
+     *
+     * The Flag indicating whether the SoundRecording contains content that is hidden in some way from the Consumer (=true) or not (=false).
+     *
+     * @param bool $containsHiddenContent
+     * @return self
+     */
+    public function setContainsHiddenContent($containsHiddenContent)
+    {
+        $this->containsHiddenContent = $containsHiddenContent;
+        return $this;
+    }
+
+    /**
+     * Gets as isRemastered
+     *
+     * The Flag indicating whether the SoundRecording is remastered (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getIsRemastered()
+    {
+        return $this->isRemastered;
+    }
+
+    /**
+     * Sets a new isRemastered
+     *
+     * The Flag indicating whether the SoundRecording is remastered (=true) or not (=false).
+     *
+     * @param bool $isRemastered
+     * @return self
+     */
+    public function setIsRemastered($isRemastered)
+    {
+        $this->isRemastered = $isRemastered;
+        return $this;
+    }
+
+    /**
+     * Gets as isHiResMusic
+     *
+     * The Flag indicating whether the SoundRecording meets the criteria to carry the HiResMusic logo, provided the MessageRecipient meets all the other requirements to use it (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getIsHiResMusic()
+    {
+        return $this->isHiResMusic;
+    }
+
+    /**
+     * Sets a new isHiResMusic
+     *
+     * The Flag indicating whether the SoundRecording meets the criteria to carry the HiResMusic logo, provided the MessageRecipient meets all the other requirements to use it (=true) or not (=false).
+     *
+     * @param bool $isHiResMusic
+     * @return self
+     */
+    public function setIsHiResMusic($isHiResMusic)
+    {
+        $this->isHiResMusic = $isHiResMusic;
+        return $this;
+    }
+
+    /**
+     * Gets as disableCrossfade
+     *
+     * A Flag indicating to a DSP whether the SoundRecording should not be crossfaded from/into another SoundRecording (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getDisableCrossfade()
+    {
+        return $this->disableCrossfade;
+    }
+
+    /**
+     * Sets a new disableCrossfade
+     *
+     * A Flag indicating to a DSP whether the SoundRecording should not be crossfaded from/into another SoundRecording (=true) or not (=false).
+     *
+     * @param bool $disableCrossfade
+     * @return self
+     */
+    public function setDisableCrossfade($disableCrossfade)
+    {
+        $this->disableCrossfade = $disableCrossfade;
+        return $this;
+    }
+
+    /**
+     * Gets as disableSearch
+     *
+     * A Flag indicating to a DSP whether the SoundRecording should not be included in any search results (=true) or not (=false). Note that exclusion from search results implies that the SoundRecording should not appear in any recommendations.
+     *
+     * @return bool
+     */
+    public function getDisableSearch()
+    {
+        return $this->disableSearch;
+    }
+
+    /**
+     * Sets a new disableSearch
+     *
+     * A Flag indicating to a DSP whether the SoundRecording should not be included in any search results (=true) or not (=false). Note that exclusion from search results implies that the SoundRecording should not appear in any recommendations.
+     *
+     * @param bool $disableSearch
+     * @return self
+     */
+    public function setDisableSearch($disableSearch)
+    {
+        $this->disableSearch = $disableSearch;
+        return $this;
+    }
+
+    /**
+     * Adds as displayCredits
+     *
+     * A Role and instrumentation for which a Party is credited.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayCreditsType $displayCredits
+     */
+    public function addToDisplayCredits(\DedexBundle\Entity\Ern42\DisplayCreditsType $displayCredits)
+    {
+        $this->displayCredits[] = $displayCredits;
+        return $this;
+    }
+
+    /**
+     * isset displayCredits
+     *
+     * A Role and instrumentation for which a Party is credited.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayCredits($index)
+    {
+        return isset($this->displayCredits[$index]);
+    }
+
+    /**
+     * unset displayCredits
+     *
+     * A Role and instrumentation for which a Party is credited.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayCredits($index)
+    {
+        unset($this->displayCredits[$index]);
+    }
+
+    /**
+     * Gets as displayCredits
+     *
+     * A Role and instrumentation for which a Party is credited.
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayCreditsType[]
+     */
+    public function getDisplayCredits()
+    {
+        return $this->displayCredits;
+    }
+
+    /**
+     * Sets a new displayCredits
+     *
+     * A Role and instrumentation for which a Party is credited.
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayCreditsType[] $displayCredits
+     * @return self
+     */
+    public function setDisplayCredits(?array $displayCredits = null)
+    {
+        $this->displayCredits = $displayCredits;
+        return $this;
+    }
+
+    /**
+     * Adds as languageOfPerformance
+     *
+     * The Language of the Performance recorded in the SoundRecording as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @return self
+     * @param string $languageOfPerformance
+     */
+    public function addToLanguageOfPerformance($languageOfPerformance)
+    {
+        $this->languageOfPerformance[] = $languageOfPerformance;
+        return $this;
+    }
+
+    /**
+     * isset languageOfPerformance
+     *
+     * The Language of the Performance recorded in the SoundRecording as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetLanguageOfPerformance($index)
+    {
+        return isset($this->languageOfPerformance[$index]);
+    }
+
+    /**
+     * unset languageOfPerformance
+     *
+     * The Language of the Performance recorded in the SoundRecording as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetLanguageOfPerformance($index)
+    {
+        unset($this->languageOfPerformance[$index]);
+    }
+
+    /**
+     * Gets as languageOfPerformance
+     *
+     * The Language of the Performance recorded in the SoundRecording as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @return string[]
+     */
+    public function getLanguageOfPerformance()
+    {
+        return $this->languageOfPerformance;
+    }
+
+    /**
+     * Sets a new languageOfPerformance
+     *
+     * The Language of the Performance recorded in the SoundRecording as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @param string $languageOfPerformance
+     * @return self
+     */
+    public function setLanguageOfPerformance(?array $languageOfPerformance = null)
+    {
+        $this->languageOfPerformance = $languageOfPerformance;
+        return $this;
+    }
+
+    /**
+     * Gets as audioChannelConfiguration
+     *
+     * A configuration of audio channels.
+     *
+     * @return string
+     */
+    public function getAudioChannelConfiguration()
+    {
+        return $this->audioChannelConfiguration;
+    }
+
+    /**
+     * Sets a new audioChannelConfiguration
+     *
+     * A configuration of audio channels.
+     *
+     * @param string $audioChannelConfiguration
+     * @return self
+     */
+    public function setAudioChannelConfiguration($audioChannelConfiguration)
+    {
+        $this->audioChannelConfiguration = $audioChannelConfiguration;
+        return $this;
+    }
+
+    /**
+     * Adds as technicalDetails
+     *
+     * A Composite containing technical details of the SoundRecording.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\TechnicalSoundRecordingDetailsType $technicalDetails
+     */
+    public function addToTechnicalDetails(\DedexBundle\Entity\Ern42\TechnicalSoundRecordingDetailsType $technicalDetails)
+    {
+        $this->technicalDetails[] = $technicalDetails;
+        return $this;
+    }
+
+    /**
+     * isset technicalDetails
+     *
+     * A Composite containing technical details of the SoundRecording.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetTechnicalDetails($index)
+    {
+        return isset($this->technicalDetails[$index]);
+    }
+
+    /**
+     * unset technicalDetails
+     *
+     * A Composite containing technical details of the SoundRecording.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetTechnicalDetails($index)
+    {
+        unset($this->technicalDetails[$index]);
+    }
+
+    /**
+     * Gets as technicalDetails
+     *
+     * A Composite containing technical details of the SoundRecording.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @return \DedexBundle\Entity\Ern42\TechnicalSoundRecordingDetailsType[]
+     */
+    public function getTechnicalDetails()
+    {
+        return $this->technicalDetails;
+    }
+
+    /**
+     * Sets a new technicalDetails
+     *
+     * A Composite containing technical details of the SoundRecording.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @param \DedexBundle\Entity\Ern42\TechnicalSoundRecordingDetailsType[] $technicalDetails
+     * @return self
+     */
+    public function setTechnicalDetails(?array $technicalDetails = null)
+    {
+        $this->technicalDetails = $technicalDetails;
+        return $this;
+    }
+
+    /**
+     * Adds as raga
+     *
+     * A Description of the melodic mode of a MusicalWork in the SoundRecording.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\RagaType $raga
+     */
+    public function addToRaga(\DedexBundle\Entity\Ern42\RagaType $raga)
+    {
+        $this->raga[] = $raga;
+        return $this;
+    }
+
+    /**
+     * isset raga
+     *
+     * A Description of the melodic mode of a MusicalWork in the SoundRecording.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRaga($index)
+    {
+        return isset($this->raga[$index]);
+    }
+
+    /**
+     * unset raga
+     *
+     * A Description of the melodic mode of a MusicalWork in the SoundRecording.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRaga($index)
+    {
+        unset($this->raga[$index]);
+    }
+
+    /**
+     * Gets as raga
+     *
+     * A Description of the melodic mode of a MusicalWork in the SoundRecording.
+     *
+     * @return \DedexBundle\Entity\Ern42\RagaType[]
+     */
+    public function getRaga()
+    {
+        return $this->raga;
+    }
+
+    /**
+     * Sets a new raga
+     *
+     * A Description of the melodic mode of a MusicalWork in the SoundRecording.
+     *
+     * @param \DedexBundle\Entity\Ern42\RagaType[] $raga
+     * @return self
+     */
+    public function setRaga(?array $raga = null)
+    {
+        $this->raga = $raga;
+        return $this;
+    }
+
+    /**
+     * Adds as tala
+     *
+     * A Description of the rhythmic pattern of a MusicalWork in the SoundRecording.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\TalaType $tala
+     */
+    public function addToTala(\DedexBundle\Entity\Ern42\TalaType $tala)
+    {
+        $this->tala[] = $tala;
+        return $this;
+    }
+
+    /**
+     * isset tala
+     *
+     * A Description of the rhythmic pattern of a MusicalWork in the SoundRecording.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetTala($index)
+    {
+        return isset($this->tala[$index]);
+    }
+
+    /**
+     * unset tala
+     *
+     * A Description of the rhythmic pattern of a MusicalWork in the SoundRecording.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetTala($index)
+    {
+        unset($this->tala[$index]);
+    }
+
+    /**
+     * Gets as tala
+     *
+     * A Description of the rhythmic pattern of a MusicalWork in the SoundRecording.
+     *
+     * @return \DedexBundle\Entity\Ern42\TalaType[]
+     */
+    public function getTala()
+    {
+        return $this->tala;
+    }
+
+    /**
+     * Sets a new tala
+     *
+     * A Description of the rhythmic pattern of a MusicalWork in the SoundRecording.
+     *
+     * @param \DedexBundle\Entity\Ern42\TalaType[] $tala
+     * @return self
+     */
+    public function setTala(?array $tala = null)
+    {
+        $this->tala = $tala;
+        return $this;
+    }
+
+    /**
+     * Adds as deity
+     *
+     * A deity name relating to the SoundRecording.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DeityType $deity
+     */
+    public function addToDeity(\DedexBundle\Entity\Ern42\DeityType $deity)
+    {
+        $this->deity[] = $deity;
+        return $this;
+    }
+
+    /**
+     * isset deity
+     *
+     * A deity name relating to the SoundRecording.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDeity($index)
+    {
+        return isset($this->deity[$index]);
+    }
+
+    /**
+     * unset deity
+     *
+     * A deity name relating to the SoundRecording.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDeity($index)
+    {
+        unset($this->deity[$index]);
+    }
+
+    /**
+     * Gets as deity
+     *
+     * A deity name relating to the SoundRecording.
+     *
+     * @return \DedexBundle\Entity\Ern42\DeityType[]
+     */
+    public function getDeity()
+    {
+        return $this->deity;
+    }
+
+    /**
+     * Sets a new deity
+     *
+     * A deity name relating to the SoundRecording.
+     *
+     * @param \DedexBundle\Entity\Ern42\DeityType[] $deity
+     * @return self
+     */
+    public function setDeity(?array $deity = null)
+    {
+        $this->deity = $deity;
+        return $this;
+    }
+
+    /**
+     * Adds as audioChapterReference
+     *
+     * A Reference for a Chapter (specific to this Message). This is a LocalCollectionAnchorReference starting with the letter X.
+     *
+     * @return self
+     * @param string $audioChapterReference
+     */
+    public function addToAudioChapterReference($audioChapterReference)
+    {
+        $this->audioChapterReference[] = $audioChapterReference;
+        return $this;
+    }
+
+    /**
+     * isset audioChapterReference
+     *
+     * A Reference for a Chapter (specific to this Message). This is a LocalCollectionAnchorReference starting with the letter X.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetAudioChapterReference($index)
+    {
+        return isset($this->audioChapterReference[$index]);
+    }
+
+    /**
+     * unset audioChapterReference
+     *
+     * A Reference for a Chapter (specific to this Message). This is a LocalCollectionAnchorReference starting with the letter X.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetAudioChapterReference($index)
+    {
+        unset($this->audioChapterReference[$index]);
+    }
+
+    /**
+     * Gets as audioChapterReference
+     *
+     * A Reference for a Chapter (specific to this Message). This is a LocalCollectionAnchorReference starting with the letter X.
+     *
+     * @return string[]
+     */
+    public function getAudioChapterReference()
+    {
+        return $this->audioChapterReference;
+    }
+
+    /**
+     * Sets a new audioChapterReference
+     *
+     * A Reference for a Chapter (specific to this Message). This is a LocalCollectionAnchorReference starting with the letter X.
+     *
+     * @param string $audioChapterReference
+     * @return self
+     */
+    public function setAudioChapterReference(?array $audioChapterReference = null)
+    {
+        $this->audioChapterReference = $audioChapterReference;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/SoundRecordingTypeType.php
+++ b/src/Entity/Ern42/SoundRecordingTypeType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing SoundRecordingTypeType
+ *
+ * A Composite containing details of a SoundRecordingType.
+ * XSD Type: SoundRecordingType
+ */
+class SoundRecordingTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the SoundRecordingType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the SoundRecordingType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the SoundRecordingType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the SoundRecordingType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the SoundRecordingType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the SoundRecordingType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/SubGenreCategoryType.php
+++ b/src/Entity/Ern42/SubGenreCategoryType.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing SubGenreCategoryType
+ *
+ * A Composite containing details of a sub-genre within the classical genre.
+ * XSD Type: SubGenreCategory
+ */
+class SubGenreCategoryType
+{
+    /**
+     * The text of the sub-genre.
+     *
+     * @var \DedexBundle\Entity\Ern42\SubGenreCategoryValueType[] $value
+     */
+    private $value = [
+        
+    ];
+
+    /**
+     * Adds as value
+     *
+     * The text of the sub-genre.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\SubGenreCategoryValueType $value
+     */
+    public function addToValue(\DedexBundle\Entity\Ern42\SubGenreCategoryValueType $value)
+    {
+        $this->value[] = $value;
+        return $this;
+    }
+
+    /**
+     * isset value
+     *
+     * The text of the sub-genre.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetValue($index)
+    {
+        return isset($this->value[$index]);
+    }
+
+    /**
+     * unset value
+     *
+     * The text of the sub-genre.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetValue($index)
+    {
+        unset($this->value[$index]);
+    }
+
+    /**
+     * Gets as value
+     *
+     * The text of the sub-genre.
+     *
+     * @return \DedexBundle\Entity\Ern42\SubGenreCategoryValueType[]
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Sets a new value
+     *
+     * The text of the sub-genre.
+     *
+     * @param \DedexBundle\Entity\Ern42\SubGenreCategoryValueType[] $value
+     * @return self
+     */
+    public function setValue(array $value)
+    {
+        $this->value = $value;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/SubGenreCategoryValueType.php
+++ b/src/Entity/Ern42/SubGenreCategoryValueType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing SubGenreCategoryValueType
+ *
+ * A Composite containing details of a sub-genre within the classical genre.
+ * XSD Type: SubGenreCategoryValue
+ */
+class SubGenreCategoryValueType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the classical sub-genre. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the vocal register. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the classical sub-genre. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the classical sub-genre. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the vocal register. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the vocal register. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/SupplementalDocumentListType.php
+++ b/src/Entity/Ern42/SupplementalDocumentListType.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing SupplementalDocumentListType
+ *
+ * A Composite containing details of one or more supplemental documents.
+ * XSD Type: SupplementalDocumentList
+ */
+class SupplementalDocumentListType
+{
+    /**
+     * A Composite containing details of a supplemental document.
+     *
+     * @var \DedexBundle\Entity\Ern42\FileType[] $supplementalDocument
+     */
+    private $supplementalDocument = [
+        
+    ];
+
+    /**
+     * Adds as supplementalDocument
+     *
+     * A Composite containing details of a supplemental document.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\FileType $supplementalDocument
+     */
+    public function addToSupplementalDocument(\DedexBundle\Entity\Ern42\FileType $supplementalDocument)
+    {
+        $this->supplementalDocument[] = $supplementalDocument;
+        return $this;
+    }
+
+    /**
+     * isset supplementalDocument
+     *
+     * A Composite containing details of a supplemental document.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetSupplementalDocument($index)
+    {
+        return isset($this->supplementalDocument[$index]);
+    }
+
+    /**
+     * unset supplementalDocument
+     *
+     * A Composite containing details of a supplemental document.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetSupplementalDocument($index)
+    {
+        unset($this->supplementalDocument[$index]);
+    }
+
+    /**
+     * Gets as supplementalDocument
+     *
+     * A Composite containing details of a supplemental document.
+     *
+     * @return \DedexBundle\Entity\Ern42\FileType[]
+     */
+    public function getSupplementalDocument()
+    {
+        return $this->supplementalDocument;
+    }
+
+    /**
+     * Sets a new supplementalDocument
+     *
+     * A Composite containing details of a supplemental document.
+     *
+     * @param \DedexBundle\Entity\Ern42\FileType[] $supplementalDocument
+     * @return self
+     */
+    public function setSupplementalDocument(array $supplementalDocument)
+    {
+        $this->supplementalDocument = $supplementalDocument;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/SynopsisWithTerritoryType.php
+++ b/src/Entity/Ern42/SynopsisWithTerritoryType.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing SynopsisWithTerritoryType
+ *
+ * A Composite containing details of a Synopsis.
+ * Explanatory Note: This Composite is named SynopsisWithTerritory to disambiguate it from the basic Synopsis Composite.
+ * XSD Type: SynopsisWithTerritory
+ */
+class SynopsisWithTerritoryType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Language and script of the Synopsis as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * A Territory to which the Synopsis applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * The Flag indicating whether the Synopsis is short (=true) or not (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isShortSynopsis
+     */
+    private $isShortSynopsis = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script of the Synopsis as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script of the Synopsis as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the Synopsis applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the Synopsis applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+
+    /**
+     * Gets as isShortSynopsis
+     *
+     * The Flag indicating whether the Synopsis is short (=true) or not (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsShortSynopsis()
+    {
+        return $this->isShortSynopsis;
+    }
+
+    /**
+     * Sets a new isShortSynopsis
+     *
+     * The Flag indicating whether the Synopsis is short (=true) or not (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isShortSynopsis
+     * @return self
+     */
+    public function setIsShortSynopsis($isShortSynopsis)
+    {
+        $this->isShortSynopsis = $isShortSynopsis;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/TalaType.php
+++ b/src/Entity/Ern42/TalaType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing TalaType
+ *
+ * A Composite containing details of a Tala.
+ * XSD Type: Tala
+ */
+class TalaType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * A Territory to which the Tala applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the Tala applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the Tala applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/TechnicalImageDetailsType.php
+++ b/src/Entity/Ern42/TechnicalImageDetailsType.php
@@ -1,0 +1,586 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing TechnicalImageDetailsType
+ *
+ * A Composite containing technical details of an Image.
+ * XSD Type: TechnicalImageDetails
+ */
+class TechnicalImageDetailsType
+{
+    /**
+     * The Language and script for the Elements of the TechnicalImageDetails as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * A Territory to which the TechnicalImageDetails apply. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * The Identifier (specific to the Message) of the TechnicalImageDetails within the Release which contains it. This is a LocalTechnicalResourceDetailsAnchor starting with the letter T.
+     *
+     * @var string $technicalResourceDetailsReference
+     */
+    private $technicalResourceDetailsReference = null;
+
+    /**
+     * A Composite containing details of a Type of ImageCodec.
+     *
+     * @var \DedexBundle\Entity\Ern42\ImageCodecTypeType $imageCodecType
+     */
+    private $imageCodecType = null;
+
+    /**
+     * A Composite containing the vertical Extent of an Image of the Image and a UnitOfMeasure (the default is Pixels).
+     *
+     * @var \DedexBundle\Entity\Ern42\ExtentType $imageHeight
+     */
+    private $imageHeight = null;
+
+    /**
+     * A Composite containing the horizontal Extent of an Image of the Image and a UnitOfMeasure (the default is Pixels).
+     *
+     * @var \DedexBundle\Entity\Ern42\ExtentType $imageWidth
+     */
+    private $imageWidth = null;
+
+    /**
+     * A Composite containing the ratio formed by dividing the ImageHeight by the ImageWidth.
+     *
+     * @var \DedexBundle\Entity\Ern42\AspectRatioType $aspectRatio
+     */
+    private $aspectRatio = null;
+
+    /**
+     * An amount of data determining the color of a Pixel of the Image (given in bits per pixel).
+     *
+     * @var int $colorDepth
+     */
+    private $colorDepth = null;
+
+    /**
+     * A number of Pixels of the Image displayed in a specific spatial range (given in dpi).
+     *
+     * @var int $imageResolution
+     */
+    private $imageResolution = null;
+
+    /**
+     * The BitDepth of the File.
+     *
+     * @var int $bitDepth
+     */
+    private $bitDepth = null;
+
+    /**
+     * The Flag indicating whether the Image is technically a preview of the parent Resource (=true) or not (=false). Note that nothing can be implied from this element as to the conditions under which the preview can be made available.
+     *
+     * @var bool $isPreview
+     */
+    private $isPreview = null;
+
+    /**
+     * A Composite containing details of a preview.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-previews/preview-resources
+     *
+     * @var \DedexBundle\Entity\Ern42\PreviewDetailsType $previewDetails
+     */
+    private $previewDetails = null;
+
+    /**
+     * A Composite containing details of a File containing the Image that a DSP can obtain.
+     *
+     * @var \DedexBundle\Entity\Ern42\FileType $file
+     */
+    private $file = null;
+
+    /**
+     * A Flag indicating whether a File containing the Image is a provided in a delivery (=true) or not (=false).
+     *
+     * @var bool $isProvidedInDelivery
+     */
+    private $isProvidedInDelivery = null;
+
+    /**
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @var \DedexBundle\Entity\Ern42\FingerprintType[] $fingerprint
+     */
+    private $fingerprint = [
+        
+    ];
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the Elements of the TechnicalImageDetails as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the Elements of the TechnicalImageDetails as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the TechnicalImageDetails apply. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the TechnicalImageDetails apply. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+
+    /**
+     * Gets as technicalResourceDetailsReference
+     *
+     * The Identifier (specific to the Message) of the TechnicalImageDetails within the Release which contains it. This is a LocalTechnicalResourceDetailsAnchor starting with the letter T.
+     *
+     * @return string
+     */
+    public function getTechnicalResourceDetailsReference()
+    {
+        return $this->technicalResourceDetailsReference;
+    }
+
+    /**
+     * Sets a new technicalResourceDetailsReference
+     *
+     * The Identifier (specific to the Message) of the TechnicalImageDetails within the Release which contains it. This is a LocalTechnicalResourceDetailsAnchor starting with the letter T.
+     *
+     * @param string $technicalResourceDetailsReference
+     * @return self
+     */
+    public function setTechnicalResourceDetailsReference($technicalResourceDetailsReference)
+    {
+        $this->technicalResourceDetailsReference = $technicalResourceDetailsReference;
+        return $this;
+    }
+
+    /**
+     * Gets as imageCodecType
+     *
+     * A Composite containing details of a Type of ImageCodec.
+     *
+     * @return \DedexBundle\Entity\Ern42\ImageCodecTypeType
+     */
+    public function getImageCodecType()
+    {
+        return $this->imageCodecType;
+    }
+
+    /**
+     * Sets a new imageCodecType
+     *
+     * A Composite containing details of a Type of ImageCodec.
+     *
+     * @param \DedexBundle\Entity\Ern42\ImageCodecTypeType $imageCodecType
+     * @return self
+     */
+    public function setImageCodecType(?\DedexBundle\Entity\Ern42\ImageCodecTypeType $imageCodecType = null)
+    {
+        $this->imageCodecType = $imageCodecType;
+        return $this;
+    }
+
+    /**
+     * Gets as imageHeight
+     *
+     * A Composite containing the vertical Extent of an Image of the Image and a UnitOfMeasure (the default is Pixels).
+     *
+     * @return \DedexBundle\Entity\Ern42\ExtentType
+     */
+    public function getImageHeight()
+    {
+        return $this->imageHeight;
+    }
+
+    /**
+     * Sets a new imageHeight
+     *
+     * A Composite containing the vertical Extent of an Image of the Image and a UnitOfMeasure (the default is Pixels).
+     *
+     * @param \DedexBundle\Entity\Ern42\ExtentType $imageHeight
+     * @return self
+     */
+    public function setImageHeight(?\DedexBundle\Entity\Ern42\ExtentType $imageHeight = null)
+    {
+        $this->imageHeight = $imageHeight;
+        return $this;
+    }
+
+    /**
+     * Gets as imageWidth
+     *
+     * A Composite containing the horizontal Extent of an Image of the Image and a UnitOfMeasure (the default is Pixels).
+     *
+     * @return \DedexBundle\Entity\Ern42\ExtentType
+     */
+    public function getImageWidth()
+    {
+        return $this->imageWidth;
+    }
+
+    /**
+     * Sets a new imageWidth
+     *
+     * A Composite containing the horizontal Extent of an Image of the Image and a UnitOfMeasure (the default is Pixels).
+     *
+     * @param \DedexBundle\Entity\Ern42\ExtentType $imageWidth
+     * @return self
+     */
+    public function setImageWidth(?\DedexBundle\Entity\Ern42\ExtentType $imageWidth = null)
+    {
+        $this->imageWidth = $imageWidth;
+        return $this;
+    }
+
+    /**
+     * Gets as aspectRatio
+     *
+     * A Composite containing the ratio formed by dividing the ImageHeight by the ImageWidth.
+     *
+     * @return \DedexBundle\Entity\Ern42\AspectRatioType
+     */
+    public function getAspectRatio()
+    {
+        return $this->aspectRatio;
+    }
+
+    /**
+     * Sets a new aspectRatio
+     *
+     * A Composite containing the ratio formed by dividing the ImageHeight by the ImageWidth.
+     *
+     * @param \DedexBundle\Entity\Ern42\AspectRatioType $aspectRatio
+     * @return self
+     */
+    public function setAspectRatio(?\DedexBundle\Entity\Ern42\AspectRatioType $aspectRatio = null)
+    {
+        $this->aspectRatio = $aspectRatio;
+        return $this;
+    }
+
+    /**
+     * Gets as colorDepth
+     *
+     * An amount of data determining the color of a Pixel of the Image (given in bits per pixel).
+     *
+     * @return int
+     */
+    public function getColorDepth()
+    {
+        return $this->colorDepth;
+    }
+
+    /**
+     * Sets a new colorDepth
+     *
+     * An amount of data determining the color of a Pixel of the Image (given in bits per pixel).
+     *
+     * @param int $colorDepth
+     * @return self
+     */
+    public function setColorDepth($colorDepth)
+    {
+        $this->colorDepth = $colorDepth;
+        return $this;
+    }
+
+    /**
+     * Gets as imageResolution
+     *
+     * A number of Pixels of the Image displayed in a specific spatial range (given in dpi).
+     *
+     * @return int
+     */
+    public function getImageResolution()
+    {
+        return $this->imageResolution;
+    }
+
+    /**
+     * Sets a new imageResolution
+     *
+     * A number of Pixels of the Image displayed in a specific spatial range (given in dpi).
+     *
+     * @param int $imageResolution
+     * @return self
+     */
+    public function setImageResolution($imageResolution)
+    {
+        $this->imageResolution = $imageResolution;
+        return $this;
+    }
+
+    /**
+     * Gets as bitDepth
+     *
+     * The BitDepth of the File.
+     *
+     * @return int
+     */
+    public function getBitDepth()
+    {
+        return $this->bitDepth;
+    }
+
+    /**
+     * Sets a new bitDepth
+     *
+     * The BitDepth of the File.
+     *
+     * @param int $bitDepth
+     * @return self
+     */
+    public function setBitDepth($bitDepth)
+    {
+        $this->bitDepth = $bitDepth;
+        return $this;
+    }
+
+    /**
+     * Gets as isPreview
+     *
+     * The Flag indicating whether the Image is technically a preview of the parent Resource (=true) or not (=false). Note that nothing can be implied from this element as to the conditions under which the preview can be made available.
+     *
+     * @return bool
+     */
+    public function getIsPreview()
+    {
+        return $this->isPreview;
+    }
+
+    /**
+     * Sets a new isPreview
+     *
+     * The Flag indicating whether the Image is technically a preview of the parent Resource (=true) or not (=false). Note that nothing can be implied from this element as to the conditions under which the preview can be made available.
+     *
+     * @param bool $isPreview
+     * @return self
+     */
+    public function setIsPreview($isPreview)
+    {
+        $this->isPreview = $isPreview;
+        return $this;
+    }
+
+    /**
+     * Gets as previewDetails
+     *
+     * A Composite containing details of a preview.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-previews/preview-resources
+     *
+     * @return \DedexBundle\Entity\Ern42\PreviewDetailsType
+     */
+    public function getPreviewDetails()
+    {
+        return $this->previewDetails;
+    }
+
+    /**
+     * Sets a new previewDetails
+     *
+     * A Composite containing details of a preview.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-previews/preview-resources
+     *
+     * @param \DedexBundle\Entity\Ern42\PreviewDetailsType $previewDetails
+     * @return self
+     */
+    public function setPreviewDetails(?\DedexBundle\Entity\Ern42\PreviewDetailsType $previewDetails = null)
+    {
+        $this->previewDetails = $previewDetails;
+        return $this;
+    }
+
+    /**
+     * Gets as file
+     *
+     * A Composite containing details of a File containing the Image that a DSP can obtain.
+     *
+     * @return \DedexBundle\Entity\Ern42\FileType
+     */
+    public function getFile()
+    {
+        return $this->file;
+    }
+
+    /**
+     * Sets a new file
+     *
+     * A Composite containing details of a File containing the Image that a DSP can obtain.
+     *
+     * @param \DedexBundle\Entity\Ern42\FileType $file
+     * @return self
+     */
+    public function setFile(?\DedexBundle\Entity\Ern42\FileType $file = null)
+    {
+        $this->file = $file;
+        return $this;
+    }
+
+    /**
+     * Gets as isProvidedInDelivery
+     *
+     * A Flag indicating whether a File containing the Image is a provided in a delivery (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getIsProvidedInDelivery()
+    {
+        return $this->isProvidedInDelivery;
+    }
+
+    /**
+     * Sets a new isProvidedInDelivery
+     *
+     * A Flag indicating whether a File containing the Image is a provided in a delivery (=true) or not (=false).
+     *
+     * @param bool $isProvidedInDelivery
+     * @return self
+     */
+    public function setIsProvidedInDelivery($isProvidedInDelivery)
+    {
+        $this->isProvidedInDelivery = $isProvidedInDelivery;
+        return $this;
+    }
+
+    /**
+     * Adds as fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\FingerprintType $fingerprint
+     */
+    public function addToFingerprint(\DedexBundle\Entity\Ern42\FingerprintType $fingerprint)
+    {
+        $this->fingerprint[] = $fingerprint;
+        return $this;
+    }
+
+    /**
+     * isset fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetFingerprint($index)
+    {
+        return isset($this->fingerprint[$index]);
+    }
+
+    /**
+     * unset fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetFingerprint($index)
+    {
+        unset($this->fingerprint[$index]);
+    }
+
+    /**
+     * Gets as fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @return \DedexBundle\Entity\Ern42\FingerprintType[]
+     */
+    public function getFingerprint()
+    {
+        return $this->fingerprint;
+    }
+
+    /**
+     * Sets a new fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @param \DedexBundle\Entity\Ern42\FingerprintType[] $fingerprint
+     * @return self
+     */
+    public function setFingerprint(?array $fingerprint = null)
+    {
+        $this->fingerprint = $fingerprint;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/TechnicalSheetMusicDetailsType.php
+++ b/src/Entity/Ern42/TechnicalSheetMusicDetailsType.php
@@ -1,0 +1,421 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing TechnicalSheetMusicDetailsType
+ *
+ * A Composite containing technical details of a SheetMusic.
+ * XSD Type: TechnicalSheetMusicDetails
+ */
+class TechnicalSheetMusicDetailsType
+{
+    /**
+     * The Language and script for the Elements of the TechnicalSheetMusicDetails as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * A Territory to which the TechnicalSheetMusicDetails apply. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * The Identifier (specific to the Message) of the TechnicalSheetMusicDetails within the Release which contains it. This is a LocalTechnicalResourceDetailsAnchor starting with the letter T.
+     *
+     * @var string $technicalResourceDetailsReference
+     */
+    private $technicalResourceDetailsReference = null;
+
+    /**
+     * A Composite containing details of a Type of SheetMusic Codec.
+     *
+     * @var \DedexBundle\Entity\Ern42\SheetMusicCodecTypeType $sheetMusicCodecType
+     */
+    private $sheetMusicCodecType = null;
+
+    /**
+     * The BitDepth of the File.
+     *
+     * @var int $bitDepth
+     */
+    private $bitDepth = null;
+
+    /**
+     * The Flag indicating whether the SheetMusic is technically a preview of the parent Resource (=true) or not (=false). Note that nothing can be implied from this element as to the conditions under which the preview can be made available.
+     *
+     * @var bool $isPreview
+     */
+    private $isPreview = null;
+
+    /**
+     * A Composite containing details of a preview.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-previews/preview-resources
+     *
+     * @var \DedexBundle\Entity\Ern42\PreviewDetailsType $previewDetails
+     */
+    private $previewDetails = null;
+
+    /**
+     * A Composite containing details of a File containing the SheetMusic that a DSP can obtain.
+     *
+     * @var \DedexBundle\Entity\Ern42\FileType $file
+     */
+    private $file = null;
+
+    /**
+     * A Flag indicating whether a File containing the SheetMusic is a provided in a delivery (=true) or not (=false).
+     *
+     * @var bool $isProvidedInDelivery
+     */
+    private $isProvidedInDelivery = null;
+
+    /**
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @var \DedexBundle\Entity\Ern42\FingerprintType[] $fingerprint
+     */
+    private $fingerprint = [
+        
+    ];
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the Elements of the TechnicalSheetMusicDetails as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the Elements of the TechnicalSheetMusicDetails as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the TechnicalSheetMusicDetails apply. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the TechnicalSheetMusicDetails apply. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+
+    /**
+     * Gets as technicalResourceDetailsReference
+     *
+     * The Identifier (specific to the Message) of the TechnicalSheetMusicDetails within the Release which contains it. This is a LocalTechnicalResourceDetailsAnchor starting with the letter T.
+     *
+     * @return string
+     */
+    public function getTechnicalResourceDetailsReference()
+    {
+        return $this->technicalResourceDetailsReference;
+    }
+
+    /**
+     * Sets a new technicalResourceDetailsReference
+     *
+     * The Identifier (specific to the Message) of the TechnicalSheetMusicDetails within the Release which contains it. This is a LocalTechnicalResourceDetailsAnchor starting with the letter T.
+     *
+     * @param string $technicalResourceDetailsReference
+     * @return self
+     */
+    public function setTechnicalResourceDetailsReference($technicalResourceDetailsReference)
+    {
+        $this->technicalResourceDetailsReference = $technicalResourceDetailsReference;
+        return $this;
+    }
+
+    /**
+     * Gets as sheetMusicCodecType
+     *
+     * A Composite containing details of a Type of SheetMusic Codec.
+     *
+     * @return \DedexBundle\Entity\Ern42\SheetMusicCodecTypeType
+     */
+    public function getSheetMusicCodecType()
+    {
+        return $this->sheetMusicCodecType;
+    }
+
+    /**
+     * Sets a new sheetMusicCodecType
+     *
+     * A Composite containing details of a Type of SheetMusic Codec.
+     *
+     * @param \DedexBundle\Entity\Ern42\SheetMusicCodecTypeType $sheetMusicCodecType
+     * @return self
+     */
+    public function setSheetMusicCodecType(?\DedexBundle\Entity\Ern42\SheetMusicCodecTypeType $sheetMusicCodecType = null)
+    {
+        $this->sheetMusicCodecType = $sheetMusicCodecType;
+        return $this;
+    }
+
+    /**
+     * Gets as bitDepth
+     *
+     * The BitDepth of the File.
+     *
+     * @return int
+     */
+    public function getBitDepth()
+    {
+        return $this->bitDepth;
+    }
+
+    /**
+     * Sets a new bitDepth
+     *
+     * The BitDepth of the File.
+     *
+     * @param int $bitDepth
+     * @return self
+     */
+    public function setBitDepth($bitDepth)
+    {
+        $this->bitDepth = $bitDepth;
+        return $this;
+    }
+
+    /**
+     * Gets as isPreview
+     *
+     * The Flag indicating whether the SheetMusic is technically a preview of the parent Resource (=true) or not (=false). Note that nothing can be implied from this element as to the conditions under which the preview can be made available.
+     *
+     * @return bool
+     */
+    public function getIsPreview()
+    {
+        return $this->isPreview;
+    }
+
+    /**
+     * Sets a new isPreview
+     *
+     * The Flag indicating whether the SheetMusic is technically a preview of the parent Resource (=true) or not (=false). Note that nothing can be implied from this element as to the conditions under which the preview can be made available.
+     *
+     * @param bool $isPreview
+     * @return self
+     */
+    public function setIsPreview($isPreview)
+    {
+        $this->isPreview = $isPreview;
+        return $this;
+    }
+
+    /**
+     * Gets as previewDetails
+     *
+     * A Composite containing details of a preview.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-previews/preview-resources
+     *
+     * @return \DedexBundle\Entity\Ern42\PreviewDetailsType
+     */
+    public function getPreviewDetails()
+    {
+        return $this->previewDetails;
+    }
+
+    /**
+     * Sets a new previewDetails
+     *
+     * A Composite containing details of a preview.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-previews/preview-resources
+     *
+     * @param \DedexBundle\Entity\Ern42\PreviewDetailsType $previewDetails
+     * @return self
+     */
+    public function setPreviewDetails(?\DedexBundle\Entity\Ern42\PreviewDetailsType $previewDetails = null)
+    {
+        $this->previewDetails = $previewDetails;
+        return $this;
+    }
+
+    /**
+     * Gets as file
+     *
+     * A Composite containing details of a File containing the SheetMusic that a DSP can obtain.
+     *
+     * @return \DedexBundle\Entity\Ern42\FileType
+     */
+    public function getFile()
+    {
+        return $this->file;
+    }
+
+    /**
+     * Sets a new file
+     *
+     * A Composite containing details of a File containing the SheetMusic that a DSP can obtain.
+     *
+     * @param \DedexBundle\Entity\Ern42\FileType $file
+     * @return self
+     */
+    public function setFile(?\DedexBundle\Entity\Ern42\FileType $file = null)
+    {
+        $this->file = $file;
+        return $this;
+    }
+
+    /**
+     * Gets as isProvidedInDelivery
+     *
+     * A Flag indicating whether a File containing the SheetMusic is a provided in a delivery (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getIsProvidedInDelivery()
+    {
+        return $this->isProvidedInDelivery;
+    }
+
+    /**
+     * Sets a new isProvidedInDelivery
+     *
+     * A Flag indicating whether a File containing the SheetMusic is a provided in a delivery (=true) or not (=false).
+     *
+     * @param bool $isProvidedInDelivery
+     * @return self
+     */
+    public function setIsProvidedInDelivery($isProvidedInDelivery)
+    {
+        $this->isProvidedInDelivery = $isProvidedInDelivery;
+        return $this;
+    }
+
+    /**
+     * Adds as fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\FingerprintType $fingerprint
+     */
+    public function addToFingerprint(\DedexBundle\Entity\Ern42\FingerprintType $fingerprint)
+    {
+        $this->fingerprint[] = $fingerprint;
+        return $this;
+    }
+
+    /**
+     * isset fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetFingerprint($index)
+    {
+        return isset($this->fingerprint[$index]);
+    }
+
+    /**
+     * unset fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetFingerprint($index)
+    {
+        unset($this->fingerprint[$index]);
+    }
+
+    /**
+     * Gets as fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @return \DedexBundle\Entity\Ern42\FingerprintType[]
+     */
+    public function getFingerprint()
+    {
+        return $this->fingerprint;
+    }
+
+    /**
+     * Sets a new fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @param \DedexBundle\Entity\Ern42\FingerprintType[] $fingerprint
+     * @return self
+     */
+    public function setFingerprint(?array $fingerprint = null)
+    {
+        $this->fingerprint = $fingerprint;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/TechnicalSoftwareDetailsType.php
+++ b/src/Entity/Ern42/TechnicalSoftwareDetailsType.php
@@ -1,0 +1,421 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing TechnicalSoftwareDetailsType
+ *
+ * A Composite containing technical details of a Software.
+ * XSD Type: TechnicalSoftwareDetails
+ */
+class TechnicalSoftwareDetailsType
+{
+    /**
+     * The Language and script for the Elements of the TechnicalSoftwareDetails as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * A Territory to which the TechnicalSoftwareDetails apply. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * The Identifier (specific to the Message) of the TechnicalSoftwareDetails within the Release which contains it. This is a LocalTechnicalResourceDetailsAnchor starting with the letter T.
+     *
+     * @var string $technicalResourceDetailsReference
+     */
+    private $technicalResourceDetailsReference = null;
+
+    /**
+     * A Composite containing details of a Type of OperatingSystem.
+     *
+     * @var \DedexBundle\Entity\Ern42\OperatingSystemTypeType $operatingSystemType
+     */
+    private $operatingSystemType = null;
+
+    /**
+     * The BitDepth of the File.
+     *
+     * @var int $bitDepth
+     */
+    private $bitDepth = null;
+
+    /**
+     * The Flag indicating whether the Software is technically a preview of the parent Resource (=true) or not (=false). Note that nothing can be implied from this element as to the conditions under which the preview can be made available.
+     *
+     * @var bool $isPreview
+     */
+    private $isPreview = null;
+
+    /**
+     * A Composite containing details of a preview.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-previews/preview-resources
+     *
+     * @var \DedexBundle\Entity\Ern42\PreviewDetailsType $previewDetails
+     */
+    private $previewDetails = null;
+
+    /**
+     * A Composite containing details of a File containing the Software that a DSP can obtain.
+     *
+     * @var \DedexBundle\Entity\Ern42\FileType $file
+     */
+    private $file = null;
+
+    /**
+     * A Flag indicating whether a File containing the Software is a provided in a delivery (=true) or not (=false).
+     *
+     * @var bool $isProvidedInDelivery
+     */
+    private $isProvidedInDelivery = null;
+
+    /**
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @var \DedexBundle\Entity\Ern42\FingerprintType[] $fingerprint
+     */
+    private $fingerprint = [
+        
+    ];
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the Elements of the TechnicalSoftwareDetails as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the Elements of the TechnicalSoftwareDetails as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the TechnicalSoftwareDetails apply. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the TechnicalSoftwareDetails apply. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+
+    /**
+     * Gets as technicalResourceDetailsReference
+     *
+     * The Identifier (specific to the Message) of the TechnicalSoftwareDetails within the Release which contains it. This is a LocalTechnicalResourceDetailsAnchor starting with the letter T.
+     *
+     * @return string
+     */
+    public function getTechnicalResourceDetailsReference()
+    {
+        return $this->technicalResourceDetailsReference;
+    }
+
+    /**
+     * Sets a new technicalResourceDetailsReference
+     *
+     * The Identifier (specific to the Message) of the TechnicalSoftwareDetails within the Release which contains it. This is a LocalTechnicalResourceDetailsAnchor starting with the letter T.
+     *
+     * @param string $technicalResourceDetailsReference
+     * @return self
+     */
+    public function setTechnicalResourceDetailsReference($technicalResourceDetailsReference)
+    {
+        $this->technicalResourceDetailsReference = $technicalResourceDetailsReference;
+        return $this;
+    }
+
+    /**
+     * Gets as operatingSystemType
+     *
+     * A Composite containing details of a Type of OperatingSystem.
+     *
+     * @return \DedexBundle\Entity\Ern42\OperatingSystemTypeType
+     */
+    public function getOperatingSystemType()
+    {
+        return $this->operatingSystemType;
+    }
+
+    /**
+     * Sets a new operatingSystemType
+     *
+     * A Composite containing details of a Type of OperatingSystem.
+     *
+     * @param \DedexBundle\Entity\Ern42\OperatingSystemTypeType $operatingSystemType
+     * @return self
+     */
+    public function setOperatingSystemType(?\DedexBundle\Entity\Ern42\OperatingSystemTypeType $operatingSystemType = null)
+    {
+        $this->operatingSystemType = $operatingSystemType;
+        return $this;
+    }
+
+    /**
+     * Gets as bitDepth
+     *
+     * The BitDepth of the File.
+     *
+     * @return int
+     */
+    public function getBitDepth()
+    {
+        return $this->bitDepth;
+    }
+
+    /**
+     * Sets a new bitDepth
+     *
+     * The BitDepth of the File.
+     *
+     * @param int $bitDepth
+     * @return self
+     */
+    public function setBitDepth($bitDepth)
+    {
+        $this->bitDepth = $bitDepth;
+        return $this;
+    }
+
+    /**
+     * Gets as isPreview
+     *
+     * The Flag indicating whether the Software is technically a preview of the parent Resource (=true) or not (=false). Note that nothing can be implied from this element as to the conditions under which the preview can be made available.
+     *
+     * @return bool
+     */
+    public function getIsPreview()
+    {
+        return $this->isPreview;
+    }
+
+    /**
+     * Sets a new isPreview
+     *
+     * The Flag indicating whether the Software is technically a preview of the parent Resource (=true) or not (=false). Note that nothing can be implied from this element as to the conditions under which the preview can be made available.
+     *
+     * @param bool $isPreview
+     * @return self
+     */
+    public function setIsPreview($isPreview)
+    {
+        $this->isPreview = $isPreview;
+        return $this;
+    }
+
+    /**
+     * Gets as previewDetails
+     *
+     * A Composite containing details of a preview.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-previews/preview-resources
+     *
+     * @return \DedexBundle\Entity\Ern42\PreviewDetailsType
+     */
+    public function getPreviewDetails()
+    {
+        return $this->previewDetails;
+    }
+
+    /**
+     * Sets a new previewDetails
+     *
+     * A Composite containing details of a preview.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-previews/preview-resources
+     *
+     * @param \DedexBundle\Entity\Ern42\PreviewDetailsType $previewDetails
+     * @return self
+     */
+    public function setPreviewDetails(?\DedexBundle\Entity\Ern42\PreviewDetailsType $previewDetails = null)
+    {
+        $this->previewDetails = $previewDetails;
+        return $this;
+    }
+
+    /**
+     * Gets as file
+     *
+     * A Composite containing details of a File containing the Software that a DSP can obtain.
+     *
+     * @return \DedexBundle\Entity\Ern42\FileType
+     */
+    public function getFile()
+    {
+        return $this->file;
+    }
+
+    /**
+     * Sets a new file
+     *
+     * A Composite containing details of a File containing the Software that a DSP can obtain.
+     *
+     * @param \DedexBundle\Entity\Ern42\FileType $file
+     * @return self
+     */
+    public function setFile(?\DedexBundle\Entity\Ern42\FileType $file = null)
+    {
+        $this->file = $file;
+        return $this;
+    }
+
+    /**
+     * Gets as isProvidedInDelivery
+     *
+     * A Flag indicating whether a File containing the Software is a provided in a delivery (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getIsProvidedInDelivery()
+    {
+        return $this->isProvidedInDelivery;
+    }
+
+    /**
+     * Sets a new isProvidedInDelivery
+     *
+     * A Flag indicating whether a File containing the Software is a provided in a delivery (=true) or not (=false).
+     *
+     * @param bool $isProvidedInDelivery
+     * @return self
+     */
+    public function setIsProvidedInDelivery($isProvidedInDelivery)
+    {
+        $this->isProvidedInDelivery = $isProvidedInDelivery;
+        return $this;
+    }
+
+    /**
+     * Adds as fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\FingerprintType $fingerprint
+     */
+    public function addToFingerprint(\DedexBundle\Entity\Ern42\FingerprintType $fingerprint)
+    {
+        $this->fingerprint[] = $fingerprint;
+        return $this;
+    }
+
+    /**
+     * isset fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetFingerprint($index)
+    {
+        return isset($this->fingerprint[$index]);
+    }
+
+    /**
+     * unset fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetFingerprint($index)
+    {
+        unset($this->fingerprint[$index]);
+    }
+
+    /**
+     * Gets as fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @return \DedexBundle\Entity\Ern42\FingerprintType[]
+     */
+    public function getFingerprint()
+    {
+        return $this->fingerprint;
+    }
+
+    /**
+     * Sets a new fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @param \DedexBundle\Entity\Ern42\FingerprintType[] $fingerprint
+     * @return self
+     */
+    public function setFingerprint(?array $fingerprint = null)
+    {
+        $this->fingerprint = $fingerprint;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/TechnicalSoundRecordingDetailsType.php
+++ b/src/Entity/Ern42/TechnicalSoundRecordingDetailsType.php
@@ -1,0 +1,715 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing TechnicalSoundRecordingDetailsType
+ *
+ * A Composite containing technical details of a SoundRecording.
+ * XSD Type: TechnicalSoundRecordingDetails
+ */
+class TechnicalSoundRecordingDetailsType
+{
+    /**
+     * The Language and script for the Elements of the TechnicalSoundRecordingDetails as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * A Territory to which the TechnicalSoundRecordingDetails apply. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * The Identifier (specific to the Message) of the TechnicalSoundRecordingDetails within the Release which contains it. This is a LocalTechnicalResourceDetailsAnchor starting with the letter T.
+     *
+     * @var string $technicalResourceDetailsReference
+     */
+    private $technicalResourceDetailsReference = null;
+
+    /**
+     * A Composite containing details of an identifier of the encoding. The default is that all encodings for a SoundRecording share a common identifier (as provided on the SoundRecording composite) and that, looking at the ISRC standard for instance, there should not be a different identifier for different encodings (unless there is a substantial difference). However, reality indicates that different identifiers have been allocated and therefore should be communicable.
+     *
+     * @var \DedexBundle\Entity\Ern42\SoundRecordingIdType $encodingId
+     */
+    private $encodingId = null;
+
+    /**
+     * A Composite containing details of a Type of AudioCodec.
+     *
+     * @var \DedexBundle\Entity\Ern42\AudioCodecTypeType $audioCodecType
+     */
+    private $audioCodecType = null;
+
+    /**
+     * A Composite containing the BitRate for the audio data and a UnitOfMeasure (the default is kbps).
+     *
+     * @var \DedexBundle\Entity\Ern42\BitRateType $bitRate
+     */
+    private $bitRate = null;
+
+    /**
+     * A Composite containing the BitRate for the audio data recording and a UnitOfMeasure (the default is kbps).
+     *
+     * @var \DedexBundle\Entity\Ern42\BitRateType $originalBitRate
+     */
+    private $originalBitRate = null;
+
+    /**
+     * A number of audio channels.
+     *
+     * @var int $numberOfChannels
+     */
+    private $numberOfChannels = null;
+
+    /**
+     * A Composite containing the sampling rate of the SoundRecording and a UnitOfMeasure (the default is Hz).
+     *
+     * @var \DedexBundle\Entity\Ern42\SamplingRateType $samplingRate
+     */
+    private $samplingRate = null;
+
+    /**
+     * A Composite containing the sampling rate of the SoundRecording during the recording, and a UnitOfMeasure (the default is Hz).
+     *
+     * @var \DedexBundle\Entity\Ern42\SamplingRateType $originalSamplingRate
+     */
+    private $originalSamplingRate = null;
+
+    /**
+     * An amount of audio data in a sample.
+     *
+     * @var int $bitsPerSample
+     */
+    private $bitsPerSample = null;
+
+    /**
+     * The Duration of the instantiation of the SoundRecording if this differs from the Duration provided for the SoundRecording itself (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S). This element must only be used if and when there are no royalty reporting implications on this change in duration and when the specific technical instantiation is a clip taken from a technical instantiation representing the whole SoundRecording.
+     *
+     * @var \DateInterval $duration
+     */
+    private $duration = null;
+
+    /**
+     * The BitDepth of the File.
+     *
+     * @var int $bitDepth
+     */
+    private $bitDepth = null;
+
+    /**
+     * The Flag indicating whether the SoundRecording is technically a preview of the parent Resource (=true) or not (=false). Note that nothing can be implied from this element as to the conditions under which the preview can be made available.
+     *
+     * @var bool $isPreview
+     */
+    private $isPreview = null;
+
+    /**
+     * A Composite containing details of a preview.
+     *
+     * @var \DedexBundle\Entity\Ern42\SoundRecordingPreviewDetailsType $previewDetails
+     */
+    private $previewDetails = null;
+
+    /**
+     * A Composite containing details of a File containing the SoundRecording that a DSP can obtain.
+     *
+     * @var \DedexBundle\Entity\Ern42\FileType $file
+     */
+    private $file = null;
+
+    /**
+     * A Flag indicating whether a File containing the SoundRecording is a provided in a delivery (=true) or not (=false).
+     *
+     * @var bool $isProvidedInDelivery
+     */
+    private $isProvidedInDelivery = null;
+
+    /**
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @var \DedexBundle\Entity\Ern42\FingerprintType[] $fingerprint
+     */
+    private $fingerprint = [
+        
+    ];
+
+    /**
+     * A textual Description of the encoding.
+     *
+     * @var string $encodingDescription
+     */
+    private $encodingDescription = null;
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the Elements of the TechnicalSoundRecordingDetails as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the Elements of the TechnicalSoundRecordingDetails as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the TechnicalSoundRecordingDetails apply. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the TechnicalSoundRecordingDetails apply. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+
+    /**
+     * Gets as technicalResourceDetailsReference
+     *
+     * The Identifier (specific to the Message) of the TechnicalSoundRecordingDetails within the Release which contains it. This is a LocalTechnicalResourceDetailsAnchor starting with the letter T.
+     *
+     * @return string
+     */
+    public function getTechnicalResourceDetailsReference()
+    {
+        return $this->technicalResourceDetailsReference;
+    }
+
+    /**
+     * Sets a new technicalResourceDetailsReference
+     *
+     * The Identifier (specific to the Message) of the TechnicalSoundRecordingDetails within the Release which contains it. This is a LocalTechnicalResourceDetailsAnchor starting with the letter T.
+     *
+     * @param string $technicalResourceDetailsReference
+     * @return self
+     */
+    public function setTechnicalResourceDetailsReference($technicalResourceDetailsReference)
+    {
+        $this->technicalResourceDetailsReference = $technicalResourceDetailsReference;
+        return $this;
+    }
+
+    /**
+     * Gets as encodingId
+     *
+     * A Composite containing details of an identifier of the encoding. The default is that all encodings for a SoundRecording share a common identifier (as provided on the SoundRecording composite) and that, looking at the ISRC standard for instance, there should not be a different identifier for different encodings (unless there is a substantial difference). However, reality indicates that different identifiers have been allocated and therefore should be communicable.
+     *
+     * @return \DedexBundle\Entity\Ern42\SoundRecordingIdType
+     */
+    public function getEncodingId()
+    {
+        return $this->encodingId;
+    }
+
+    /**
+     * Sets a new encodingId
+     *
+     * A Composite containing details of an identifier of the encoding. The default is that all encodings for a SoundRecording share a common identifier (as provided on the SoundRecording composite) and that, looking at the ISRC standard for instance, there should not be a different identifier for different encodings (unless there is a substantial difference). However, reality indicates that different identifiers have been allocated and therefore should be communicable.
+     *
+     * @param \DedexBundle\Entity\Ern42\SoundRecordingIdType $encodingId
+     * @return self
+     */
+    public function setEncodingId(?\DedexBundle\Entity\Ern42\SoundRecordingIdType $encodingId = null)
+    {
+        $this->encodingId = $encodingId;
+        return $this;
+    }
+
+    /**
+     * Gets as audioCodecType
+     *
+     * A Composite containing details of a Type of AudioCodec.
+     *
+     * @return \DedexBundle\Entity\Ern42\AudioCodecTypeType
+     */
+    public function getAudioCodecType()
+    {
+        return $this->audioCodecType;
+    }
+
+    /**
+     * Sets a new audioCodecType
+     *
+     * A Composite containing details of a Type of AudioCodec.
+     *
+     * @param \DedexBundle\Entity\Ern42\AudioCodecTypeType $audioCodecType
+     * @return self
+     */
+    public function setAudioCodecType(?\DedexBundle\Entity\Ern42\AudioCodecTypeType $audioCodecType = null)
+    {
+        $this->audioCodecType = $audioCodecType;
+        return $this;
+    }
+
+    /**
+     * Gets as bitRate
+     *
+     * A Composite containing the BitRate for the audio data and a UnitOfMeasure (the default is kbps).
+     *
+     * @return \DedexBundle\Entity\Ern42\BitRateType
+     */
+    public function getBitRate()
+    {
+        return $this->bitRate;
+    }
+
+    /**
+     * Sets a new bitRate
+     *
+     * A Composite containing the BitRate for the audio data and a UnitOfMeasure (the default is kbps).
+     *
+     * @param \DedexBundle\Entity\Ern42\BitRateType $bitRate
+     * @return self
+     */
+    public function setBitRate(?\DedexBundle\Entity\Ern42\BitRateType $bitRate = null)
+    {
+        $this->bitRate = $bitRate;
+        return $this;
+    }
+
+    /**
+     * Gets as originalBitRate
+     *
+     * A Composite containing the BitRate for the audio data recording and a UnitOfMeasure (the default is kbps).
+     *
+     * @return \DedexBundle\Entity\Ern42\BitRateType
+     */
+    public function getOriginalBitRate()
+    {
+        return $this->originalBitRate;
+    }
+
+    /**
+     * Sets a new originalBitRate
+     *
+     * A Composite containing the BitRate for the audio data recording and a UnitOfMeasure (the default is kbps).
+     *
+     * @param \DedexBundle\Entity\Ern42\BitRateType $originalBitRate
+     * @return self
+     */
+    public function setOriginalBitRate(?\DedexBundle\Entity\Ern42\BitRateType $originalBitRate = null)
+    {
+        $this->originalBitRate = $originalBitRate;
+        return $this;
+    }
+
+    /**
+     * Gets as numberOfChannels
+     *
+     * A number of audio channels.
+     *
+     * @return int
+     */
+    public function getNumberOfChannels()
+    {
+        return $this->numberOfChannels;
+    }
+
+    /**
+     * Sets a new numberOfChannels
+     *
+     * A number of audio channels.
+     *
+     * @param int $numberOfChannels
+     * @return self
+     */
+    public function setNumberOfChannels($numberOfChannels)
+    {
+        $this->numberOfChannels = $numberOfChannels;
+        return $this;
+    }
+
+    /**
+     * Gets as samplingRate
+     *
+     * A Composite containing the sampling rate of the SoundRecording and a UnitOfMeasure (the default is Hz).
+     *
+     * @return \DedexBundle\Entity\Ern42\SamplingRateType
+     */
+    public function getSamplingRate()
+    {
+        return $this->samplingRate;
+    }
+
+    /**
+     * Sets a new samplingRate
+     *
+     * A Composite containing the sampling rate of the SoundRecording and a UnitOfMeasure (the default is Hz).
+     *
+     * @param \DedexBundle\Entity\Ern42\SamplingRateType $samplingRate
+     * @return self
+     */
+    public function setSamplingRate(?\DedexBundle\Entity\Ern42\SamplingRateType $samplingRate = null)
+    {
+        $this->samplingRate = $samplingRate;
+        return $this;
+    }
+
+    /**
+     * Gets as originalSamplingRate
+     *
+     * A Composite containing the sampling rate of the SoundRecording during the recording, and a UnitOfMeasure (the default is Hz).
+     *
+     * @return \DedexBundle\Entity\Ern42\SamplingRateType
+     */
+    public function getOriginalSamplingRate()
+    {
+        return $this->originalSamplingRate;
+    }
+
+    /**
+     * Sets a new originalSamplingRate
+     *
+     * A Composite containing the sampling rate of the SoundRecording during the recording, and a UnitOfMeasure (the default is Hz).
+     *
+     * @param \DedexBundle\Entity\Ern42\SamplingRateType $originalSamplingRate
+     * @return self
+     */
+    public function setOriginalSamplingRate(?\DedexBundle\Entity\Ern42\SamplingRateType $originalSamplingRate = null)
+    {
+        $this->originalSamplingRate = $originalSamplingRate;
+        return $this;
+    }
+
+    /**
+     * Gets as bitsPerSample
+     *
+     * An amount of audio data in a sample.
+     *
+     * @return int
+     */
+    public function getBitsPerSample()
+    {
+        return $this->bitsPerSample;
+    }
+
+    /**
+     * Sets a new bitsPerSample
+     *
+     * An amount of audio data in a sample.
+     *
+     * @param int $bitsPerSample
+     * @return self
+     */
+    public function setBitsPerSample($bitsPerSample)
+    {
+        $this->bitsPerSample = $bitsPerSample;
+        return $this;
+    }
+
+    /**
+     * Gets as duration
+     *
+     * The Duration of the instantiation of the SoundRecording if this differs from the Duration provided for the SoundRecording itself (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S). This element must only be used if and when there are no royalty reporting implications on this change in duration and when the specific technical instantiation is a clip taken from a technical instantiation representing the whole SoundRecording.
+     *
+     * @return \DateInterval
+     */
+    public function getDuration()
+    {
+        return $this->duration;
+    }
+
+    /**
+     * Sets a new duration
+     *
+     * The Duration of the instantiation of the SoundRecording if this differs from the Duration provided for the SoundRecording itself (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S). This element must only be used if and when there are no royalty reporting implications on this change in duration and when the specific technical instantiation is a clip taken from a technical instantiation representing the whole SoundRecording.
+     *
+     * @param \DateInterval $duration
+     * @return self
+     */
+    public function setDuration(?\DateInterval $duration = null)
+    {
+        $this->duration = $duration;
+        return $this;
+    }
+
+    /**
+     * Gets as bitDepth
+     *
+     * The BitDepth of the File.
+     *
+     * @return int
+     */
+    public function getBitDepth()
+    {
+        return $this->bitDepth;
+    }
+
+    /**
+     * Sets a new bitDepth
+     *
+     * The BitDepth of the File.
+     *
+     * @param int $bitDepth
+     * @return self
+     */
+    public function setBitDepth($bitDepth)
+    {
+        $this->bitDepth = $bitDepth;
+        return $this;
+    }
+
+    /**
+     * Gets as isPreview
+     *
+     * The Flag indicating whether the SoundRecording is technically a preview of the parent Resource (=true) or not (=false). Note that nothing can be implied from this element as to the conditions under which the preview can be made available.
+     *
+     * @return bool
+     */
+    public function getIsPreview()
+    {
+        return $this->isPreview;
+    }
+
+    /**
+     * Sets a new isPreview
+     *
+     * The Flag indicating whether the SoundRecording is technically a preview of the parent Resource (=true) or not (=false). Note that nothing can be implied from this element as to the conditions under which the preview can be made available.
+     *
+     * @param bool $isPreview
+     * @return self
+     */
+    public function setIsPreview($isPreview)
+    {
+        $this->isPreview = $isPreview;
+        return $this;
+    }
+
+    /**
+     * Gets as previewDetails
+     *
+     * A Composite containing details of a preview.
+     *
+     * @return \DedexBundle\Entity\Ern42\SoundRecordingPreviewDetailsType
+     */
+    public function getPreviewDetails()
+    {
+        return $this->previewDetails;
+    }
+
+    /**
+     * Sets a new previewDetails
+     *
+     * A Composite containing details of a preview.
+     *
+     * @param \DedexBundle\Entity\Ern42\SoundRecordingPreviewDetailsType $previewDetails
+     * @return self
+     */
+    public function setPreviewDetails(?\DedexBundle\Entity\Ern42\SoundRecordingPreviewDetailsType $previewDetails = null)
+    {
+        $this->previewDetails = $previewDetails;
+        return $this;
+    }
+
+    /**
+     * Gets as file
+     *
+     * A Composite containing details of a File containing the SoundRecording that a DSP can obtain.
+     *
+     * @return \DedexBundle\Entity\Ern42\FileType
+     */
+    public function getFile()
+    {
+        return $this->file;
+    }
+
+    /**
+     * Sets a new file
+     *
+     * A Composite containing details of a File containing the SoundRecording that a DSP can obtain.
+     *
+     * @param \DedexBundle\Entity\Ern42\FileType $file
+     * @return self
+     */
+    public function setFile(?\DedexBundle\Entity\Ern42\FileType $file = null)
+    {
+        $this->file = $file;
+        return $this;
+    }
+
+    /**
+     * Gets as isProvidedInDelivery
+     *
+     * A Flag indicating whether a File containing the SoundRecording is a provided in a delivery (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getIsProvidedInDelivery()
+    {
+        return $this->isProvidedInDelivery;
+    }
+
+    /**
+     * Sets a new isProvidedInDelivery
+     *
+     * A Flag indicating whether a File containing the SoundRecording is a provided in a delivery (=true) or not (=false).
+     *
+     * @param bool $isProvidedInDelivery
+     * @return self
+     */
+    public function setIsProvidedInDelivery($isProvidedInDelivery)
+    {
+        $this->isProvidedInDelivery = $isProvidedInDelivery;
+        return $this;
+    }
+
+    /**
+     * Adds as fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\FingerprintType $fingerprint
+     */
+    public function addToFingerprint(\DedexBundle\Entity\Ern42\FingerprintType $fingerprint)
+    {
+        $this->fingerprint[] = $fingerprint;
+        return $this;
+    }
+
+    /**
+     * isset fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetFingerprint($index)
+    {
+        return isset($this->fingerprint[$index]);
+    }
+
+    /**
+     * unset fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetFingerprint($index)
+    {
+        unset($this->fingerprint[$index]);
+    }
+
+    /**
+     * Gets as fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @return \DedexBundle\Entity\Ern42\FingerprintType[]
+     */
+    public function getFingerprint()
+    {
+        return $this->fingerprint;
+    }
+
+    /**
+     * Sets a new fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @param \DedexBundle\Entity\Ern42\FingerprintType[] $fingerprint
+     * @return self
+     */
+    public function setFingerprint(?array $fingerprint = null)
+    {
+        $this->fingerprint = $fingerprint;
+        return $this;
+    }
+
+    /**
+     * Gets as encodingDescription
+     *
+     * A textual Description of the encoding.
+     *
+     * @return string
+     */
+    public function getEncodingDescription()
+    {
+        return $this->encodingDescription;
+    }
+
+    /**
+     * Sets a new encodingDescription
+     *
+     * A textual Description of the encoding.
+     *
+     * @param string $encodingDescription
+     * @return self
+     */
+    public function setEncodingDescription($encodingDescription)
+    {
+        $this->encodingDescription = $encodingDescription;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/TechnicalTextDetailsType.php
+++ b/src/Entity/Ern42/TechnicalTextDetailsType.php
@@ -1,0 +1,421 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing TechnicalTextDetailsType
+ *
+ * A Composite containing technical details of a Text.
+ * XSD Type: TechnicalTextDetails
+ */
+class TechnicalTextDetailsType
+{
+    /**
+     * The Language and script for the Elements of the TechnicalTextDetails as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * A Territory to which the TechnicalTextDetails apply. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * The Identifier (specific to the Message) of the TechnicalTextDetails within the Release which contains it. This is a LocalTechnicalResourceDetailsAnchor starting with the letter T.
+     *
+     * @var string $technicalResourceDetailsReference
+     */
+    private $technicalResourceDetailsReference = null;
+
+    /**
+     * A Composite containing details of a Type of TextCodec.
+     *
+     * @var \DedexBundle\Entity\Ern42\TextCodecTypeType $textCodecType
+     */
+    private $textCodecType = null;
+
+    /**
+     * The BitDepth of the File.
+     *
+     * @var int $bitDepth
+     */
+    private $bitDepth = null;
+
+    /**
+     * The Flag indicating whether the Text is technically a preview of the parent Resource (=true) or not (=false). Note that nothing can be implied from this element as to the conditions under which the preview can be made available.
+     *
+     * @var bool $isPreview
+     */
+    private $isPreview = null;
+
+    /**
+     * A Composite containing details of a preview.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-previews/preview-resources
+     *
+     * @var \DedexBundle\Entity\Ern42\PreviewDetailsType $previewDetails
+     */
+    private $previewDetails = null;
+
+    /**
+     * A Composite containing details of a File containing the Text that a DSP can obtain.
+     *
+     * @var \DedexBundle\Entity\Ern42\FileType $file
+     */
+    private $file = null;
+
+    /**
+     * A Flag indicating whether a File containing the Text is a provided in a delivery (=true) or not (=false).
+     *
+     * @var bool $isProvidedInDelivery
+     */
+    private $isProvidedInDelivery = null;
+
+    /**
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @var \DedexBundle\Entity\Ern42\FingerprintType[] $fingerprint
+     */
+    private $fingerprint = [
+        
+    ];
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the Elements of the TechnicalTextDetails as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the Elements of the TechnicalTextDetails as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the TechnicalTextDetails apply. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the TechnicalTextDetails apply. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+
+    /**
+     * Gets as technicalResourceDetailsReference
+     *
+     * The Identifier (specific to the Message) of the TechnicalTextDetails within the Release which contains it. This is a LocalTechnicalResourceDetailsAnchor starting with the letter T.
+     *
+     * @return string
+     */
+    public function getTechnicalResourceDetailsReference()
+    {
+        return $this->technicalResourceDetailsReference;
+    }
+
+    /**
+     * Sets a new technicalResourceDetailsReference
+     *
+     * The Identifier (specific to the Message) of the TechnicalTextDetails within the Release which contains it. This is a LocalTechnicalResourceDetailsAnchor starting with the letter T.
+     *
+     * @param string $technicalResourceDetailsReference
+     * @return self
+     */
+    public function setTechnicalResourceDetailsReference($technicalResourceDetailsReference)
+    {
+        $this->technicalResourceDetailsReference = $technicalResourceDetailsReference;
+        return $this;
+    }
+
+    /**
+     * Gets as textCodecType
+     *
+     * A Composite containing details of a Type of TextCodec.
+     *
+     * @return \DedexBundle\Entity\Ern42\TextCodecTypeType
+     */
+    public function getTextCodecType()
+    {
+        return $this->textCodecType;
+    }
+
+    /**
+     * Sets a new textCodecType
+     *
+     * A Composite containing details of a Type of TextCodec.
+     *
+     * @param \DedexBundle\Entity\Ern42\TextCodecTypeType $textCodecType
+     * @return self
+     */
+    public function setTextCodecType(?\DedexBundle\Entity\Ern42\TextCodecTypeType $textCodecType = null)
+    {
+        $this->textCodecType = $textCodecType;
+        return $this;
+    }
+
+    /**
+     * Gets as bitDepth
+     *
+     * The BitDepth of the File.
+     *
+     * @return int
+     */
+    public function getBitDepth()
+    {
+        return $this->bitDepth;
+    }
+
+    /**
+     * Sets a new bitDepth
+     *
+     * The BitDepth of the File.
+     *
+     * @param int $bitDepth
+     * @return self
+     */
+    public function setBitDepth($bitDepth)
+    {
+        $this->bitDepth = $bitDepth;
+        return $this;
+    }
+
+    /**
+     * Gets as isPreview
+     *
+     * The Flag indicating whether the Text is technically a preview of the parent Resource (=true) or not (=false). Note that nothing can be implied from this element as to the conditions under which the preview can be made available.
+     *
+     * @return bool
+     */
+    public function getIsPreview()
+    {
+        return $this->isPreview;
+    }
+
+    /**
+     * Sets a new isPreview
+     *
+     * The Flag indicating whether the Text is technically a preview of the parent Resource (=true) or not (=false). Note that nothing can be implied from this element as to the conditions under which the preview can be made available.
+     *
+     * @param bool $isPreview
+     * @return self
+     */
+    public function setIsPreview($isPreview)
+    {
+        $this->isPreview = $isPreview;
+        return $this;
+    }
+
+    /**
+     * Gets as previewDetails
+     *
+     * A Composite containing details of a preview.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-previews/preview-resources
+     *
+     * @return \DedexBundle\Entity\Ern42\PreviewDetailsType
+     */
+    public function getPreviewDetails()
+    {
+        return $this->previewDetails;
+    }
+
+    /**
+     * Sets a new previewDetails
+     *
+     * A Composite containing details of a preview.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-previews/preview-resources
+     *
+     * @param \DedexBundle\Entity\Ern42\PreviewDetailsType $previewDetails
+     * @return self
+     */
+    public function setPreviewDetails(?\DedexBundle\Entity\Ern42\PreviewDetailsType $previewDetails = null)
+    {
+        $this->previewDetails = $previewDetails;
+        return $this;
+    }
+
+    /**
+     * Gets as file
+     *
+     * A Composite containing details of a File containing the Text that a DSP can obtain.
+     *
+     * @return \DedexBundle\Entity\Ern42\FileType
+     */
+    public function getFile()
+    {
+        return $this->file;
+    }
+
+    /**
+     * Sets a new file
+     *
+     * A Composite containing details of a File containing the Text that a DSP can obtain.
+     *
+     * @param \DedexBundle\Entity\Ern42\FileType $file
+     * @return self
+     */
+    public function setFile(?\DedexBundle\Entity\Ern42\FileType $file = null)
+    {
+        $this->file = $file;
+        return $this;
+    }
+
+    /**
+     * Gets as isProvidedInDelivery
+     *
+     * A Flag indicating whether a File containing the Text is a provided in a delivery (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getIsProvidedInDelivery()
+    {
+        return $this->isProvidedInDelivery;
+    }
+
+    /**
+     * Sets a new isProvidedInDelivery
+     *
+     * A Flag indicating whether a File containing the Text is a provided in a delivery (=true) or not (=false).
+     *
+     * @param bool $isProvidedInDelivery
+     * @return self
+     */
+    public function setIsProvidedInDelivery($isProvidedInDelivery)
+    {
+        $this->isProvidedInDelivery = $isProvidedInDelivery;
+        return $this;
+    }
+
+    /**
+     * Adds as fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\FingerprintType $fingerprint
+     */
+    public function addToFingerprint(\DedexBundle\Entity\Ern42\FingerprintType $fingerprint)
+    {
+        $this->fingerprint[] = $fingerprint;
+        return $this;
+    }
+
+    /**
+     * isset fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetFingerprint($index)
+    {
+        return isset($this->fingerprint[$index]);
+    }
+
+    /**
+     * unset fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetFingerprint($index)
+    {
+        unset($this->fingerprint[$index]);
+    }
+
+    /**
+     * Gets as fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @return \DedexBundle\Entity\Ern42\FingerprintType[]
+     */
+    public function getFingerprint()
+    {
+        return $this->fingerprint;
+    }
+
+    /**
+     * Sets a new fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @param \DedexBundle\Entity\Ern42\FingerprintType[] $fingerprint
+     * @return self
+     */
+    public function setFingerprint(?array $fingerprint = null)
+    {
+        $this->fingerprint = $fingerprint;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/TechnicalVideoDetailsType.php
+++ b/src/Entity/Ern42/TechnicalVideoDetailsType.php
@@ -1,0 +1,1012 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing TechnicalVideoDetailsType
+ *
+ * A Composite containing technical details of a Video.
+ * XSD Type: TechnicalVideoDetails
+ */
+class TechnicalVideoDetailsType
+{
+    /**
+     * The Language and script for the Elements of the TechnicalSoundRecordingDetails as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * A Territory to which the TechnicalVideoDetails apply. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * The Identifier (specific to the Message) of the TechnicalVideoDetails within the Release which contains it. This is a LocalTechnicalResourceDetailsAnchor starting with the letter T.
+     *
+     * @var string $technicalResourceDetailsReference
+     */
+    private $technicalResourceDetailsReference = null;
+
+    /**
+     * A Composite containing details of an identifier of the encoding. The default is that all encodings for a Video share a common identifier (as provided on the Video composite) and that, looking at the ISRC standard for instance, there should not be a different identifier for different encodings (unless there is a substantial difference). However, reality indicates that different identifiers have been allocated and therefore should be communicable.
+     *
+     * @var \DedexBundle\Entity\Ern42\VideoIdType $encodingId
+     */
+    private $encodingId = null;
+
+    /**
+     * A Composite containing the overall BitRate and a UnitOfMeasure (the default is kbps).
+     *
+     * @var \DedexBundle\Entity\Ern42\BitRateType $overallBitRate
+     */
+    private $overallBitRate = null;
+
+    /**
+     * A Composite containing details of a ContainerFormat.
+     *
+     * @var \DedexBundle\Entity\Ern42\ContainerFormatType $containerFormat
+     */
+    private $containerFormat = null;
+
+    /**
+     * A Composite containing details of a Type of VideoCodec.
+     *
+     * @var \DedexBundle\Entity\Ern42\VideoCodecTypeType $videoCodecType
+     */
+    private $videoCodecType = null;
+
+    /**
+     * A Composite containing the BitRate for the video data and a UnitOfMeasure (the default is kbps).
+     *
+     * @var \DedexBundle\Entity\Ern42\BitRateType $videoBitRate
+     */
+    private $videoBitRate = null;
+
+    /**
+     * A Composite containing the Rate for a number of frames shown in the Video in a specific Period of Time and a UnitOfMeasure (the default is Hz, interlaced).
+     *
+     * @var \DedexBundle\Entity\Ern42\FrameRateType $frameRate
+     */
+    private $frameRate = null;
+
+    /**
+     * A Composite containing the vertical Extent of an Image of the Video and a UnitOfMeasure (the default is Pixels).
+     *
+     * @var \DedexBundle\Entity\Ern42\ExtentType $imageHeight
+     */
+    private $imageHeight = null;
+
+    /**
+     * A Composite containing the horizontal Extent of an Image of the Video and a UnitOfMeasure (the default is Pixels).
+     *
+     * @var \DedexBundle\Entity\Ern42\ExtentType $imageWidth
+     */
+    private $imageWidth = null;
+
+    /**
+     * A Composite containing the ratio formed by dividing the ImageHeight by the ImageWidth.
+     *
+     * @var \DedexBundle\Entity\Ern42\AspectRatioType $aspectRatio
+     */
+    private $aspectRatio = null;
+
+    /**
+     * A Composite containing details of the core part of the Video.
+     *
+     * @var \DedexBundle\Entity\Ern42\CoreAreaType $coreArea
+     */
+    private $coreArea = null;
+
+    /**
+     * An amount of data determining the color of a pixel of an Image of the Video (given in bits per pixel).
+     *
+     * @var int $colorDepth
+     */
+    private $colorDepth = null;
+
+    /**
+     * A Type of resolution (or definition) in which the Video is provided.
+     *
+     * @var \DedexBundle\Entity\Ern42\VideoDefinitionTypeType $videoDefinitionType
+     */
+    private $videoDefinitionType = null;
+
+    /**
+     * A Composite containing details of a Type of AudioCodec.
+     *
+     * @var \DedexBundle\Entity\Ern42\AudioCodecTypeType $audioCodecType
+     */
+    private $audioCodecType = null;
+
+    /**
+     * A Composite containing the BitRate for the audio data and a UnitOfMeasure (the default is kbps).
+     *
+     * @var \DedexBundle\Entity\Ern42\BitRateType $audioBitRate
+     */
+    private $audioBitRate = null;
+
+    /**
+     * A number of audio channels.
+     *
+     * @var int $numberOfAudioChannels
+     */
+    private $numberOfAudioChannels = null;
+
+    /**
+     * A Composite containing the SamplingRate for the audio data and a UnitOfMeasure (the default is Hz).
+     *
+     * @var \DedexBundle\Entity\Ern42\SamplingRateType $audioSamplingRate
+     */
+    private $audioSamplingRate = null;
+
+    /**
+     * An amount of audio data in a sample.
+     *
+     * @var int $audioBitsPerSample
+     */
+    private $audioBitsPerSample = null;
+
+    /**
+     * The Duration of the instantiation of the Video if this differs from the Duration provided for the Video itself (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S). This element must only be used if and when there are no royalty reporting implications on this change in duration and when the specific technical instantiation is a clip taken from a technical instantiation representing the whole Video.
+     *
+     * @var \DateInterval $duration
+     */
+    private $duration = null;
+
+    /**
+     * The BitDepth of the File.
+     *
+     * @var int $bitDepth
+     */
+    private $bitDepth = null;
+
+    /**
+     * The Flag indicating whether the Video is technically a preview of the parent Resource (=true) or not (=false). Note that nothing can be implied from this element as to the conditions under which the preview can be made available.
+     *
+     * @var bool $isPreview
+     */
+    private $isPreview = null;
+
+    /**
+     * A Composite containing details of a preview.
+     *
+     * @var \DedexBundle\Entity\Ern42\SoundRecordingPreviewDetailsType $previewDetails
+     */
+    private $previewDetails = null;
+
+    /**
+     * A Composite containing details of a File containing the Video that a DSP can obtain.
+     *
+     * @var \DedexBundle\Entity\Ern42\FileType $file
+     */
+    private $file = null;
+
+    /**
+     * A Flag indicating whether a File containing the Video is a provided in a delivery (=true) or not (=false).
+     *
+     * @var bool $isProvidedInDelivery
+     */
+    private $isProvidedInDelivery = null;
+
+    /**
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @var \DedexBundle\Entity\Ern42\FingerprintType[] $fingerprint
+     */
+    private $fingerprint = [
+        
+    ];
+
+    /**
+     * A textual Description of the encoding.
+     *
+     * @var string $encodingDescription
+     */
+    private $encodingDescription = null;
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the Elements of the TechnicalSoundRecordingDetails as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the Elements of the TechnicalSoundRecordingDetails as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the TechnicalVideoDetails apply. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the TechnicalVideoDetails apply. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+
+    /**
+     * Gets as technicalResourceDetailsReference
+     *
+     * The Identifier (specific to the Message) of the TechnicalVideoDetails within the Release which contains it. This is a LocalTechnicalResourceDetailsAnchor starting with the letter T.
+     *
+     * @return string
+     */
+    public function getTechnicalResourceDetailsReference()
+    {
+        return $this->technicalResourceDetailsReference;
+    }
+
+    /**
+     * Sets a new technicalResourceDetailsReference
+     *
+     * The Identifier (specific to the Message) of the TechnicalVideoDetails within the Release which contains it. This is a LocalTechnicalResourceDetailsAnchor starting with the letter T.
+     *
+     * @param string $technicalResourceDetailsReference
+     * @return self
+     */
+    public function setTechnicalResourceDetailsReference($technicalResourceDetailsReference)
+    {
+        $this->technicalResourceDetailsReference = $technicalResourceDetailsReference;
+        return $this;
+    }
+
+    /**
+     * Gets as encodingId
+     *
+     * A Composite containing details of an identifier of the encoding. The default is that all encodings for a Video share a common identifier (as provided on the Video composite) and that, looking at the ISRC standard for instance, there should not be a different identifier for different encodings (unless there is a substantial difference). However, reality indicates that different identifiers have been allocated and therefore should be communicable.
+     *
+     * @return \DedexBundle\Entity\Ern42\VideoIdType
+     */
+    public function getEncodingId()
+    {
+        return $this->encodingId;
+    }
+
+    /**
+     * Sets a new encodingId
+     *
+     * A Composite containing details of an identifier of the encoding. The default is that all encodings for a Video share a common identifier (as provided on the Video composite) and that, looking at the ISRC standard for instance, there should not be a different identifier for different encodings (unless there is a substantial difference). However, reality indicates that different identifiers have been allocated and therefore should be communicable.
+     *
+     * @param \DedexBundle\Entity\Ern42\VideoIdType $encodingId
+     * @return self
+     */
+    public function setEncodingId(?\DedexBundle\Entity\Ern42\VideoIdType $encodingId = null)
+    {
+        $this->encodingId = $encodingId;
+        return $this;
+    }
+
+    /**
+     * Gets as overallBitRate
+     *
+     * A Composite containing the overall BitRate and a UnitOfMeasure (the default is kbps).
+     *
+     * @return \DedexBundle\Entity\Ern42\BitRateType
+     */
+    public function getOverallBitRate()
+    {
+        return $this->overallBitRate;
+    }
+
+    /**
+     * Sets a new overallBitRate
+     *
+     * A Composite containing the overall BitRate and a UnitOfMeasure (the default is kbps).
+     *
+     * @param \DedexBundle\Entity\Ern42\BitRateType $overallBitRate
+     * @return self
+     */
+    public function setOverallBitRate(?\DedexBundle\Entity\Ern42\BitRateType $overallBitRate = null)
+    {
+        $this->overallBitRate = $overallBitRate;
+        return $this;
+    }
+
+    /**
+     * Gets as containerFormat
+     *
+     * A Composite containing details of a ContainerFormat.
+     *
+     * @return \DedexBundle\Entity\Ern42\ContainerFormatType
+     */
+    public function getContainerFormat()
+    {
+        return $this->containerFormat;
+    }
+
+    /**
+     * Sets a new containerFormat
+     *
+     * A Composite containing details of a ContainerFormat.
+     *
+     * @param \DedexBundle\Entity\Ern42\ContainerFormatType $containerFormat
+     * @return self
+     */
+    public function setContainerFormat(?\DedexBundle\Entity\Ern42\ContainerFormatType $containerFormat = null)
+    {
+        $this->containerFormat = $containerFormat;
+        return $this;
+    }
+
+    /**
+     * Gets as videoCodecType
+     *
+     * A Composite containing details of a Type of VideoCodec.
+     *
+     * @return \DedexBundle\Entity\Ern42\VideoCodecTypeType
+     */
+    public function getVideoCodecType()
+    {
+        return $this->videoCodecType;
+    }
+
+    /**
+     * Sets a new videoCodecType
+     *
+     * A Composite containing details of a Type of VideoCodec.
+     *
+     * @param \DedexBundle\Entity\Ern42\VideoCodecTypeType $videoCodecType
+     * @return self
+     */
+    public function setVideoCodecType(?\DedexBundle\Entity\Ern42\VideoCodecTypeType $videoCodecType = null)
+    {
+        $this->videoCodecType = $videoCodecType;
+        return $this;
+    }
+
+    /**
+     * Gets as videoBitRate
+     *
+     * A Composite containing the BitRate for the video data and a UnitOfMeasure (the default is kbps).
+     *
+     * @return \DedexBundle\Entity\Ern42\BitRateType
+     */
+    public function getVideoBitRate()
+    {
+        return $this->videoBitRate;
+    }
+
+    /**
+     * Sets a new videoBitRate
+     *
+     * A Composite containing the BitRate for the video data and a UnitOfMeasure (the default is kbps).
+     *
+     * @param \DedexBundle\Entity\Ern42\BitRateType $videoBitRate
+     * @return self
+     */
+    public function setVideoBitRate(?\DedexBundle\Entity\Ern42\BitRateType $videoBitRate = null)
+    {
+        $this->videoBitRate = $videoBitRate;
+        return $this;
+    }
+
+    /**
+     * Gets as frameRate
+     *
+     * A Composite containing the Rate for a number of frames shown in the Video in a specific Period of Time and a UnitOfMeasure (the default is Hz, interlaced).
+     *
+     * @return \DedexBundle\Entity\Ern42\FrameRateType
+     */
+    public function getFrameRate()
+    {
+        return $this->frameRate;
+    }
+
+    /**
+     * Sets a new frameRate
+     *
+     * A Composite containing the Rate for a number of frames shown in the Video in a specific Period of Time and a UnitOfMeasure (the default is Hz, interlaced).
+     *
+     * @param \DedexBundle\Entity\Ern42\FrameRateType $frameRate
+     * @return self
+     */
+    public function setFrameRate(?\DedexBundle\Entity\Ern42\FrameRateType $frameRate = null)
+    {
+        $this->frameRate = $frameRate;
+        return $this;
+    }
+
+    /**
+     * Gets as imageHeight
+     *
+     * A Composite containing the vertical Extent of an Image of the Video and a UnitOfMeasure (the default is Pixels).
+     *
+     * @return \DedexBundle\Entity\Ern42\ExtentType
+     */
+    public function getImageHeight()
+    {
+        return $this->imageHeight;
+    }
+
+    /**
+     * Sets a new imageHeight
+     *
+     * A Composite containing the vertical Extent of an Image of the Video and a UnitOfMeasure (the default is Pixels).
+     *
+     * @param \DedexBundle\Entity\Ern42\ExtentType $imageHeight
+     * @return self
+     */
+    public function setImageHeight(?\DedexBundle\Entity\Ern42\ExtentType $imageHeight = null)
+    {
+        $this->imageHeight = $imageHeight;
+        return $this;
+    }
+
+    /**
+     * Gets as imageWidth
+     *
+     * A Composite containing the horizontal Extent of an Image of the Video and a UnitOfMeasure (the default is Pixels).
+     *
+     * @return \DedexBundle\Entity\Ern42\ExtentType
+     */
+    public function getImageWidth()
+    {
+        return $this->imageWidth;
+    }
+
+    /**
+     * Sets a new imageWidth
+     *
+     * A Composite containing the horizontal Extent of an Image of the Video and a UnitOfMeasure (the default is Pixels).
+     *
+     * @param \DedexBundle\Entity\Ern42\ExtentType $imageWidth
+     * @return self
+     */
+    public function setImageWidth(?\DedexBundle\Entity\Ern42\ExtentType $imageWidth = null)
+    {
+        $this->imageWidth = $imageWidth;
+        return $this;
+    }
+
+    /**
+     * Gets as aspectRatio
+     *
+     * A Composite containing the ratio formed by dividing the ImageHeight by the ImageWidth.
+     *
+     * @return \DedexBundle\Entity\Ern42\AspectRatioType
+     */
+    public function getAspectRatio()
+    {
+        return $this->aspectRatio;
+    }
+
+    /**
+     * Sets a new aspectRatio
+     *
+     * A Composite containing the ratio formed by dividing the ImageHeight by the ImageWidth.
+     *
+     * @param \DedexBundle\Entity\Ern42\AspectRatioType $aspectRatio
+     * @return self
+     */
+    public function setAspectRatio(?\DedexBundle\Entity\Ern42\AspectRatioType $aspectRatio = null)
+    {
+        $this->aspectRatio = $aspectRatio;
+        return $this;
+    }
+
+    /**
+     * Gets as coreArea
+     *
+     * A Composite containing details of the core part of the Video.
+     *
+     * @return \DedexBundle\Entity\Ern42\CoreAreaType
+     */
+    public function getCoreArea()
+    {
+        return $this->coreArea;
+    }
+
+    /**
+     * Sets a new coreArea
+     *
+     * A Composite containing details of the core part of the Video.
+     *
+     * @param \DedexBundle\Entity\Ern42\CoreAreaType $coreArea
+     * @return self
+     */
+    public function setCoreArea(?\DedexBundle\Entity\Ern42\CoreAreaType $coreArea = null)
+    {
+        $this->coreArea = $coreArea;
+        return $this;
+    }
+
+    /**
+     * Gets as colorDepth
+     *
+     * An amount of data determining the color of a pixel of an Image of the Video (given in bits per pixel).
+     *
+     * @return int
+     */
+    public function getColorDepth()
+    {
+        return $this->colorDepth;
+    }
+
+    /**
+     * Sets a new colorDepth
+     *
+     * An amount of data determining the color of a pixel of an Image of the Video (given in bits per pixel).
+     *
+     * @param int $colorDepth
+     * @return self
+     */
+    public function setColorDepth($colorDepth)
+    {
+        $this->colorDepth = $colorDepth;
+        return $this;
+    }
+
+    /**
+     * Gets as videoDefinitionType
+     *
+     * A Type of resolution (or definition) in which the Video is provided.
+     *
+     * @return \DedexBundle\Entity\Ern42\VideoDefinitionTypeType
+     */
+    public function getVideoDefinitionType()
+    {
+        return $this->videoDefinitionType;
+    }
+
+    /**
+     * Sets a new videoDefinitionType
+     *
+     * A Type of resolution (or definition) in which the Video is provided.
+     *
+     * @param \DedexBundle\Entity\Ern42\VideoDefinitionTypeType $videoDefinitionType
+     * @return self
+     */
+    public function setVideoDefinitionType(?\DedexBundle\Entity\Ern42\VideoDefinitionTypeType $videoDefinitionType = null)
+    {
+        $this->videoDefinitionType = $videoDefinitionType;
+        return $this;
+    }
+
+    /**
+     * Gets as audioCodecType
+     *
+     * A Composite containing details of a Type of AudioCodec.
+     *
+     * @return \DedexBundle\Entity\Ern42\AudioCodecTypeType
+     */
+    public function getAudioCodecType()
+    {
+        return $this->audioCodecType;
+    }
+
+    /**
+     * Sets a new audioCodecType
+     *
+     * A Composite containing details of a Type of AudioCodec.
+     *
+     * @param \DedexBundle\Entity\Ern42\AudioCodecTypeType $audioCodecType
+     * @return self
+     */
+    public function setAudioCodecType(?\DedexBundle\Entity\Ern42\AudioCodecTypeType $audioCodecType = null)
+    {
+        $this->audioCodecType = $audioCodecType;
+        return $this;
+    }
+
+    /**
+     * Gets as audioBitRate
+     *
+     * A Composite containing the BitRate for the audio data and a UnitOfMeasure (the default is kbps).
+     *
+     * @return \DedexBundle\Entity\Ern42\BitRateType
+     */
+    public function getAudioBitRate()
+    {
+        return $this->audioBitRate;
+    }
+
+    /**
+     * Sets a new audioBitRate
+     *
+     * A Composite containing the BitRate for the audio data and a UnitOfMeasure (the default is kbps).
+     *
+     * @param \DedexBundle\Entity\Ern42\BitRateType $audioBitRate
+     * @return self
+     */
+    public function setAudioBitRate(?\DedexBundle\Entity\Ern42\BitRateType $audioBitRate = null)
+    {
+        $this->audioBitRate = $audioBitRate;
+        return $this;
+    }
+
+    /**
+     * Gets as numberOfAudioChannels
+     *
+     * A number of audio channels.
+     *
+     * @return int
+     */
+    public function getNumberOfAudioChannels()
+    {
+        return $this->numberOfAudioChannels;
+    }
+
+    /**
+     * Sets a new numberOfAudioChannels
+     *
+     * A number of audio channels.
+     *
+     * @param int $numberOfAudioChannels
+     * @return self
+     */
+    public function setNumberOfAudioChannels($numberOfAudioChannels)
+    {
+        $this->numberOfAudioChannels = $numberOfAudioChannels;
+        return $this;
+    }
+
+    /**
+     * Gets as audioSamplingRate
+     *
+     * A Composite containing the SamplingRate for the audio data and a UnitOfMeasure (the default is Hz).
+     *
+     * @return \DedexBundle\Entity\Ern42\SamplingRateType
+     */
+    public function getAudioSamplingRate()
+    {
+        return $this->audioSamplingRate;
+    }
+
+    /**
+     * Sets a new audioSamplingRate
+     *
+     * A Composite containing the SamplingRate for the audio data and a UnitOfMeasure (the default is Hz).
+     *
+     * @param \DedexBundle\Entity\Ern42\SamplingRateType $audioSamplingRate
+     * @return self
+     */
+    public function setAudioSamplingRate(?\DedexBundle\Entity\Ern42\SamplingRateType $audioSamplingRate = null)
+    {
+        $this->audioSamplingRate = $audioSamplingRate;
+        return $this;
+    }
+
+    /**
+     * Gets as audioBitsPerSample
+     *
+     * An amount of audio data in a sample.
+     *
+     * @return int
+     */
+    public function getAudioBitsPerSample()
+    {
+        return $this->audioBitsPerSample;
+    }
+
+    /**
+     * Sets a new audioBitsPerSample
+     *
+     * An amount of audio data in a sample.
+     *
+     * @param int $audioBitsPerSample
+     * @return self
+     */
+    public function setAudioBitsPerSample($audioBitsPerSample)
+    {
+        $this->audioBitsPerSample = $audioBitsPerSample;
+        return $this;
+    }
+
+    /**
+     * Gets as duration
+     *
+     * The Duration of the instantiation of the Video if this differs from the Duration provided for the Video itself (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S). This element must only be used if and when there are no royalty reporting implications on this change in duration and when the specific technical instantiation is a clip taken from a technical instantiation representing the whole Video.
+     *
+     * @return \DateInterval
+     */
+    public function getDuration()
+    {
+        return $this->duration;
+    }
+
+    /**
+     * Sets a new duration
+     *
+     * The Duration of the instantiation of the Video if this differs from the Duration provided for the Video itself (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S). This element must only be used if and when there are no royalty reporting implications on this change in duration and when the specific technical instantiation is a clip taken from a technical instantiation representing the whole Video.
+     *
+     * @param \DateInterval $duration
+     * @return self
+     */
+    public function setDuration(?\DateInterval $duration = null)
+    {
+        $this->duration = $duration;
+        return $this;
+    }
+
+    /**
+     * Gets as bitDepth
+     *
+     * The BitDepth of the File.
+     *
+     * @return int
+     */
+    public function getBitDepth()
+    {
+        return $this->bitDepth;
+    }
+
+    /**
+     * Sets a new bitDepth
+     *
+     * The BitDepth of the File.
+     *
+     * @param int $bitDepth
+     * @return self
+     */
+    public function setBitDepth($bitDepth)
+    {
+        $this->bitDepth = $bitDepth;
+        return $this;
+    }
+
+    /**
+     * Gets as isPreview
+     *
+     * The Flag indicating whether the Video is technically a preview of the parent Resource (=true) or not (=false). Note that nothing can be implied from this element as to the conditions under which the preview can be made available.
+     *
+     * @return bool
+     */
+    public function getIsPreview()
+    {
+        return $this->isPreview;
+    }
+
+    /**
+     * Sets a new isPreview
+     *
+     * The Flag indicating whether the Video is technically a preview of the parent Resource (=true) or not (=false). Note that nothing can be implied from this element as to the conditions under which the preview can be made available.
+     *
+     * @param bool $isPreview
+     * @return self
+     */
+    public function setIsPreview($isPreview)
+    {
+        $this->isPreview = $isPreview;
+        return $this;
+    }
+
+    /**
+     * Gets as previewDetails
+     *
+     * A Composite containing details of a preview.
+     *
+     * @return \DedexBundle\Entity\Ern42\SoundRecordingPreviewDetailsType
+     */
+    public function getPreviewDetails()
+    {
+        return $this->previewDetails;
+    }
+
+    /**
+     * Sets a new previewDetails
+     *
+     * A Composite containing details of a preview.
+     *
+     * @param \DedexBundle\Entity\Ern42\SoundRecordingPreviewDetailsType $previewDetails
+     * @return self
+     */
+    public function setPreviewDetails(?\DedexBundle\Entity\Ern42\SoundRecordingPreviewDetailsType $previewDetails = null)
+    {
+        $this->previewDetails = $previewDetails;
+        return $this;
+    }
+
+    /**
+     * Gets as file
+     *
+     * A Composite containing details of a File containing the Video that a DSP can obtain.
+     *
+     * @return \DedexBundle\Entity\Ern42\FileType
+     */
+    public function getFile()
+    {
+        return $this->file;
+    }
+
+    /**
+     * Sets a new file
+     *
+     * A Composite containing details of a File containing the Video that a DSP can obtain.
+     *
+     * @param \DedexBundle\Entity\Ern42\FileType $file
+     * @return self
+     */
+    public function setFile(?\DedexBundle\Entity\Ern42\FileType $file = null)
+    {
+        $this->file = $file;
+        return $this;
+    }
+
+    /**
+     * Gets as isProvidedInDelivery
+     *
+     * A Flag indicating whether a File containing the Video is a provided in a delivery (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getIsProvidedInDelivery()
+    {
+        return $this->isProvidedInDelivery;
+    }
+
+    /**
+     * Sets a new isProvidedInDelivery
+     *
+     * A Flag indicating whether a File containing the Video is a provided in a delivery (=true) or not (=false).
+     *
+     * @param bool $isProvidedInDelivery
+     * @return self
+     */
+    public function setIsProvidedInDelivery($isProvidedInDelivery)
+    {
+        $this->isProvidedInDelivery = $isProvidedInDelivery;
+        return $this;
+    }
+
+    /**
+     * Adds as fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\FingerprintType $fingerprint
+     */
+    public function addToFingerprint(\DedexBundle\Entity\Ern42\FingerprintType $fingerprint)
+    {
+        $this->fingerprint[] = $fingerprint;
+        return $this;
+    }
+
+    /**
+     * isset fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetFingerprint($index)
+    {
+        return isset($this->fingerprint[$index]);
+    }
+
+    /**
+     * unset fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetFingerprint($index)
+    {
+        unset($this->fingerprint[$index]);
+    }
+
+    /**
+     * Gets as fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @return \DedexBundle\Entity\Ern42\FingerprintType[]
+     */
+    public function getFingerprint()
+    {
+        return $this->fingerprint;
+    }
+
+    /**
+     * Sets a new fingerprint
+     *
+     * A Composite containing details of a Fingerprint and its governing algorithm.
+     *
+     * @param \DedexBundle\Entity\Ern42\FingerprintType[] $fingerprint
+     * @return self
+     */
+    public function setFingerprint(?array $fingerprint = null)
+    {
+        $this->fingerprint = $fingerprint;
+        return $this;
+    }
+
+    /**
+     * Gets as encodingDescription
+     *
+     * A textual Description of the encoding.
+     *
+     * @return string
+     */
+    public function getEncodingDescription()
+    {
+        return $this->encodingDescription;
+    }
+
+    /**
+     * Sets a new encodingDescription
+     *
+     * A textual Description of the encoding.
+     *
+     * @param string $encodingDescription
+     * @return self
+     */
+    public function setEncodingDescription($encodingDescription)
+    {
+        $this->encodingDescription = $encodingDescription;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/TextCodecTypeType.php
+++ b/src/Entity/Ern42/TextCodecTypeType.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing TextCodecTypeType
+ *
+ * A Composite containing details of a TextCodecType.
+ * XSD Type: TextCodecType
+ */
+class TextCodecTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Identifier of the Version of the TextCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $version
+     */
+    private $version = null;
+
+    /**
+     * The Namespace of the TextCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the TextCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as version
+     *
+     * The Identifier of the Version of the TextCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getVersion()
+    {
+        return $this->version;
+    }
+
+    /**
+     * Sets a new version
+     *
+     * The Identifier of the Version of the TextCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $version
+     * @return self
+     */
+    public function setVersion($version)
+    {
+        $this->version = $version;
+        return $this;
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the TextCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the TextCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the TextCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the TextCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/TextIdType.php
+++ b/src/Entity/Ern42/TextIdType.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing TextIdType
+ *
+ * A Composite containing details of Identifiers of a Text.
+ * XSD Type: TextId
+ */
+class TextIdType
+{
+    /**
+     * The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.
+     *
+     * @var bool $isReplaced
+     */
+    private $isReplaced = null;
+
+    /**
+     * The ISBN (International Standard Book Number defined in ISO 2108) for the Text. An ISBN is a 13-digit number. Pre-2007, ISBNs, which had 10-digits and are now deprecated, are converted by adding the prefix '978' and re-calculating the check character. DDEX will enforce the syntax 97[8-9][0-9]{9}[X0-9] using XML Schema in the future.
+     *
+     * @var string $iSBN
+     */
+    private $iSBN = null;
+
+    /**
+     * The ISSN (International Standard Serial Number defined in ISO 3297) identifying the Text. An ISSN comprises two groups of four digits, separated by a hyphen and a control digit. DDEX will enforce the syntax [0-9]{4}-[0-9]{3}[X0-9] using XML Schema in the future.
+     *
+     * @var string $iSSN
+     */
+    private $iSSN = null;
+
+    /**
+     * The SICI (Serial Item and Contribution Identifier defined in ANSI/NISO Z39.56-199) for the Text. DDEX will enforce the syntax [0-9]{4}-[0-9]{3}[X0-9].+ using XML Schema in the future.
+     *
+     * @var string $sICI
+     */
+    private $sICI = null;
+
+    /**
+     * A Composite containing details of a ProprietaryIdentifier of the Text (usually one per society involved in the messaging).
+     *
+     * @var \DedexBundle\Entity\Ern42\ProprietaryIdType[] $proprietaryId
+     */
+    private $proprietaryId = [
+        
+    ];
+
+    /**
+     * Gets as isReplaced
+     *
+     * The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.
+     *
+     * @return bool
+     */
+    public function getIsReplaced()
+    {
+        return $this->isReplaced;
+    }
+
+    /**
+     * Sets a new isReplaced
+     *
+     * The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.
+     *
+     * @param bool $isReplaced
+     * @return self
+     */
+    public function setIsReplaced($isReplaced)
+    {
+        $this->isReplaced = $isReplaced;
+        return $this;
+    }
+
+    /**
+     * Gets as iSBN
+     *
+     * The ISBN (International Standard Book Number defined in ISO 2108) for the Text. An ISBN is a 13-digit number. Pre-2007, ISBNs, which had 10-digits and are now deprecated, are converted by adding the prefix '978' and re-calculating the check character. DDEX will enforce the syntax 97[8-9][0-9]{9}[X0-9] using XML Schema in the future.
+     *
+     * @return string
+     */
+    public function getISBN()
+    {
+        return $this->iSBN;
+    }
+
+    /**
+     * Sets a new iSBN
+     *
+     * The ISBN (International Standard Book Number defined in ISO 2108) for the Text. An ISBN is a 13-digit number. Pre-2007, ISBNs, which had 10-digits and are now deprecated, are converted by adding the prefix '978' and re-calculating the check character. DDEX will enforce the syntax 97[8-9][0-9]{9}[X0-9] using XML Schema in the future.
+     *
+     * @param string $iSBN
+     * @return self
+     */
+    public function setISBN($iSBN)
+    {
+        $this->iSBN = $iSBN;
+        return $this;
+    }
+
+    /**
+     * Gets as iSSN
+     *
+     * The ISSN (International Standard Serial Number defined in ISO 3297) identifying the Text. An ISSN comprises two groups of four digits, separated by a hyphen and a control digit. DDEX will enforce the syntax [0-9]{4}-[0-9]{3}[X0-9] using XML Schema in the future.
+     *
+     * @return string
+     */
+    public function getISSN()
+    {
+        return $this->iSSN;
+    }
+
+    /**
+     * Sets a new iSSN
+     *
+     * The ISSN (International Standard Serial Number defined in ISO 3297) identifying the Text. An ISSN comprises two groups of four digits, separated by a hyphen and a control digit. DDEX will enforce the syntax [0-9]{4}-[0-9]{3}[X0-9] using XML Schema in the future.
+     *
+     * @param string $iSSN
+     * @return self
+     */
+    public function setISSN($iSSN)
+    {
+        $this->iSSN = $iSSN;
+        return $this;
+    }
+
+    /**
+     * Gets as sICI
+     *
+     * The SICI (Serial Item and Contribution Identifier defined in ANSI/NISO Z39.56-199) for the Text. DDEX will enforce the syntax [0-9]{4}-[0-9]{3}[X0-9].+ using XML Schema in the future.
+     *
+     * @return string
+     */
+    public function getSICI()
+    {
+        return $this->sICI;
+    }
+
+    /**
+     * Sets a new sICI
+     *
+     * The SICI (Serial Item and Contribution Identifier defined in ANSI/NISO Z39.56-199) for the Text. DDEX will enforce the syntax [0-9]{4}-[0-9]{3}[X0-9].+ using XML Schema in the future.
+     *
+     * @param string $sICI
+     * @return self
+     */
+    public function setSICI($sICI)
+    {
+        $this->sICI = $sICI;
+        return $this;
+    }
+
+    /**
+     * Adds as proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Text (usually one per society involved in the messaging).
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ProprietaryIdType $proprietaryId
+     */
+    public function addToProprietaryId(\DedexBundle\Entity\Ern42\ProprietaryIdType $proprietaryId)
+    {
+        $this->proprietaryId[] = $proprietaryId;
+        return $this;
+    }
+
+    /**
+     * isset proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Text (usually one per society involved in the messaging).
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetProprietaryId($index)
+    {
+        return isset($this->proprietaryId[$index]);
+    }
+
+    /**
+     * unset proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Text (usually one per society involved in the messaging).
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetProprietaryId($index)
+    {
+        unset($this->proprietaryId[$index]);
+    }
+
+    /**
+     * Gets as proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Text (usually one per society involved in the messaging).
+     *
+     * @return \DedexBundle\Entity\Ern42\ProprietaryIdType[]
+     */
+    public function getProprietaryId()
+    {
+        return $this->proprietaryId;
+    }
+
+    /**
+     * Sets a new proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Text (usually one per society involved in the messaging).
+     *
+     * @param \DedexBundle\Entity\Ern42\ProprietaryIdType[] $proprietaryId
+     * @return self
+     */
+    public function setProprietaryId(?array $proprietaryId = null)
+    {
+        $this->proprietaryId = $proprietaryId;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/TextType.php
+++ b/src/Entity/Ern42/TextType.php
@@ -1,0 +1,1682 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing TextType
+ *
+ * A Composite containing details of a Text.
+ * XSD Type: Text
+ */
+class TextType
+{
+    /**
+     * The Language and script for the Elements of the Text as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * The Flag indicating whether the Text is provided in a addition to the Resources that form part of the Release (=true) or not (=false). If the flag is set to false (or absent) the Text is part of at least one Release in the message. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isSupplemental
+     */
+    private $isSupplemental = null;
+
+    /**
+     * The Identifier (specific to the Message) of the Text within the Release which contains it. This is a LocalResourceAnchor starting with the letter A.
+     *
+     * @var string $resourceReference
+     */
+    private $resourceReference = null;
+
+    /**
+     * A Composite containing details of the Type of the Text.
+     *
+     * @var \DedexBundle\Entity\Ern42\TextTypeType $type
+     */
+    private $type = null;
+
+    /**
+     * A Composite containing details of an Identifier of the Text.
+     *
+     * @var \DedexBundle\Entity\Ern42\TextIdType[] $resourceId
+     */
+    private $resourceId = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the Text.
+     *
+     * @var \DedexBundle\Entity\Ern42\MusicalWorkIdType[] $workId
+     */
+    private $workId = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Title of the Text as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayTitleTextType[] $displayTitleText
+     */
+    private $displayTitleText = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Title of the Text as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayTitleType[] $displayTitle
+     */
+    private $displayTitle = [
+        
+    ];
+
+    /**
+     * A Composite containing details of an AdditionalTitle of the Text. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @var \DedexBundle\Entity\Ern42\AdditionalTitleType[] $additionalTitle
+     */
+    private $additionalTitle = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Type of Version of the Text.
+     *
+     * @var \DedexBundle\Entity\Ern42\VersionTypeType[] $versionType
+     */
+    private $versionType = [
+        
+    ];
+
+    /**
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType[] $displayArtistName
+     */
+    private $displayArtistName = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the DisplayArtist for the Text. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayArtistType[] $displayArtist
+     */
+    private $displayArtist = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Contributor to the Text.
+     *
+     * @var \DedexBundle\Entity\Ern42\ContributorType[] $contributor
+     */
+    private $contributor = [
+        
+    ];
+
+    /**
+     * A Composite containing details of RightsController of Rights in the Text.
+     *
+     * @var \DedexBundle\Entity\Ern42\ResourceRightsControllerType[] $resourceRightsController
+     */
+    private $resourceRightsController = [
+        
+    ];
+
+    /**
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @var \DedexBundle\Entity\Ern42\WorkRightsControllerType[] $workRightsController
+     */
+    private $workRightsController = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the CLine for the Text.
+     *
+     * @var \DedexBundle\Entity\Ern42\CLineWithDefaultType[] $cLine
+     */
+    private $cLine = [
+        
+    ];
+
+    /**
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured in the Text.
+     *
+     * @var \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType[] $courtesyLine
+     */
+    private $courtesyLine = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the Date and Place of the Event in which the Text was created. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $creationDate
+     */
+    private $creationDate = null;
+
+    /**
+     * A Composite containing details of the Date and Place of the Event in which the Text was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @var \DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType[] $firstPublicationDate
+     */
+    private $firstPublicationDate = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the classification of the Text according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @var \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType[] $parentalWarningType
+     */
+    private $parentalWarningType = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Text.
+     *
+     * @var \DedexBundle\Entity\Ern42\RelatedReleaseType[] $relatedRelease
+     */
+    private $relatedRelease = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Text.
+     *
+     * @var \DedexBundle\Entity\Ern42\RelatedResourceType[] $relatedResource
+     */
+    private $relatedResource = [
+        
+    ];
+
+    /**
+     * The Flag indicating whether the Text contains content that is hidden in some way from the Consumer (=true) or not (=false).
+     *
+     * @var bool $containsHiddenContent
+     */
+    private $containsHiddenContent = null;
+
+    /**
+     * A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current Text.
+     *
+     * @var \DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType[] $resourceContainedResourceReferenceList
+     */
+    private $resourceContainedResourceReferenceList = null;
+
+    /**
+     * A Composite containing technical details of the Text.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @var \DedexBundle\Entity\Ern42\TechnicalTextDetailsType[] $technicalDetails
+     */
+    private $technicalDetails = [
+        
+    ];
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the Elements of the Text as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the Elements of the Text as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isSupplemental
+     *
+     * The Flag indicating whether the Text is provided in a addition to the Resources that form part of the Release (=true) or not (=false). If the flag is set to false (or absent) the Text is part of at least one Release in the message. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsSupplemental()
+    {
+        return $this->isSupplemental;
+    }
+
+    /**
+     * Sets a new isSupplemental
+     *
+     * The Flag indicating whether the Text is provided in a addition to the Resources that form part of the Release (=true) or not (=false). If the flag is set to false (or absent) the Text is part of at least one Release in the message. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isSupplemental
+     * @return self
+     */
+    public function setIsSupplemental($isSupplemental)
+    {
+        $this->isSupplemental = $isSupplemental;
+        return $this;
+    }
+
+    /**
+     * Gets as resourceReference
+     *
+     * The Identifier (specific to the Message) of the Text within the Release which contains it. This is a LocalResourceAnchor starting with the letter A.
+     *
+     * @return string
+     */
+    public function getResourceReference()
+    {
+        return $this->resourceReference;
+    }
+
+    /**
+     * Sets a new resourceReference
+     *
+     * The Identifier (specific to the Message) of the Text within the Release which contains it. This is a LocalResourceAnchor starting with the letter A.
+     *
+     * @param string $resourceReference
+     * @return self
+     */
+    public function setResourceReference($resourceReference)
+    {
+        $this->resourceReference = $resourceReference;
+        return $this;
+    }
+
+    /**
+     * Gets as type
+     *
+     * A Composite containing details of the Type of the Text.
+     *
+     * @return \DedexBundle\Entity\Ern42\TextTypeType
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * Sets a new type
+     *
+     * A Composite containing details of the Type of the Text.
+     *
+     * @param \DedexBundle\Entity\Ern42\TextTypeType $type
+     * @return self
+     */
+    public function setType(\DedexBundle\Entity\Ern42\TextTypeType $type)
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    /**
+     * Adds as resourceId
+     *
+     * A Composite containing details of an Identifier of the Text.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\TextIdType $resourceId
+     */
+    public function addToResourceId(\DedexBundle\Entity\Ern42\TextIdType $resourceId)
+    {
+        $this->resourceId[] = $resourceId;
+        return $this;
+    }
+
+    /**
+     * isset resourceId
+     *
+     * A Composite containing details of an Identifier of the Text.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetResourceId($index)
+    {
+        return isset($this->resourceId[$index]);
+    }
+
+    /**
+     * unset resourceId
+     *
+     * A Composite containing details of an Identifier of the Text.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetResourceId($index)
+    {
+        unset($this->resourceId[$index]);
+    }
+
+    /**
+     * Gets as resourceId
+     *
+     * A Composite containing details of an Identifier of the Text.
+     *
+     * @return \DedexBundle\Entity\Ern42\TextIdType[]
+     */
+    public function getResourceId()
+    {
+        return $this->resourceId;
+    }
+
+    /**
+     * Sets a new resourceId
+     *
+     * A Composite containing details of an Identifier of the Text.
+     *
+     * @param \DedexBundle\Entity\Ern42\TextIdType[] $resourceId
+     * @return self
+     */
+    public function setResourceId(?array $resourceId = null)
+    {
+        $this->resourceId = $resourceId;
+        return $this;
+    }
+
+    /**
+     * Adds as workId
+     *
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the Text.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\MusicalWorkIdType $workId
+     */
+    public function addToWorkId(\DedexBundle\Entity\Ern42\MusicalWorkIdType $workId)
+    {
+        $this->workId[] = $workId;
+        return $this;
+    }
+
+    /**
+     * isset workId
+     *
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the Text.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetWorkId($index)
+    {
+        return isset($this->workId[$index]);
+    }
+
+    /**
+     * unset workId
+     *
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the Text.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetWorkId($index)
+    {
+        unset($this->workId[$index]);
+    }
+
+    /**
+     * Gets as workId
+     *
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the Text.
+     *
+     * @return \DedexBundle\Entity\Ern42\MusicalWorkIdType[]
+     */
+    public function getWorkId()
+    {
+        return $this->workId;
+    }
+
+    /**
+     * Sets a new workId
+     *
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the Text.
+     *
+     * @param \DedexBundle\Entity\Ern42\MusicalWorkIdType[] $workId
+     * @return self
+     */
+    public function setWorkId(?array $workId = null)
+    {
+        $this->workId = $workId;
+        return $this;
+    }
+
+    /**
+     * Adds as displayTitleText
+     *
+     * A Composite containing details of a Title of the Text as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleTextType $displayTitleText
+     */
+    public function addToDisplayTitleText(\DedexBundle\Entity\Ern42\DisplayTitleTextType $displayTitleText)
+    {
+        $this->displayTitleText[] = $displayTitleText;
+        return $this;
+    }
+
+    /**
+     * isset displayTitleText
+     *
+     * A Composite containing details of a Title of the Text as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayTitleText($index)
+    {
+        return isset($this->displayTitleText[$index]);
+    }
+
+    /**
+     * unset displayTitleText
+     *
+     * A Composite containing details of a Title of the Text as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayTitleText($index)
+    {
+        unset($this->displayTitleText[$index]);
+    }
+
+    /**
+     * Gets as displayTitleText
+     *
+     * A Composite containing details of a Title of the Text as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayTitleTextType[]
+     */
+    public function getDisplayTitleText()
+    {
+        return $this->displayTitleText;
+    }
+
+    /**
+     * Sets a new displayTitleText
+     *
+     * A Composite containing details of a Title of the Text as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleTextType[] $displayTitleText
+     * @return self
+     */
+    public function setDisplayTitleText(?array $displayTitleText = null)
+    {
+        $this->displayTitleText = $displayTitleText;
+        return $this;
+    }
+
+    /**
+     * Adds as displayTitle
+     *
+     * A Composite containing details of a Title of the Text as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleType $displayTitle
+     */
+    public function addToDisplayTitle(\DedexBundle\Entity\Ern42\DisplayTitleType $displayTitle)
+    {
+        $this->displayTitle[] = $displayTitle;
+        return $this;
+    }
+
+    /**
+     * isset displayTitle
+     *
+     * A Composite containing details of a Title of the Text as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayTitle($index)
+    {
+        return isset($this->displayTitle[$index]);
+    }
+
+    /**
+     * unset displayTitle
+     *
+     * A Composite containing details of a Title of the Text as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayTitle($index)
+    {
+        unset($this->displayTitle[$index]);
+    }
+
+    /**
+     * Gets as displayTitle
+     *
+     * A Composite containing details of a Title of the Text as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayTitleType[]
+     */
+    public function getDisplayTitle()
+    {
+        return $this->displayTitle;
+    }
+
+    /**
+     * Sets a new displayTitle
+     *
+     * A Composite containing details of a Title of the Text as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleType[] $displayTitle
+     * @return self
+     */
+    public function setDisplayTitle(?array $displayTitle = null)
+    {
+        $this->displayTitle = $displayTitle;
+        return $this;
+    }
+
+    /**
+     * Adds as additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Text. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\AdditionalTitleType $additionalTitle
+     */
+    public function addToAdditionalTitle(\DedexBundle\Entity\Ern42\AdditionalTitleType $additionalTitle)
+    {
+        $this->additionalTitle[] = $additionalTitle;
+        return $this;
+    }
+
+    /**
+     * isset additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Text. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetAdditionalTitle($index)
+    {
+        return isset($this->additionalTitle[$index]);
+    }
+
+    /**
+     * unset additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Text. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetAdditionalTitle($index)
+    {
+        unset($this->additionalTitle[$index]);
+    }
+
+    /**
+     * Gets as additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Text. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return \DedexBundle\Entity\Ern42\AdditionalTitleType[]
+     */
+    public function getAdditionalTitle()
+    {
+        return $this->additionalTitle;
+    }
+
+    /**
+     * Sets a new additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Text. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param \DedexBundle\Entity\Ern42\AdditionalTitleType[] $additionalTitle
+     * @return self
+     */
+    public function setAdditionalTitle(?array $additionalTitle = null)
+    {
+        $this->additionalTitle = $additionalTitle;
+        return $this;
+    }
+
+    /**
+     * Adds as versionType
+     *
+     * A Composite containing details of a Type of Version of the Text.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\VersionTypeType $versionType
+     */
+    public function addToVersionType(\DedexBundle\Entity\Ern42\VersionTypeType $versionType)
+    {
+        $this->versionType[] = $versionType;
+        return $this;
+    }
+
+    /**
+     * isset versionType
+     *
+     * A Composite containing details of a Type of Version of the Text.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetVersionType($index)
+    {
+        return isset($this->versionType[$index]);
+    }
+
+    /**
+     * unset versionType
+     *
+     * A Composite containing details of a Type of Version of the Text.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetVersionType($index)
+    {
+        unset($this->versionType[$index]);
+    }
+
+    /**
+     * Gets as versionType
+     *
+     * A Composite containing details of a Type of Version of the Text.
+     *
+     * @return \DedexBundle\Entity\Ern42\VersionTypeType[]
+     */
+    public function getVersionType()
+    {
+        return $this->versionType;
+    }
+
+    /**
+     * Sets a new versionType
+     *
+     * A Composite containing details of a Type of Version of the Text.
+     *
+     * @param \DedexBundle\Entity\Ern42\VersionTypeType[] $versionType
+     * @return self
+     */
+    public function setVersionType(?array $versionType = null)
+    {
+        $this->versionType = $versionType;
+        return $this;
+    }
+
+    /**
+     * Adds as displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType $displayArtistName
+     */
+    public function addToDisplayArtistName(\DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType $displayArtistName)
+    {
+        $this->displayArtistName[] = $displayArtistName;
+        return $this;
+    }
+
+    /**
+     * isset displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayArtistName($index)
+    {
+        return isset($this->displayArtistName[$index]);
+    }
+
+    /**
+     * unset displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayArtistName($index)
+    {
+        unset($this->displayArtistName[$index]);
+    }
+
+    /**
+     * Gets as displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType[]
+     */
+    public function getDisplayArtistName()
+    {
+        return $this->displayArtistName;
+    }
+
+    /**
+     * Sets a new displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType[] $displayArtistName
+     * @return self
+     */
+    public function setDisplayArtistName(?array $displayArtistName = null)
+    {
+        $this->displayArtistName = $displayArtistName;
+        return $this;
+    }
+
+    /**
+     * Adds as displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the Text. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistType $displayArtist
+     */
+    public function addToDisplayArtist(\DedexBundle\Entity\Ern42\DisplayArtistType $displayArtist)
+    {
+        $this->displayArtist[] = $displayArtist;
+        return $this;
+    }
+
+    /**
+     * isset displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the Text. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayArtist($index)
+    {
+        return isset($this->displayArtist[$index]);
+    }
+
+    /**
+     * unset displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the Text. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayArtist($index)
+    {
+        unset($this->displayArtist[$index]);
+    }
+
+    /**
+     * Gets as displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the Text. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayArtistType[]
+     */
+    public function getDisplayArtist()
+    {
+        return $this->displayArtist;
+    }
+
+    /**
+     * Sets a new displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the Text. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistType[] $displayArtist
+     * @return self
+     */
+    public function setDisplayArtist(?array $displayArtist = null)
+    {
+        $this->displayArtist = $displayArtist;
+        return $this;
+    }
+
+    /**
+     * Adds as contributor
+     *
+     * A Composite containing details of a Contributor to the Text.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ContributorType $contributor
+     */
+    public function addToContributor(\DedexBundle\Entity\Ern42\ContributorType $contributor)
+    {
+        $this->contributor[] = $contributor;
+        return $this;
+    }
+
+    /**
+     * isset contributor
+     *
+     * A Composite containing details of a Contributor to the Text.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetContributor($index)
+    {
+        return isset($this->contributor[$index]);
+    }
+
+    /**
+     * unset contributor
+     *
+     * A Composite containing details of a Contributor to the Text.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetContributor($index)
+    {
+        unset($this->contributor[$index]);
+    }
+
+    /**
+     * Gets as contributor
+     *
+     * A Composite containing details of a Contributor to the Text.
+     *
+     * @return \DedexBundle\Entity\Ern42\ContributorType[]
+     */
+    public function getContributor()
+    {
+        return $this->contributor;
+    }
+
+    /**
+     * Sets a new contributor
+     *
+     * A Composite containing details of a Contributor to the Text.
+     *
+     * @param \DedexBundle\Entity\Ern42\ContributorType[] $contributor
+     * @return self
+     */
+    public function setContributor(?array $contributor = null)
+    {
+        $this->contributor = $contributor;
+        return $this;
+    }
+
+    /**
+     * Adds as resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Text.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ResourceRightsControllerType $resourceRightsController
+     */
+    public function addToResourceRightsController(\DedexBundle\Entity\Ern42\ResourceRightsControllerType $resourceRightsController)
+    {
+        $this->resourceRightsController[] = $resourceRightsController;
+        return $this;
+    }
+
+    /**
+     * isset resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Text.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetResourceRightsController($index)
+    {
+        return isset($this->resourceRightsController[$index]);
+    }
+
+    /**
+     * unset resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Text.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetResourceRightsController($index)
+    {
+        unset($this->resourceRightsController[$index]);
+    }
+
+    /**
+     * Gets as resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Text.
+     *
+     * @return \DedexBundle\Entity\Ern42\ResourceRightsControllerType[]
+     */
+    public function getResourceRightsController()
+    {
+        return $this->resourceRightsController;
+    }
+
+    /**
+     * Sets a new resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Text.
+     *
+     * @param \DedexBundle\Entity\Ern42\ResourceRightsControllerType[] $resourceRightsController
+     * @return self
+     */
+    public function setResourceRightsController(?array $resourceRightsController = null)
+    {
+        $this->resourceRightsController = $resourceRightsController;
+        return $this;
+    }
+
+    /**
+     * Adds as workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\WorkRightsControllerType $workRightsController
+     */
+    public function addToWorkRightsController(\DedexBundle\Entity\Ern42\WorkRightsControllerType $workRightsController)
+    {
+        $this->workRightsController[] = $workRightsController;
+        return $this;
+    }
+
+    /**
+     * isset workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetWorkRightsController($index)
+    {
+        return isset($this->workRightsController[$index]);
+    }
+
+    /**
+     * unset workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetWorkRightsController($index)
+    {
+        unset($this->workRightsController[$index]);
+    }
+
+    /**
+     * Gets as workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @return \DedexBundle\Entity\Ern42\WorkRightsControllerType[]
+     */
+    public function getWorkRightsController()
+    {
+        return $this->workRightsController;
+    }
+
+    /**
+     * Sets a new workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @param \DedexBundle\Entity\Ern42\WorkRightsControllerType[] $workRightsController
+     * @return self
+     */
+    public function setWorkRightsController(?array $workRightsController = null)
+    {
+        $this->workRightsController = $workRightsController;
+        return $this;
+    }
+
+    /**
+     * Adds as cLine
+     *
+     * A Composite containing details of the CLine for the Text.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\CLineWithDefaultType $cLine
+     */
+    public function addToCLine(\DedexBundle\Entity\Ern42\CLineWithDefaultType $cLine)
+    {
+        $this->cLine[] = $cLine;
+        return $this;
+    }
+
+    /**
+     * isset cLine
+     *
+     * A Composite containing details of the CLine for the Text.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetCLine($index)
+    {
+        return isset($this->cLine[$index]);
+    }
+
+    /**
+     * unset cLine
+     *
+     * A Composite containing details of the CLine for the Text.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetCLine($index)
+    {
+        unset($this->cLine[$index]);
+    }
+
+    /**
+     * Gets as cLine
+     *
+     * A Composite containing details of the CLine for the Text.
+     *
+     * @return \DedexBundle\Entity\Ern42\CLineWithDefaultType[]
+     */
+    public function getCLine()
+    {
+        return $this->cLine;
+    }
+
+    /**
+     * Sets a new cLine
+     *
+     * A Composite containing details of the CLine for the Text.
+     *
+     * @param \DedexBundle\Entity\Ern42\CLineWithDefaultType[] $cLine
+     * @return self
+     */
+    public function setCLine(?array $cLine = null)
+    {
+        $this->cLine = $cLine;
+        return $this;
+    }
+
+    /**
+     * Adds as courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured in the Text.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType $courtesyLine
+     */
+    public function addToCourtesyLine(\DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType $courtesyLine)
+    {
+        $this->courtesyLine[] = $courtesyLine;
+        return $this;
+    }
+
+    /**
+     * isset courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured in the Text.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetCourtesyLine($index)
+    {
+        return isset($this->courtesyLine[$index]);
+    }
+
+    /**
+     * unset courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured in the Text.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetCourtesyLine($index)
+    {
+        unset($this->courtesyLine[$index]);
+    }
+
+    /**
+     * Gets as courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured in the Text.
+     *
+     * @return \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType[]
+     */
+    public function getCourtesyLine()
+    {
+        return $this->courtesyLine;
+    }
+
+    /**
+     * Sets a new courtesyLine
+     *
+     * A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured in the Text.
+     *
+     * @param \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType[] $courtesyLine
+     * @return self
+     */
+    public function setCourtesyLine(?array $courtesyLine = null)
+    {
+        $this->courtesyLine = $courtesyLine;
+        return $this;
+    }
+
+    /**
+     * Gets as creationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Text was created. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType
+     */
+    public function getCreationDate()
+    {
+        return $this->creationDate;
+    }
+
+    /**
+     * Sets a new creationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Text was created. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $creationDate
+     * @return self
+     */
+    public function setCreationDate(?\DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $creationDate = null)
+    {
+        $this->creationDate = $creationDate;
+        return $this;
+    }
+
+    /**
+     * Adds as firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Text was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType $firstPublicationDate
+     */
+    public function addToFirstPublicationDate(\DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType $firstPublicationDate)
+    {
+        $this->firstPublicationDate[] = $firstPublicationDate;
+        return $this;
+    }
+
+    /**
+     * isset firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Text was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetFirstPublicationDate($index)
+    {
+        return isset($this->firstPublicationDate[$index]);
+    }
+
+    /**
+     * unset firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Text was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetFirstPublicationDate($index)
+    {
+        unset($this->firstPublicationDate[$index]);
+    }
+
+    /**
+     * Gets as firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Text was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @return \DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType[]
+     */
+    public function getFirstPublicationDate()
+    {
+        return $this->firstPublicationDate;
+    }
+
+    /**
+     * Sets a new firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Text was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param \DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType[] $firstPublicationDate
+     * @return self
+     */
+    public function setFirstPublicationDate(?array $firstPublicationDate = null)
+    {
+        $this->firstPublicationDate = $firstPublicationDate;
+        return $this;
+    }
+
+    /**
+     * Adds as parentalWarningType
+     *
+     * A Composite containing details of the classification of the Text according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType $parentalWarningType
+     */
+    public function addToParentalWarningType(\DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType $parentalWarningType)
+    {
+        $this->parentalWarningType[] = $parentalWarningType;
+        return $this;
+    }
+
+    /**
+     * isset parentalWarningType
+     *
+     * A Composite containing details of the classification of the Text according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetParentalWarningType($index)
+    {
+        return isset($this->parentalWarningType[$index]);
+    }
+
+    /**
+     * unset parentalWarningType
+     *
+     * A Composite containing details of the classification of the Text according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetParentalWarningType($index)
+    {
+        unset($this->parentalWarningType[$index]);
+    }
+
+    /**
+     * Gets as parentalWarningType
+     *
+     * A Composite containing details of the classification of the Text according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @return \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType[]
+     */
+    public function getParentalWarningType()
+    {
+        return $this->parentalWarningType;
+    }
+
+    /**
+     * Sets a new parentalWarningType
+     *
+     * A Composite containing details of the classification of the Text according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @param \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType[] $parentalWarningType
+     * @return self
+     */
+    public function setParentalWarningType(?array $parentalWarningType = null)
+    {
+        $this->parentalWarningType = $parentalWarningType;
+        return $this;
+    }
+
+    /**
+     * Adds as relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Text.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\RelatedReleaseType $relatedRelease
+     */
+    public function addToRelatedRelease(\DedexBundle\Entity\Ern42\RelatedReleaseType $relatedRelease)
+    {
+        $this->relatedRelease[] = $relatedRelease;
+        return $this;
+    }
+
+    /**
+     * isset relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Text.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRelatedRelease($index)
+    {
+        return isset($this->relatedRelease[$index]);
+    }
+
+    /**
+     * unset relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Text.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRelatedRelease($index)
+    {
+        unset($this->relatedRelease[$index]);
+    }
+
+    /**
+     * Gets as relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Text.
+     *
+     * @return \DedexBundle\Entity\Ern42\RelatedReleaseType[]
+     */
+    public function getRelatedRelease()
+    {
+        return $this->relatedRelease;
+    }
+
+    /**
+     * Sets a new relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Text.
+     *
+     * @param \DedexBundle\Entity\Ern42\RelatedReleaseType[] $relatedRelease
+     * @return self
+     */
+    public function setRelatedRelease(?array $relatedRelease = null)
+    {
+        $this->relatedRelease = $relatedRelease;
+        return $this;
+    }
+
+    /**
+     * Adds as relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Text.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\RelatedResourceType $relatedResource
+     */
+    public function addToRelatedResource(\DedexBundle\Entity\Ern42\RelatedResourceType $relatedResource)
+    {
+        $this->relatedResource[] = $relatedResource;
+        return $this;
+    }
+
+    /**
+     * isset relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Text.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRelatedResource($index)
+    {
+        return isset($this->relatedResource[$index]);
+    }
+
+    /**
+     * unset relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Text.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRelatedResource($index)
+    {
+        unset($this->relatedResource[$index]);
+    }
+
+    /**
+     * Gets as relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Text.
+     *
+     * @return \DedexBundle\Entity\Ern42\RelatedResourceType[]
+     */
+    public function getRelatedResource()
+    {
+        return $this->relatedResource;
+    }
+
+    /**
+     * Sets a new relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Text.
+     *
+     * @param \DedexBundle\Entity\Ern42\RelatedResourceType[] $relatedResource
+     * @return self
+     */
+    public function setRelatedResource(?array $relatedResource = null)
+    {
+        $this->relatedResource = $relatedResource;
+        return $this;
+    }
+
+    /**
+     * Gets as containsHiddenContent
+     *
+     * The Flag indicating whether the Text contains content that is hidden in some way from the Consumer (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getContainsHiddenContent()
+    {
+        return $this->containsHiddenContent;
+    }
+
+    /**
+     * Sets a new containsHiddenContent
+     *
+     * The Flag indicating whether the Text contains content that is hidden in some way from the Consumer (=true) or not (=false).
+     *
+     * @param bool $containsHiddenContent
+     * @return self
+     */
+    public function setContainsHiddenContent($containsHiddenContent)
+    {
+        $this->containsHiddenContent = $containsHiddenContent;
+        return $this;
+    }
+
+    /**
+     * Adds as resourceContainedResourceReference
+     *
+     * A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current Text.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType $resourceContainedResourceReference
+     */
+    public function addToResourceContainedResourceReferenceList(\DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType $resourceContainedResourceReference)
+    {
+        $this->resourceContainedResourceReferenceList[] = $resourceContainedResourceReference;
+        return $this;
+    }
+
+    /**
+     * isset resourceContainedResourceReferenceList
+     *
+     * A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current Text.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetResourceContainedResourceReferenceList($index)
+    {
+        return isset($this->resourceContainedResourceReferenceList[$index]);
+    }
+
+    /**
+     * unset resourceContainedResourceReferenceList
+     *
+     * A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current Text.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetResourceContainedResourceReferenceList($index)
+    {
+        unset($this->resourceContainedResourceReferenceList[$index]);
+    }
+
+    /**
+     * Gets as resourceContainedResourceReferenceList
+     *
+     * A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current Text.
+     *
+     * @return \DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType[]
+     */
+    public function getResourceContainedResourceReferenceList()
+    {
+        return $this->resourceContainedResourceReferenceList;
+    }
+
+    /**
+     * Sets a new resourceContainedResourceReferenceList
+     *
+     * A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current Text.
+     *
+     * @param \DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType[] $resourceContainedResourceReferenceList
+     * @return self
+     */
+    public function setResourceContainedResourceReferenceList(?array $resourceContainedResourceReferenceList = null)
+    {
+        $this->resourceContainedResourceReferenceList = $resourceContainedResourceReferenceList;
+        return $this;
+    }
+
+    /**
+     * Adds as technicalDetails
+     *
+     * A Composite containing technical details of the Text.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\TechnicalTextDetailsType $technicalDetails
+     */
+    public function addToTechnicalDetails(\DedexBundle\Entity\Ern42\TechnicalTextDetailsType $technicalDetails)
+    {
+        $this->technicalDetails[] = $technicalDetails;
+        return $this;
+    }
+
+    /**
+     * isset technicalDetails
+     *
+     * A Composite containing technical details of the Text.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetTechnicalDetails($index)
+    {
+        return isset($this->technicalDetails[$index]);
+    }
+
+    /**
+     * unset technicalDetails
+     *
+     * A Composite containing technical details of the Text.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetTechnicalDetails($index)
+    {
+        unset($this->technicalDetails[$index]);
+    }
+
+    /**
+     * Gets as technicalDetails
+     *
+     * A Composite containing technical details of the Text.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @return \DedexBundle\Entity\Ern42\TechnicalTextDetailsType[]
+     */
+    public function getTechnicalDetails()
+    {
+        return $this->technicalDetails;
+    }
+
+    /**
+     * Sets a new technicalDetails
+     *
+     * A Composite containing technical details of the Text.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @param \DedexBundle\Entity\Ern42\TechnicalTextDetailsType[] $technicalDetails
+     * @return self
+     */
+    public function setTechnicalDetails(?array $technicalDetails = null)
+    {
+        $this->technicalDetails = $technicalDetails;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/TextTypeType.php
+++ b/src/Entity/Ern42/TextTypeType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing TextTypeType
+ *
+ * A Composite containing details of a TextType.
+ * XSD Type: TextType
+ */
+class TextTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the TextType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the TextType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the TextType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the TextType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the TextType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the TextType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/TextWithFormatType.php
+++ b/src/Entity/Ern42/TextWithFormatType.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing TextWithFormatType
+ *
+ * A Composite containing details of an Annotation, e.g. a Description or a Comment.
+ * XSD Type: TextWithFormat
+ */
+class TextWithFormatType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Language and script of the Annotation as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * A Territory to which the Annotation applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * The format of the Annotation. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $format
+     */
+    private $format = null;
+
+    /**
+     * The Namespace of the Format. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the Format. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script of the Annotation as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script of the Annotation as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the Annotation applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the Annotation applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+
+    /**
+     * Gets as format
+     *
+     * The format of the Annotation. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getFormat()
+    {
+        return $this->format;
+    }
+
+    /**
+     * Sets a new format
+     *
+     * The format of the Annotation. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $format
+     * @return self
+     */
+    public function setFormat($format)
+    {
+        $this->format = $format;
+        return $this;
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the Format. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the Format. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the Format. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the Format. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/TextWithoutTerritoryType.php
+++ b/src/Entity/Ern42/TextWithoutTerritoryType.php
@@ -1,0 +1,251 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing TextWithoutTerritoryType
+ *
+ * A Composite containing details of an Annotation, e.g. a Description or a Comment.
+ * Explanatory Note: This Composite is named TextWithoutTerritory to disambiguate it from the basic TextWithFormat Composite.
+ * XSD Type: TextWithoutTerritory
+ */
+class TextWithoutTerritoryType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Language and script of the Annotation as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * A Territory to which the Annotation applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var string $applicableTerritoryCode
+     */
+    private $applicableTerritoryCode = null;
+
+    /**
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isDefault
+     */
+    private $isDefault = null;
+
+    /**
+     * The format of the Annotation. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $format
+     */
+    private $format = null;
+
+    /**
+     * The Namespace of the Format. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the Format. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script of the Annotation as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script of the Annotation as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as applicableTerritoryCode
+     *
+     * A Territory to which the Annotation applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return string
+     */
+    public function getApplicableTerritoryCode()
+    {
+        return $this->applicableTerritoryCode;
+    }
+
+    /**
+     * Sets a new applicableTerritoryCode
+     *
+     * A Territory to which the Annotation applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param string $applicableTerritoryCode
+     * @return self
+     */
+    public function setApplicableTerritoryCode($applicableTerritoryCode)
+    {
+        $this->applicableTerritoryCode = $applicableTerritoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * Sets a new isDefault
+     *
+     * The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isDefault
+     * @return self
+     */
+    public function setIsDefault($isDefault)
+    {
+        $this->isDefault = $isDefault;
+        return $this;
+    }
+
+    /**
+     * Gets as format
+     *
+     * The format of the Annotation. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getFormat()
+    {
+        return $this->format;
+    }
+
+    /**
+     * Sets a new format
+     *
+     * The format of the Annotation. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $format
+     * @return self
+     */
+    public function setFormat($format)
+    {
+        $this->format = $format;
+        return $this;
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the Format. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the Format. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the Format. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the Format. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/TimingType.php
+++ b/src/Entity/Ern42/TimingType.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing TimingType
+ *
+ * A Composite containing details of a StartTime and a Duration of a Resource.
+ * XSD Type: Timing
+ */
+class TimingType
+{
+    /**
+     * The start point of the related Resource from the start of the referencing Resource (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @var \DateInterval $startPoint
+     */
+    private $startPoint = null;
+
+    /**
+     * The total Duration of the related Resource that has been used (this may be less than the total Duration of the Resource) (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @var \DateInterval $durationUsed
+     */
+    private $durationUsed = null;
+
+    /**
+     * Gets as startPoint
+     *
+     * The start point of the related Resource from the start of the referencing Resource (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @return \DateInterval
+     */
+    public function getStartPoint()
+    {
+        return $this->startPoint;
+    }
+
+    /**
+     * Sets a new startPoint
+     *
+     * The start point of the related Resource from the start of the referencing Resource (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @param \DateInterval $startPoint
+     * @return self
+     */
+    public function setStartPoint(?\DateInterval $startPoint = null)
+    {
+        $this->startPoint = $startPoint;
+        return $this;
+    }
+
+    /**
+     * Gets as durationUsed
+     *
+     * The total Duration of the related Resource that has been used (this may be less than the total Duration of the Resource) (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @return \DateInterval
+     */
+    public function getDurationUsed()
+    {
+        return $this->durationUsed;
+    }
+
+    /**
+     * Sets a new durationUsed
+     *
+     * The total Duration of the related Resource that has been used (this may be less than the total Duration of the Resource) (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @param \DateInterval $durationUsed
+     * @return self
+     */
+    public function setDurationUsed(?\DateInterval $durationUsed = null)
+    {
+        $this->durationUsed = $durationUsed;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/TitleDisplayInformationType.php
+++ b/src/Entity/Ern42/TitleDisplayInformationType.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing TitleDisplayInformationType
+ *
+ * A Composite containing information on how a RecordCompany wishes Artist information to be presented to Consumers as part of the Title (and in addition to displaying the DisplayArtist information).
+ * XSD Type: TitleDisplayInformation
+ */
+class TitleDisplayInformationType
+{
+    /**
+     * The Language and script of the Information as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * A number indicating the order of the display artist name in a group of display artist names, to allow sequencing different display artists. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var int $sequenceNumber
+     */
+    private $sequenceNumber = null;
+
+    /**
+     * A Flag indicating whether the information is displayed in the Title of a Resource (=true) or not (=false).
+     *
+     * @var bool $isDisplayedInTitle
+     */
+    private $isDisplayedInTitle = null;
+
+    /**
+     * A Descriptor that precedes the display artist name when multiple display artist names are given.
+     *
+     * @var \DedexBundle\Entity\Ern42\PrefixType[] $prefix
+     */
+    private $prefix = [
+        
+    ];
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script of the Information as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script of the Information as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as sequenceNumber
+     *
+     * A number indicating the order of the display artist name in a group of display artist names, to allow sequencing different display artists. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return int
+     */
+    public function getSequenceNumber()
+    {
+        return $this->sequenceNumber;
+    }
+
+    /**
+     * Sets a new sequenceNumber
+     *
+     * A number indicating the order of the display artist name in a group of display artist names, to allow sequencing different display artists. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param int $sequenceNumber
+     * @return self
+     */
+    public function setSequenceNumber($sequenceNumber)
+    {
+        $this->sequenceNumber = $sequenceNumber;
+        return $this;
+    }
+
+    /**
+     * Gets as isDisplayedInTitle
+     *
+     * A Flag indicating whether the information is displayed in the Title of a Resource (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getIsDisplayedInTitle()
+    {
+        return $this->isDisplayedInTitle;
+    }
+
+    /**
+     * Sets a new isDisplayedInTitle
+     *
+     * A Flag indicating whether the information is displayed in the Title of a Resource (=true) or not (=false).
+     *
+     * @param bool $isDisplayedInTitle
+     * @return self
+     */
+    public function setIsDisplayedInTitle($isDisplayedInTitle)
+    {
+        $this->isDisplayedInTitle = $isDisplayedInTitle;
+        return $this;
+    }
+
+    /**
+     * Adds as prefix
+     *
+     * A Descriptor that precedes the display artist name when multiple display artist names are given.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\PrefixType $prefix
+     */
+    public function addToPrefix(\DedexBundle\Entity\Ern42\PrefixType $prefix)
+    {
+        $this->prefix[] = $prefix;
+        return $this;
+    }
+
+    /**
+     * isset prefix
+     *
+     * A Descriptor that precedes the display artist name when multiple display artist names are given.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetPrefix($index)
+    {
+        return isset($this->prefix[$index]);
+    }
+
+    /**
+     * unset prefix
+     *
+     * A Descriptor that precedes the display artist name when multiple display artist names are given.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetPrefix($index)
+    {
+        unset($this->prefix[$index]);
+    }
+
+    /**
+     * Gets as prefix
+     *
+     * A Descriptor that precedes the display artist name when multiple display artist names are given.
+     *
+     * @return \DedexBundle\Entity\Ern42\PrefixType[]
+     */
+    public function getPrefix()
+    {
+        return $this->prefix;
+    }
+
+    /**
+     * Sets a new prefix
+     *
+     * A Descriptor that precedes the display artist name when multiple display artist names are given.
+     *
+     * @param \DedexBundle\Entity\Ern42\PrefixType[] $prefix
+     * @return self
+     */
+    public function setPrefix(?array $prefix = null)
+    {
+        $this->prefix = $prefix;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/TitleType.php
+++ b/src/Entity/Ern42/TitleType.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing TitleType
+ *
+ * A Composite containing details of a Title.
+ * XSD Type: Title
+ */
+class TitleType
+{
+    /**
+     * The Language and script for the Elements of the Title as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * A Type of the Title which defines its origin or the function it fulfils in relation to a Creation. Note: A Title may fulfil more than one role. Example: 'Help' may be both the OriginalTitle and the DisplayTitle for the well-known Beatles song. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $titleType
+     */
+    private $titleType = null;
+
+    /**
+     * The text of the Title.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @var string $titleText
+     */
+    private $titleText = null;
+
+    /**
+     * A SubTitle of the Title, including Titles of Versions used to differentiate different versions of the same Title, as required by the GRid and ISRC ReferenceDescriptiveMetadataSets.
+     *
+     * @var string $subTitle
+     */
+    private $subTitle = null;
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the Elements of the Title as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the Elements of the Title as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as titleType
+     *
+     * A Type of the Title which defines its origin or the function it fulfils in relation to a Creation. Note: A Title may fulfil more than one role. Example: 'Help' may be both the OriginalTitle and the DisplayTitle for the well-known Beatles song. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getTitleType()
+    {
+        return $this->titleType;
+    }
+
+    /**
+     * Sets a new titleType
+     *
+     * A Type of the Title which defines its origin or the function it fulfils in relation to a Creation. Note: A Title may fulfil more than one role. Example: 'Help' may be both the OriginalTitle and the DisplayTitle for the well-known Beatles song. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $titleType
+     * @return self
+     */
+    public function setTitleType($titleType)
+    {
+        $this->titleType = $titleType;
+        return $this;
+    }
+
+    /**
+     * Gets as titleText
+     *
+     * The text of the Title.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return string
+     */
+    public function getTitleText()
+    {
+        return $this->titleText;
+    }
+
+    /**
+     * Sets a new titleText
+     *
+     * The text of the Title.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param string $titleText
+     * @return self
+     */
+    public function setTitleText($titleText)
+    {
+        $this->titleText = $titleText;
+        return $this;
+    }
+
+    /**
+     * Gets as subTitle
+     *
+     * A SubTitle of the Title, including Titles of Versions used to differentiate different versions of the same Title, as required by the GRid and ISRC ReferenceDescriptiveMetadataSets.
+     *
+     * @return string
+     */
+    public function getSubTitle()
+    {
+        return $this->subTitle;
+    }
+
+    /**
+     * Sets a new subTitle
+     *
+     * A SubTitle of the Title, including Titles of Versions used to differentiate different versions of the same Title, as required by the GRid and ISRC ReferenceDescriptiveMetadataSets.
+     *
+     * @param string $subTitle
+     * @return self
+     */
+    public function setSubTitle($subTitle)
+    {
+        $this->subTitle = $subTitle;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/TrackReleaseType.php
+++ b/src/Entity/Ern42/TrackReleaseType.php
@@ -1,0 +1,1042 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing TrackReleaseType
+ *
+ * A Composite containing details of a DDEX Release.
+ * XSD Type: TrackRelease
+ */
+class TrackReleaseType
+{
+    /**
+     * The Flag indicating whether the Release is a main one as defined in the relevant Profile Standard (=true) or not (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isMainRelease
+     */
+    private $isMainRelease = null;
+
+    /**
+     * The Identifier (specific to the Message) of the Release. Used to link the Release to one or more Deal(s). This is a LocalReleaseAnchor starting with the letter R.
+     *
+     * @var string $releaseReference
+     */
+    private $releaseReference = null;
+
+    /**
+     * A Composite containing details of ReleaseIds. If available, a GRid has to be used. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.
+     *
+     * @var \DedexBundle\Entity\Ern42\ReleaseIdType $releaseId
+     */
+    private $releaseId = null;
+
+    /**
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayTitleTextType[] $displayTitleText
+     */
+    private $displayTitleText = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayTitleType[] $displayTitle
+     */
+    private $displayTitle = [
+        
+    ];
+
+    /**
+     * A Composite containing details of an AdditionalTitle of the Release. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @var \DedexBundle\Entity\Ern42\AdditionalTitleType[] $additionalTitle
+     */
+    private $additionalTitle = [
+        
+    ];
+
+    /**
+     * A ReleaseResourceReference for the Release (specific to this Message). The LocalAnchorReference in this Composite is a xs:string starting with the letter A.
+     *
+     * @var string $releaseResourceReference
+     */
+    private $releaseResourceReference = null;
+
+    /**
+     * A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this Release. Example: an Image, Text or NonMusicalWorkVideo associated with a SoundRecording. This LocalAnchorReference is a xs:string starting with the letter A.
+     *
+     * @var \DedexBundle\Entity\Ern42\LinkedReleaseResourceReferenceType[] $linkedReleaseResourceReference
+     */
+    private $linkedReleaseResourceReference = [
+        
+    ];
+
+    /**
+     * A Reference for a label of the Release (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @var \DedexBundle\Entity\Ern42\ReleaseLabelReferenceWithPartyType[] $releaseLabelReference
+     */
+    private $releaseLabelReference = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Genre to which the Release belongs.
+     *
+     * @var \DedexBundle\Entity\Ern42\GenreWithTerritoryType[] $genre
+     */
+    private $genre = [
+        
+    ];
+
+    /**
+     * A Reference for a set of visibility dates (specific to this Message) that applies to this Release. This defines when the Release can be shown to Consumers, not when a Consumer can get access to the Release. This is a LocalVisibilityAnchorReference starting with the letter V.
+     *
+     * @var string $releaseVisibilityReference
+     */
+    private $releaseVisibilityReference = null;
+
+    /**
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to this Release.
+     *
+     * @var \DedexBundle\Entity\Ern42\RelatedReleaseType[] $relatedRelease
+     */
+    private $relatedRelease = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Resource which is related to this Release.
+     *
+     * @var \DedexBundle\Entity\Ern42\RelatedResourceType[] $relatedResource
+     */
+    private $relatedResource = [
+        
+    ];
+
+    /**
+     * A URL of a sub-site or channel in the DSP’s system, where the Release should be made available to Consumers.
+     *
+     * @var string $targetURL
+     */
+    private $targetURL = null;
+
+    /**
+     * A Composite containing details of a Description of the Release containing Keywords.
+     *
+     * @var \DedexBundle\Entity\Ern42\KeywordsWithTerritoryType[] $keywords
+     */
+    private $keywords = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Synopsis of the Release.
+     *
+     * @var \DedexBundle\Entity\Ern42\SynopsisWithTerritoryType[] $synopsis
+     */
+    private $synopsis = [
+        
+    ];
+
+    /**
+     * A Composite containing a Comment about the promotion and marketing of the Release.
+     *
+     * @var \DedexBundle\Entity\Ern42\MarketingCommentType[] $marketingComment
+     */
+    private $marketingComment = [
+        
+    ];
+
+    /**
+     * Gets as isMainRelease
+     *
+     * The Flag indicating whether the Release is a main one as defined in the relevant Profile Standard (=true) or not (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsMainRelease()
+    {
+        return $this->isMainRelease;
+    }
+
+    /**
+     * Sets a new isMainRelease
+     *
+     * The Flag indicating whether the Release is a main one as defined in the relevant Profile Standard (=true) or not (=false). This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isMainRelease
+     * @return self
+     */
+    public function setIsMainRelease($isMainRelease)
+    {
+        $this->isMainRelease = $isMainRelease;
+        return $this;
+    }
+
+    /**
+     * Gets as releaseReference
+     *
+     * The Identifier (specific to the Message) of the Release. Used to link the Release to one or more Deal(s). This is a LocalReleaseAnchor starting with the letter R.
+     *
+     * @return string
+     */
+    public function getReleaseReference()
+    {
+        return $this->releaseReference;
+    }
+
+    /**
+     * Sets a new releaseReference
+     *
+     * The Identifier (specific to the Message) of the Release. Used to link the Release to one or more Deal(s). This is a LocalReleaseAnchor starting with the letter R.
+     *
+     * @param string $releaseReference
+     * @return self
+     */
+    public function setReleaseReference($releaseReference)
+    {
+        $this->releaseReference = $releaseReference;
+        return $this;
+    }
+
+    /**
+     * Gets as releaseId
+     *
+     * A Composite containing details of ReleaseIds. If available, a GRid has to be used. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.
+     *
+     * @return \DedexBundle\Entity\Ern42\ReleaseIdType
+     */
+    public function getReleaseId()
+    {
+        return $this->releaseId;
+    }
+
+    /**
+     * Sets a new releaseId
+     *
+     * A Composite containing details of ReleaseIds. If available, a GRid has to be used. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.
+     *
+     * @param \DedexBundle\Entity\Ern42\ReleaseIdType $releaseId
+     * @return self
+     */
+    public function setReleaseId(\DedexBundle\Entity\Ern42\ReleaseIdType $releaseId)
+    {
+        $this->releaseId = $releaseId;
+        return $this;
+    }
+
+    /**
+     * Adds as displayTitleText
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleTextType $displayTitleText
+     */
+    public function addToDisplayTitleText(\DedexBundle\Entity\Ern42\DisplayTitleTextType $displayTitleText)
+    {
+        $this->displayTitleText[] = $displayTitleText;
+        return $this;
+    }
+
+    /**
+     * isset displayTitleText
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayTitleText($index)
+    {
+        return isset($this->displayTitleText[$index]);
+    }
+
+    /**
+     * unset displayTitleText
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayTitleText($index)
+    {
+        unset($this->displayTitleText[$index]);
+    }
+
+    /**
+     * Gets as displayTitleText
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayTitleTextType[]
+     */
+    public function getDisplayTitleText()
+    {
+        return $this->displayTitleText;
+    }
+
+    /**
+     * Sets a new displayTitleText
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleTextType[] $displayTitleText
+     * @return self
+     */
+    public function setDisplayTitleText(?array $displayTitleText = null)
+    {
+        $this->displayTitleText = $displayTitleText;
+        return $this;
+    }
+
+    /**
+     * Adds as displayTitle
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleType $displayTitle
+     */
+    public function addToDisplayTitle(\DedexBundle\Entity\Ern42\DisplayTitleType $displayTitle)
+    {
+        $this->displayTitle[] = $displayTitle;
+        return $this;
+    }
+
+    /**
+     * isset displayTitle
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayTitle($index)
+    {
+        return isset($this->displayTitle[$index]);
+    }
+
+    /**
+     * unset displayTitle
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayTitle($index)
+    {
+        unset($this->displayTitle[$index]);
+    }
+
+    /**
+     * Gets as displayTitle
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayTitleType[]
+     */
+    public function getDisplayTitle()
+    {
+        return $this->displayTitle;
+    }
+
+    /**
+     * Sets a new displayTitle
+     *
+     * A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleType[] $displayTitle
+     * @return self
+     */
+    public function setDisplayTitle(?array $displayTitle = null)
+    {
+        $this->displayTitle = $displayTitle;
+        return $this;
+    }
+
+    /**
+     * Adds as additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Release. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\AdditionalTitleType $additionalTitle
+     */
+    public function addToAdditionalTitle(\DedexBundle\Entity\Ern42\AdditionalTitleType $additionalTitle)
+    {
+        $this->additionalTitle[] = $additionalTitle;
+        return $this;
+    }
+
+    /**
+     * isset additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Release. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetAdditionalTitle($index)
+    {
+        return isset($this->additionalTitle[$index]);
+    }
+
+    /**
+     * unset additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Release. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetAdditionalTitle($index)
+    {
+        unset($this->additionalTitle[$index]);
+    }
+
+    /**
+     * Gets as additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Release. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return \DedexBundle\Entity\Ern42\AdditionalTitleType[]
+     */
+    public function getAdditionalTitle()
+    {
+        return $this->additionalTitle;
+    }
+
+    /**
+     * Sets a new additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Release. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param \DedexBundle\Entity\Ern42\AdditionalTitleType[] $additionalTitle
+     * @return self
+     */
+    public function setAdditionalTitle(?array $additionalTitle = null)
+    {
+        $this->additionalTitle = $additionalTitle;
+        return $this;
+    }
+
+    /**
+     * Gets as releaseResourceReference
+     *
+     * A ReleaseResourceReference for the Release (specific to this Message). The LocalAnchorReference in this Composite is a xs:string starting with the letter A.
+     *
+     * @return string
+     */
+    public function getReleaseResourceReference()
+    {
+        return $this->releaseResourceReference;
+    }
+
+    /**
+     * Sets a new releaseResourceReference
+     *
+     * A ReleaseResourceReference for the Release (specific to this Message). The LocalAnchorReference in this Composite is a xs:string starting with the letter A.
+     *
+     * @param string $releaseResourceReference
+     * @return self
+     */
+    public function setReleaseResourceReference($releaseResourceReference)
+    {
+        $this->releaseResourceReference = $releaseResourceReference;
+        return $this;
+    }
+
+    /**
+     * Adds as linkedReleaseResourceReference
+     *
+     * A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this Release. Example: an Image, Text or NonMusicalWorkVideo associated with a SoundRecording. This LocalAnchorReference is a xs:string starting with the letter A.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\LinkedReleaseResourceReferenceType $linkedReleaseResourceReference
+     */
+    public function addToLinkedReleaseResourceReference(\DedexBundle\Entity\Ern42\LinkedReleaseResourceReferenceType $linkedReleaseResourceReference)
+    {
+        $this->linkedReleaseResourceReference[] = $linkedReleaseResourceReference;
+        return $this;
+    }
+
+    /**
+     * isset linkedReleaseResourceReference
+     *
+     * A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this Release. Example: an Image, Text or NonMusicalWorkVideo associated with a SoundRecording. This LocalAnchorReference is a xs:string starting with the letter A.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetLinkedReleaseResourceReference($index)
+    {
+        return isset($this->linkedReleaseResourceReference[$index]);
+    }
+
+    /**
+     * unset linkedReleaseResourceReference
+     *
+     * A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this Release. Example: an Image, Text or NonMusicalWorkVideo associated with a SoundRecording. This LocalAnchorReference is a xs:string starting with the letter A.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetLinkedReleaseResourceReference($index)
+    {
+        unset($this->linkedReleaseResourceReference[$index]);
+    }
+
+    /**
+     * Gets as linkedReleaseResourceReference
+     *
+     * A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this Release. Example: an Image, Text or NonMusicalWorkVideo associated with a SoundRecording. This LocalAnchorReference is a xs:string starting with the letter A.
+     *
+     * @return \DedexBundle\Entity\Ern42\LinkedReleaseResourceReferenceType[]
+     */
+    public function getLinkedReleaseResourceReference()
+    {
+        return $this->linkedReleaseResourceReference;
+    }
+
+    /**
+     * Sets a new linkedReleaseResourceReference
+     *
+     * A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this Release. Example: an Image, Text or NonMusicalWorkVideo associated with a SoundRecording. This LocalAnchorReference is a xs:string starting with the letter A.
+     *
+     * @param \DedexBundle\Entity\Ern42\LinkedReleaseResourceReferenceType[] $linkedReleaseResourceReference
+     * @return self
+     */
+    public function setLinkedReleaseResourceReference(?array $linkedReleaseResourceReference = null)
+    {
+        $this->linkedReleaseResourceReference = $linkedReleaseResourceReference;
+        return $this;
+    }
+
+    /**
+     * Adds as releaseLabelReference
+     *
+     * A Reference for a label of the Release (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ReleaseLabelReferenceWithPartyType $releaseLabelReference
+     */
+    public function addToReleaseLabelReference(\DedexBundle\Entity\Ern42\ReleaseLabelReferenceWithPartyType $releaseLabelReference)
+    {
+        $this->releaseLabelReference[] = $releaseLabelReference;
+        return $this;
+    }
+
+    /**
+     * isset releaseLabelReference
+     *
+     * A Reference for a label of the Release (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetReleaseLabelReference($index)
+    {
+        return isset($this->releaseLabelReference[$index]);
+    }
+
+    /**
+     * unset releaseLabelReference
+     *
+     * A Reference for a label of the Release (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetReleaseLabelReference($index)
+    {
+        unset($this->releaseLabelReference[$index]);
+    }
+
+    /**
+     * Gets as releaseLabelReference
+     *
+     * A Reference for a label of the Release (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @return \DedexBundle\Entity\Ern42\ReleaseLabelReferenceWithPartyType[]
+     */
+    public function getReleaseLabelReference()
+    {
+        return $this->releaseLabelReference;
+    }
+
+    /**
+     * Sets a new releaseLabelReference
+     *
+     * A Reference for a label of the Release (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @param \DedexBundle\Entity\Ern42\ReleaseLabelReferenceWithPartyType[] $releaseLabelReference
+     * @return self
+     */
+    public function setReleaseLabelReference(array $releaseLabelReference)
+    {
+        $this->releaseLabelReference = $releaseLabelReference;
+        return $this;
+    }
+
+    /**
+     * Adds as genre
+     *
+     * A Composite containing details of a Genre to which the Release belongs.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\GenreWithTerritoryType $genre
+     */
+    public function addToGenre(\DedexBundle\Entity\Ern42\GenreWithTerritoryType $genre)
+    {
+        $this->genre[] = $genre;
+        return $this;
+    }
+
+    /**
+     * isset genre
+     *
+     * A Composite containing details of a Genre to which the Release belongs.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetGenre($index)
+    {
+        return isset($this->genre[$index]);
+    }
+
+    /**
+     * unset genre
+     *
+     * A Composite containing details of a Genre to which the Release belongs.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetGenre($index)
+    {
+        unset($this->genre[$index]);
+    }
+
+    /**
+     * Gets as genre
+     *
+     * A Composite containing details of a Genre to which the Release belongs.
+     *
+     * @return \DedexBundle\Entity\Ern42\GenreWithTerritoryType[]
+     */
+    public function getGenre()
+    {
+        return $this->genre;
+    }
+
+    /**
+     * Sets a new genre
+     *
+     * A Composite containing details of a Genre to which the Release belongs.
+     *
+     * @param \DedexBundle\Entity\Ern42\GenreWithTerritoryType[] $genre
+     * @return self
+     */
+    public function setGenre(array $genre)
+    {
+        $this->genre = $genre;
+        return $this;
+    }
+
+    /**
+     * Gets as releaseVisibilityReference
+     *
+     * A Reference for a set of visibility dates (specific to this Message) that applies to this Release. This defines when the Release can be shown to Consumers, not when a Consumer can get access to the Release. This is a LocalVisibilityAnchorReference starting with the letter V.
+     *
+     * @return string
+     */
+    public function getReleaseVisibilityReference()
+    {
+        return $this->releaseVisibilityReference;
+    }
+
+    /**
+     * Sets a new releaseVisibilityReference
+     *
+     * A Reference for a set of visibility dates (specific to this Message) that applies to this Release. This defines when the Release can be shown to Consumers, not when a Consumer can get access to the Release. This is a LocalVisibilityAnchorReference starting with the letter V.
+     *
+     * @param string $releaseVisibilityReference
+     * @return self
+     */
+    public function setReleaseVisibilityReference($releaseVisibilityReference)
+    {
+        $this->releaseVisibilityReference = $releaseVisibilityReference;
+        return $this;
+    }
+
+    /**
+     * Adds as relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to this Release.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\RelatedReleaseType $relatedRelease
+     */
+    public function addToRelatedRelease(\DedexBundle\Entity\Ern42\RelatedReleaseType $relatedRelease)
+    {
+        $this->relatedRelease[] = $relatedRelease;
+        return $this;
+    }
+
+    /**
+     * isset relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to this Release.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRelatedRelease($index)
+    {
+        return isset($this->relatedRelease[$index]);
+    }
+
+    /**
+     * unset relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to this Release.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRelatedRelease($index)
+    {
+        unset($this->relatedRelease[$index]);
+    }
+
+    /**
+     * Gets as relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to this Release.
+     *
+     * @return \DedexBundle\Entity\Ern42\RelatedReleaseType[]
+     */
+    public function getRelatedRelease()
+    {
+        return $this->relatedRelease;
+    }
+
+    /**
+     * Sets a new relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to this Release.
+     *
+     * @param \DedexBundle\Entity\Ern42\RelatedReleaseType[] $relatedRelease
+     * @return self
+     */
+    public function setRelatedRelease(?array $relatedRelease = null)
+    {
+        $this->relatedRelease = $relatedRelease;
+        return $this;
+    }
+
+    /**
+     * Adds as relatedResource
+     *
+     * A Composite containing details of a Resource which is related to this Release.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\RelatedResourceType $relatedResource
+     */
+    public function addToRelatedResource(\DedexBundle\Entity\Ern42\RelatedResourceType $relatedResource)
+    {
+        $this->relatedResource[] = $relatedResource;
+        return $this;
+    }
+
+    /**
+     * isset relatedResource
+     *
+     * A Composite containing details of a Resource which is related to this Release.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRelatedResource($index)
+    {
+        return isset($this->relatedResource[$index]);
+    }
+
+    /**
+     * unset relatedResource
+     *
+     * A Composite containing details of a Resource which is related to this Release.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRelatedResource($index)
+    {
+        unset($this->relatedResource[$index]);
+    }
+
+    /**
+     * Gets as relatedResource
+     *
+     * A Composite containing details of a Resource which is related to this Release.
+     *
+     * @return \DedexBundle\Entity\Ern42\RelatedResourceType[]
+     */
+    public function getRelatedResource()
+    {
+        return $this->relatedResource;
+    }
+
+    /**
+     * Sets a new relatedResource
+     *
+     * A Composite containing details of a Resource which is related to this Release.
+     *
+     * @param \DedexBundle\Entity\Ern42\RelatedResourceType[] $relatedResource
+     * @return self
+     */
+    public function setRelatedResource(?array $relatedResource = null)
+    {
+        $this->relatedResource = $relatedResource;
+        return $this;
+    }
+
+    /**
+     * Gets as targetURL
+     *
+     * A URL of a sub-site or channel in the DSP’s system, where the Release should be made available to Consumers.
+     *
+     * @return string
+     */
+    public function getTargetURL()
+    {
+        return $this->targetURL;
+    }
+
+    /**
+     * Sets a new targetURL
+     *
+     * A URL of a sub-site or channel in the DSP’s system, where the Release should be made available to Consumers.
+     *
+     * @param string $targetURL
+     * @return self
+     */
+    public function setTargetURL($targetURL)
+    {
+        $this->targetURL = $targetURL;
+        return $this;
+    }
+
+    /**
+     * Adds as keywords
+     *
+     * A Composite containing details of a Description of the Release containing Keywords.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\KeywordsWithTerritoryType $keywords
+     */
+    public function addToKeywords(\DedexBundle\Entity\Ern42\KeywordsWithTerritoryType $keywords)
+    {
+        $this->keywords[] = $keywords;
+        return $this;
+    }
+
+    /**
+     * isset keywords
+     *
+     * A Composite containing details of a Description of the Release containing Keywords.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetKeywords($index)
+    {
+        return isset($this->keywords[$index]);
+    }
+
+    /**
+     * unset keywords
+     *
+     * A Composite containing details of a Description of the Release containing Keywords.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetKeywords($index)
+    {
+        unset($this->keywords[$index]);
+    }
+
+    /**
+     * Gets as keywords
+     *
+     * A Composite containing details of a Description of the Release containing Keywords.
+     *
+     * @return \DedexBundle\Entity\Ern42\KeywordsWithTerritoryType[]
+     */
+    public function getKeywords()
+    {
+        return $this->keywords;
+    }
+
+    /**
+     * Sets a new keywords
+     *
+     * A Composite containing details of a Description of the Release containing Keywords.
+     *
+     * @param \DedexBundle\Entity\Ern42\KeywordsWithTerritoryType[] $keywords
+     * @return self
+     */
+    public function setKeywords(?array $keywords = null)
+    {
+        $this->keywords = $keywords;
+        return $this;
+    }
+
+    /**
+     * Adds as synopsis
+     *
+     * A Composite containing details of a Synopsis of the Release.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\SynopsisWithTerritoryType $synopsis
+     */
+    public function addToSynopsis(\DedexBundle\Entity\Ern42\SynopsisWithTerritoryType $synopsis)
+    {
+        $this->synopsis[] = $synopsis;
+        return $this;
+    }
+
+    /**
+     * isset synopsis
+     *
+     * A Composite containing details of a Synopsis of the Release.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetSynopsis($index)
+    {
+        return isset($this->synopsis[$index]);
+    }
+
+    /**
+     * unset synopsis
+     *
+     * A Composite containing details of a Synopsis of the Release.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetSynopsis($index)
+    {
+        unset($this->synopsis[$index]);
+    }
+
+    /**
+     * Gets as synopsis
+     *
+     * A Composite containing details of a Synopsis of the Release.
+     *
+     * @return \DedexBundle\Entity\Ern42\SynopsisWithTerritoryType[]
+     */
+    public function getSynopsis()
+    {
+        return $this->synopsis;
+    }
+
+    /**
+     * Sets a new synopsis
+     *
+     * A Composite containing details of a Synopsis of the Release.
+     *
+     * @param \DedexBundle\Entity\Ern42\SynopsisWithTerritoryType[] $synopsis
+     * @return self
+     */
+    public function setSynopsis(?array $synopsis = null)
+    {
+        $this->synopsis = $synopsis;
+        return $this;
+    }
+
+    /**
+     * Adds as marketingComment
+     *
+     * A Composite containing a Comment about the promotion and marketing of the Release.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\MarketingCommentType $marketingComment
+     */
+    public function addToMarketingComment(\DedexBundle\Entity\Ern42\MarketingCommentType $marketingComment)
+    {
+        $this->marketingComment[] = $marketingComment;
+        return $this;
+    }
+
+    /**
+     * isset marketingComment
+     *
+     * A Composite containing a Comment about the promotion and marketing of the Release.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetMarketingComment($index)
+    {
+        return isset($this->marketingComment[$index]);
+    }
+
+    /**
+     * unset marketingComment
+     *
+     * A Composite containing a Comment about the promotion and marketing of the Release.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetMarketingComment($index)
+    {
+        unset($this->marketingComment[$index]);
+    }
+
+    /**
+     * Gets as marketingComment
+     *
+     * A Composite containing a Comment about the promotion and marketing of the Release.
+     *
+     * @return \DedexBundle\Entity\Ern42\MarketingCommentType[]
+     */
+    public function getMarketingComment()
+    {
+        return $this->marketingComment;
+    }
+
+    /**
+     * Sets a new marketingComment
+     *
+     * A Composite containing a Comment about the promotion and marketing of the Release.
+     *
+     * @param \DedexBundle\Entity\Ern42\MarketingCommentType[] $marketingComment
+     * @return self
+     */
+    public function setMarketingComment(?array $marketingComment = null)
+    {
+        $this->marketingComment = $marketingComment;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/TrackReleaseVisibilityType.php
+++ b/src/Entity/Ern42/TrackReleaseVisibilityType.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing TrackReleaseVisibilityType
+ *
+ * A Composite containing details of a Date specifying when a TrackRelease can be shown to Consumers.
+ * XSD Type: TrackReleaseVisibility
+ */
+class TrackReleaseVisibilityType
+{
+    /**
+     * The Identifier (specific to the Message) of the visibility date. This is a LocalVisibilityAnchor starting with the letter V.
+     *
+     * @var string $visibilityReference
+     */
+    private $visibilityReference = null;
+
+    /**
+     * A DateTime on which the Track list is made first available for display (it overrides the generic ReleaseDisplayStartDate if supplied). If no TrackListingPreviewStartDateTime is provided, the StartDate for the Deal is used instead. The TrackListingPreviewStartDateTime shall not be later than the StartDate of the Deal allowing the general availability of the referenced Release. This element is not applicable on Track Releases. This is a string in ISO 8601 format: YYYY-MM-DDThh:mm:ss.
+     *
+     * @var \DateTime $trackListingPreviewStartDateTime
+     */
+    private $trackListingPreviewStartDateTime = null;
+
+    /**
+     * A DateTime on which an audio or video clip is made first available for display (it overrides the generic ReleaseDisplayStartDate if supplied). If no ClipPreviewStartDateTime is provided, the StartDate for the Deal is used instead. The ClipPreviewStartDateTime shall not be later than the StartDate of the Deal allowing the general availability of the referenced Release. This is a string in ISO 8601 format: YYYY-MM-DDThh:mm:ss.
+     *
+     * @var \DateTime $clipPreviewStartDateTime
+     */
+    private $clipPreviewStartDateTime = null;
+
+    /**
+     * Gets as visibilityReference
+     *
+     * The Identifier (specific to the Message) of the visibility date. This is a LocalVisibilityAnchor starting with the letter V.
+     *
+     * @return string
+     */
+    public function getVisibilityReference()
+    {
+        return $this->visibilityReference;
+    }
+
+    /**
+     * Sets a new visibilityReference
+     *
+     * The Identifier (specific to the Message) of the visibility date. This is a LocalVisibilityAnchor starting with the letter V.
+     *
+     * @param string $visibilityReference
+     * @return self
+     */
+    public function setVisibilityReference($visibilityReference)
+    {
+        $this->visibilityReference = $visibilityReference;
+        return $this;
+    }
+
+    /**
+     * Gets as trackListingPreviewStartDateTime
+     *
+     * A DateTime on which the Track list is made first available for display (it overrides the generic ReleaseDisplayStartDate if supplied). If no TrackListingPreviewStartDateTime is provided, the StartDate for the Deal is used instead. The TrackListingPreviewStartDateTime shall not be later than the StartDate of the Deal allowing the general availability of the referenced Release. This element is not applicable on Track Releases. This is a string in ISO 8601 format: YYYY-MM-DDThh:mm:ss.
+     *
+     * @return \DateTime
+     */
+    public function getTrackListingPreviewStartDateTime()
+    {
+        return $this->trackListingPreviewStartDateTime;
+    }
+
+    /**
+     * Sets a new trackListingPreviewStartDateTime
+     *
+     * A DateTime on which the Track list is made first available for display (it overrides the generic ReleaseDisplayStartDate if supplied). If no TrackListingPreviewStartDateTime is provided, the StartDate for the Deal is used instead. The TrackListingPreviewStartDateTime shall not be later than the StartDate of the Deal allowing the general availability of the referenced Release. This element is not applicable on Track Releases. This is a string in ISO 8601 format: YYYY-MM-DDThh:mm:ss.
+     *
+     * @param \DateTime $trackListingPreviewStartDateTime
+     * @return self
+     */
+    public function setTrackListingPreviewStartDateTime(\DateTime $trackListingPreviewStartDateTime)
+    {
+        $this->trackListingPreviewStartDateTime = $trackListingPreviewStartDateTime;
+        return $this;
+    }
+
+    /**
+     * Gets as clipPreviewStartDateTime
+     *
+     * A DateTime on which an audio or video clip is made first available for display (it overrides the generic ReleaseDisplayStartDate if supplied). If no ClipPreviewStartDateTime is provided, the StartDate for the Deal is used instead. The ClipPreviewStartDateTime shall not be later than the StartDate of the Deal allowing the general availability of the referenced Release. This is a string in ISO 8601 format: YYYY-MM-DDThh:mm:ss.
+     *
+     * @return \DateTime
+     */
+    public function getClipPreviewStartDateTime()
+    {
+        return $this->clipPreviewStartDateTime;
+    }
+
+    /**
+     * Sets a new clipPreviewStartDateTime
+     *
+     * A DateTime on which an audio or video clip is made first available for display (it overrides the generic ReleaseDisplayStartDate if supplied). If no ClipPreviewStartDateTime is provided, the StartDate for the Deal is used instead. The ClipPreviewStartDateTime shall not be later than the StartDate of the Deal allowing the general availability of the referenced Release. This is a string in ISO 8601 format: YYYY-MM-DDThh:mm:ss.
+     *
+     * @param \DateTime $clipPreviewStartDateTime
+     * @return self
+     */
+    public function setClipPreviewStartDateTime(?\DateTime $clipPreviewStartDateTime = null)
+    {
+        $this->clipPreviewStartDateTime = $clipPreviewStartDateTime;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/UseTypeType.php
+++ b/src/Entity/Ern42/UseTypeType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing UseTypeType
+ *
+ * A Composite containing details of a UseType.
+ * XSD Type: UseType
+ */
+class UseTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the UseType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the UseType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the UseType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the UseType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the UseType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the UseType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/UserInterfaceTypeType.php
+++ b/src/Entity/Ern42/UserInterfaceTypeType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing UserInterfaceTypeType
+ *
+ * A Composite containing details of a UserInterfaceType.
+ * XSD Type: UserInterfaceType
+ */
+class UserInterfaceTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the UserInterfaceType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the UserInterfaceType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the UserInterfaceType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the UserInterfaceType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the UserInterfaceType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the UserInterfaceType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/ValidityPeriodType.php
+++ b/src/Entity/Ern42/ValidityPeriodType.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing ValidityPeriodType
+ *
+ * A Composite containing details about a ValidityPeriod of Time. Periods are typically describedby at least a StartDate or EndDate where the StartDate and EndDate are included in the Period. Thus a one-day period can be described by using the same date in the StartDate and EndDate.
+ * XSD Type: ValidityPeriod
+ */
+class ValidityPeriodType
+{
+    /**
+     * A Composite containing details of the Date and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DD). The StartDate must be no later than the EndDate if both are provided.
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateType $startDate
+     */
+    private $startDate = null;
+
+    /**
+     * A Composite containing details of the Date and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DD). The EndDate must not be earlier than the StartDate if both are provided.
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateType $endDate
+     */
+    private $endDate = null;
+
+    /**
+     * Gets as startDate
+     *
+     * A Composite containing details of the Date and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DD). The StartDate must be no later than the EndDate if both are provided.
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateType
+     */
+    public function getStartDate()
+    {
+        return $this->startDate;
+    }
+
+    /**
+     * Sets a new startDate
+     *
+     * A Composite containing details of the Date and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DD). The StartDate must be no later than the EndDate if both are provided.
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateType $startDate
+     * @return self
+     */
+    public function setStartDate(?\DedexBundle\Entity\Ern42\EventDateType $startDate = null)
+    {
+        $this->startDate = $startDate;
+        return $this;
+    }
+
+    /**
+     * Gets as endDate
+     *
+     * A Composite containing details of the Date and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DD). The EndDate must not be earlier than the StartDate if both are provided.
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateType
+     */
+    public function getEndDate()
+    {
+        return $this->endDate;
+    }
+
+    /**
+     * Sets a new endDate
+     *
+     * A Composite containing details of the Date and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DD). The EndDate must not be earlier than the StartDate if both are provided.
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateType $endDate
+     * @return self
+     */
+    public function setEndDate(?\DedexBundle\Entity\Ern42\EventDateType $endDate = null)
+    {
+        $this->endDate = $endDate;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/VenueType.php
+++ b/src/Entity/Ern42/VenueType.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing VenueType
+ *
+ * A Composite containing details of a venue.
+ * XSD Type: Venue
+ */
+class VenueType
+{
+    /**
+     * The Name of the venue.
+     *
+     * @var string $venueName
+     */
+    private $venueName = null;
+
+    /**
+     * The Address of the venue. The level of description may be more or less granular, possibly including only the name of the city.
+     *
+     * @var string $venueAddress
+     */
+    private $venueAddress = null;
+
+    /**
+     * A Territory of the VenueAddress. The use of ISO TerritoryCodes is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @var \DedexBundle\Entity\Ern42\AllTerritoryCodeType $territoryCode
+     */
+    private $territoryCode = null;
+
+    /**
+     * An UN/Locode of the venue.
+     *
+     * @var string $locationCode
+     */
+    private $locationCode = null;
+
+    /**
+     * A specific studio of the venue where a Session took place.
+     *
+     * @var string $venueRoom
+     */
+    private $venueRoom = null;
+
+    /**
+     * Gets as venueName
+     *
+     * The Name of the venue.
+     *
+     * @return string
+     */
+    public function getVenueName()
+    {
+        return $this->venueName;
+    }
+
+    /**
+     * Sets a new venueName
+     *
+     * The Name of the venue.
+     *
+     * @param string $venueName
+     * @return self
+     */
+    public function setVenueName($venueName)
+    {
+        $this->venueName = $venueName;
+        return $this;
+    }
+
+    /**
+     * Gets as venueAddress
+     *
+     * The Address of the venue. The level of description may be more or less granular, possibly including only the name of the city.
+     *
+     * @return string
+     */
+    public function getVenueAddress()
+    {
+        return $this->venueAddress;
+    }
+
+    /**
+     * Sets a new venueAddress
+     *
+     * The Address of the venue. The level of description may be more or less granular, possibly including only the name of the city.
+     *
+     * @param string $venueAddress
+     * @return self
+     */
+    public function setVenueAddress($venueAddress)
+    {
+        $this->venueAddress = $venueAddress;
+        return $this;
+    }
+
+    /**
+     * Gets as territoryCode
+     *
+     * A Territory of the VenueAddress. The use of ISO TerritoryCodes is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @return \DedexBundle\Entity\Ern42\AllTerritoryCodeType
+     */
+    public function getTerritoryCode()
+    {
+        return $this->territoryCode;
+    }
+
+    /**
+     * Sets a new territoryCode
+     *
+     * A Territory of the VenueAddress. The use of ISO TerritoryCodes is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.
+     *
+     * @param \DedexBundle\Entity\Ern42\AllTerritoryCodeType $territoryCode
+     * @return self
+     */
+    public function setTerritoryCode(?\DedexBundle\Entity\Ern42\AllTerritoryCodeType $territoryCode = null)
+    {
+        $this->territoryCode = $territoryCode;
+        return $this;
+    }
+
+    /**
+     * Gets as locationCode
+     *
+     * An UN/Locode of the venue.
+     *
+     * @return string
+     */
+    public function getLocationCode()
+    {
+        return $this->locationCode;
+    }
+
+    /**
+     * Sets a new locationCode
+     *
+     * An UN/Locode of the venue.
+     *
+     * @param string $locationCode
+     * @return self
+     */
+    public function setLocationCode($locationCode)
+    {
+        $this->locationCode = $locationCode;
+        return $this;
+    }
+
+    /**
+     * Gets as venueRoom
+     *
+     * A specific studio of the venue where a Session took place.
+     *
+     * @return string
+     */
+    public function getVenueRoom()
+    {
+        return $this->venueRoom;
+    }
+
+    /**
+     * Sets a new venueRoom
+     *
+     * A specific studio of the venue where a Session took place.
+     *
+     * @param string $venueRoom
+     * @return self
+     */
+    public function setVenueRoom($venueRoom)
+    {
+        $this->venueRoom = $venueRoom;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/VersionTypeType.php
+++ b/src/Entity/Ern42/VersionTypeType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing VersionTypeType
+ *
+ * A Composite containing details of a VersionType.
+ * XSD Type: VersionType
+ */
+class VersionTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the VersionType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the VersionType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the VersionType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the VersionType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the VersionType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the VersionType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/VideoCodecTypeType.php
+++ b/src/Entity/Ern42/VideoCodecTypeType.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing VideoCodecTypeType
+ *
+ * A Composite containing details of a VideoCodecType.
+ * XSD Type: VideoCodecType
+ */
+class VideoCodecTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Identifier of the Version of the VideoCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $version
+     */
+    private $version = null;
+
+    /**
+     * The Namespace of the VideoCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the VideoCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as version
+     *
+     * The Identifier of the Version of the VideoCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getVersion()
+    {
+        return $this->version;
+    }
+
+    /**
+     * Sets a new version
+     *
+     * The Identifier of the Version of the VideoCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $version
+     * @return self
+     */
+    public function setVersion($version)
+    {
+        $this->version = $version;
+        return $this;
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the VideoCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the VideoCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the VideoCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the VideoCodecType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/VideoDefinitionTypeType.php
+++ b/src/Entity/Ern42/VideoDefinitionTypeType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing VideoDefinitionTypeType
+ *
+ * A Composite containing details of a VideoDefinitionType.
+ * XSD Type: VideoDefinitionType
+ */
+class VideoDefinitionTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the VideoDefinitionType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the VideoDefinitionType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the VideoDefinitionType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the VideoDefinitionType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the VideoDefinitionType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the VideoDefinitionType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/VideoIdType.php
+++ b/src/Entity/Ern42/VideoIdType.php
@@ -1,0 +1,328 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing VideoIdType
+ *
+ * A Composite containing details of Identifiers of a Video.
+ * XSD Type: VideoId
+ */
+class VideoIdType
+{
+    /**
+     * The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.
+     *
+     * @var bool $isReplaced
+     */
+    private $isReplaced = null;
+
+    /**
+     * The ISRC (International Standard Recording Code as defined in ISO 3901) for the Video. An ISRC comprises four parts: two characters, followed by three alphanumeric characters, then two digits and five digits. DDEX will enforce the syntax [a-zA-Z]{2}[a-zA-Z0-9]{3}[0-9]{7} using XML Schema in the future.
+     *
+     * @var string $iSRC
+     */
+    private $iSRC = null;
+
+    /**
+     * The ISAN (International Standard Audiovisual Number as defined in ISO 15706) for the Video. An ISAN comprises four blocks of four hexadecimal charaters followed by a check character. DDEX will enforce the syntax [A-F0-9]{12} using XML Schema in the future.
+     *
+     * @var string $iSAN
+     */
+    private $iSAN = null;
+
+    /**
+     * The V-ISAN (Version Identifier of a International Standard Audiovisual Number as defined in ISO 15706-2) for the Video. A V-ISAN comprises four blocks of four hexadecimal charaters followed by a check character, followed by two further blocks of four hexadecimal characters, followed by a further check character. DDEX will enforce the syntax [A-F0-9]{24} using XML Schema in the future.
+     *
+     * @var string $vISAN
+     */
+    private $vISAN = null;
+
+    /**
+     * A Composite containing details of the CatalogNumber of the Video.
+     *
+     * @var \DedexBundle\Entity\Ern42\CatalogNumberType $catalogNumber
+     */
+    private $catalogNumber = null;
+
+    /**
+     * A Composite containing details of a ProprietaryIdentifier of the Video (usually one per society involved in the messaging).
+     *
+     * @var \DedexBundle\Entity\Ern42\ProprietaryIdType[] $proprietaryId
+     */
+    private $proprietaryId = [
+        
+    ];
+
+    /**
+     * An Identifier of the Video assigned by the Entertainment Identifier Registry Association (EIDR).
+     *
+     * @var string[] $eIDR
+     */
+    private $eIDR = [
+        
+    ];
+
+    /**
+     * Gets as isReplaced
+     *
+     * The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.
+     *
+     * @return bool
+     */
+    public function getIsReplaced()
+    {
+        return $this->isReplaced;
+    }
+
+    /**
+     * Sets a new isReplaced
+     *
+     * The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.
+     *
+     * @param bool $isReplaced
+     * @return self
+     */
+    public function setIsReplaced($isReplaced)
+    {
+        $this->isReplaced = $isReplaced;
+        return $this;
+    }
+
+    /**
+     * Gets as iSRC
+     *
+     * The ISRC (International Standard Recording Code as defined in ISO 3901) for the Video. An ISRC comprises four parts: two characters, followed by three alphanumeric characters, then two digits and five digits. DDEX will enforce the syntax [a-zA-Z]{2}[a-zA-Z0-9]{3}[0-9]{7} using XML Schema in the future.
+     *
+     * @return string
+     */
+    public function getISRC()
+    {
+        return $this->iSRC;
+    }
+
+    /**
+     * Sets a new iSRC
+     *
+     * The ISRC (International Standard Recording Code as defined in ISO 3901) for the Video. An ISRC comprises four parts: two characters, followed by three alphanumeric characters, then two digits and five digits. DDEX will enforce the syntax [a-zA-Z]{2}[a-zA-Z0-9]{3}[0-9]{7} using XML Schema in the future.
+     *
+     * @param string $iSRC
+     * @return self
+     */
+    public function setISRC($iSRC)
+    {
+        $this->iSRC = $iSRC;
+        return $this;
+    }
+
+    /**
+     * Gets as iSAN
+     *
+     * The ISAN (International Standard Audiovisual Number as defined in ISO 15706) for the Video. An ISAN comprises four blocks of four hexadecimal charaters followed by a check character. DDEX will enforce the syntax [A-F0-9]{12} using XML Schema in the future.
+     *
+     * @return string
+     */
+    public function getISAN()
+    {
+        return $this->iSAN;
+    }
+
+    /**
+     * Sets a new iSAN
+     *
+     * The ISAN (International Standard Audiovisual Number as defined in ISO 15706) for the Video. An ISAN comprises four blocks of four hexadecimal charaters followed by a check character. DDEX will enforce the syntax [A-F0-9]{12} using XML Schema in the future.
+     *
+     * @param string $iSAN
+     * @return self
+     */
+    public function setISAN($iSAN)
+    {
+        $this->iSAN = $iSAN;
+        return $this;
+    }
+
+    /**
+     * Gets as vISAN
+     *
+     * The V-ISAN (Version Identifier of a International Standard Audiovisual Number as defined in ISO 15706-2) for the Video. A V-ISAN comprises four blocks of four hexadecimal charaters followed by a check character, followed by two further blocks of four hexadecimal characters, followed by a further check character. DDEX will enforce the syntax [A-F0-9]{24} using XML Schema in the future.
+     *
+     * @return string
+     */
+    public function getVISAN()
+    {
+        return $this->vISAN;
+    }
+
+    /**
+     * Sets a new vISAN
+     *
+     * The V-ISAN (Version Identifier of a International Standard Audiovisual Number as defined in ISO 15706-2) for the Video. A V-ISAN comprises four blocks of four hexadecimal charaters followed by a check character, followed by two further blocks of four hexadecimal characters, followed by a further check character. DDEX will enforce the syntax [A-F0-9]{24} using XML Schema in the future.
+     *
+     * @param string $vISAN
+     * @return self
+     */
+    public function setVISAN($vISAN)
+    {
+        $this->vISAN = $vISAN;
+        return $this;
+    }
+
+    /**
+     * Gets as catalogNumber
+     *
+     * A Composite containing details of the CatalogNumber of the Video.
+     *
+     * @return \DedexBundle\Entity\Ern42\CatalogNumberType
+     */
+    public function getCatalogNumber()
+    {
+        return $this->catalogNumber;
+    }
+
+    /**
+     * Sets a new catalogNumber
+     *
+     * A Composite containing details of the CatalogNumber of the Video.
+     *
+     * @param \DedexBundle\Entity\Ern42\CatalogNumberType $catalogNumber
+     * @return self
+     */
+    public function setCatalogNumber(?\DedexBundle\Entity\Ern42\CatalogNumberType $catalogNumber = null)
+    {
+        $this->catalogNumber = $catalogNumber;
+        return $this;
+    }
+
+    /**
+     * Adds as proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Video (usually one per society involved in the messaging).
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ProprietaryIdType $proprietaryId
+     */
+    public function addToProprietaryId(\DedexBundle\Entity\Ern42\ProprietaryIdType $proprietaryId)
+    {
+        $this->proprietaryId[] = $proprietaryId;
+        return $this;
+    }
+
+    /**
+     * isset proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Video (usually one per society involved in the messaging).
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetProprietaryId($index)
+    {
+        return isset($this->proprietaryId[$index]);
+    }
+
+    /**
+     * unset proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Video (usually one per society involved in the messaging).
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetProprietaryId($index)
+    {
+        unset($this->proprietaryId[$index]);
+    }
+
+    /**
+     * Gets as proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Video (usually one per society involved in the messaging).
+     *
+     * @return \DedexBundle\Entity\Ern42\ProprietaryIdType[]
+     */
+    public function getProprietaryId()
+    {
+        return $this->proprietaryId;
+    }
+
+    /**
+     * Sets a new proprietaryId
+     *
+     * A Composite containing details of a ProprietaryIdentifier of the Video (usually one per society involved in the messaging).
+     *
+     * @param \DedexBundle\Entity\Ern42\ProprietaryIdType[] $proprietaryId
+     * @return self
+     */
+    public function setProprietaryId(?array $proprietaryId = null)
+    {
+        $this->proprietaryId = $proprietaryId;
+        return $this;
+    }
+
+    /**
+     * Adds as eIDR
+     *
+     * An Identifier of the Video assigned by the Entertainment Identifier Registry Association (EIDR).
+     *
+     * @return self
+     * @param string $eIDR
+     */
+    public function addToEIDR($eIDR)
+    {
+        $this->eIDR[] = $eIDR;
+        return $this;
+    }
+
+    /**
+     * isset eIDR
+     *
+     * An Identifier of the Video assigned by the Entertainment Identifier Registry Association (EIDR).
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetEIDR($index)
+    {
+        return isset($this->eIDR[$index]);
+    }
+
+    /**
+     * unset eIDR
+     *
+     * An Identifier of the Video assigned by the Entertainment Identifier Registry Association (EIDR).
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetEIDR($index)
+    {
+        unset($this->eIDR[$index]);
+    }
+
+    /**
+     * Gets as eIDR
+     *
+     * An Identifier of the Video assigned by the Entertainment Identifier Registry Association (EIDR).
+     *
+     * @return string[]
+     */
+    public function getEIDR()
+    {
+        return $this->eIDR;
+    }
+
+    /**
+     * Sets a new eIDR
+     *
+     * An Identifier of the Video assigned by the Entertainment Identifier Registry Association (EIDR).
+     *
+     * @param string[] $eIDR
+     * @return self
+     */
+    public function setEIDR(?array $eIDR = null)
+    {
+        $this->eIDR = $eIDR;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/VideoType.php
+++ b/src/Entity/Ern42/VideoType.php
@@ -1,0 +1,2888 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing VideoType
+ *
+ * A Composite containing details of a Video.
+ * XSD Type: Video
+ */
+class VideoType
+{
+    /**
+     * The Language and script for the Elements of the Video as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $languageAndScriptCode
+     */
+    private $languageAndScriptCode = null;
+
+    /**
+     * The Flag indicating whether the Video is provided in a addition to the Resources that form part of the Release (=true) or not (=false). If the flag is set to false (or absent) the Video is part of at least one Release in the message. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var bool $isSupplemental
+     */
+    private $isSupplemental = null;
+
+    /**
+     * The Identifier (specific to the Message) of the Video within the Release which contains it. This is a LocalResourceAnchor starting with the letter A.
+     *
+     * @var string $resourceReference
+     */
+    private $resourceReference = null;
+
+    /**
+     * A Composite containing details of the Type of the Video.
+     *
+     * @var \DedexBundle\Entity\Ern42\VideoTypeType $type
+     */
+    private $type = null;
+
+    /**
+     * A Composite containing details of an Identifier of the Video.
+     *
+     * @var \DedexBundle\Entity\Ern42\VideoIdType[] $resourceId
+     */
+    private $resourceId = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the Video.
+     *
+     * @var \DedexBundle\Entity\Ern42\MusicalWorkIdType[] $workId
+     */
+    private $workId = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Title of the Video as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayTitleTextType[] $displayTitleText
+     */
+    private $displayTitleText = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Title of the Video as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayTitleType[] $displayTitle
+     */
+    private $displayTitle = [
+        
+    ];
+
+    /**
+     * A Composite containing details of an AdditionalTitle of the Video. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @var \DedexBundle\Entity\Ern42\AdditionalTitleType[] $additionalTitle
+     */
+    private $additionalTitle = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Type of Version of the Video.
+     *
+     * @var \DedexBundle\Entity\Ern42\VersionTypeType[] $versionType
+     */
+    private $versionType = [
+        
+    ];
+
+    /**
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType[] $displayArtistName
+     */
+    private $displayArtistName = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the DisplayArtist for the Video. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayArtistType[] $displayArtist
+     */
+    private $displayArtist = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Contributor to the Video.
+     *
+     * @var \DedexBundle\Entity\Ern42\ContributorType[] $contributor
+     */
+    private $contributor = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Character in the Video. A Character may be described through Name, Identifier and Roles.
+     *
+     * @var \DedexBundle\Entity\Ern42\CharacterType[] $character
+     */
+    private $character = [
+        
+    ];
+
+    /**
+     * A Composite containing details of RightsController of Rights in the Video.
+     *
+     * @var \DedexBundle\Entity\Ern42\ResourceRightsControllerType[] $resourceRightsController
+     */
+    private $resourceRightsController = [
+        
+    ];
+
+    /**
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @var \DedexBundle\Entity\Ern42\WorkRightsControllerType[] $workRightsController
+     */
+    private $workRightsController = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the PLine for the Video.
+     *
+     * @var \DedexBundle\Entity\Ern42\PLineWithDefaultType[] $pLine
+     */
+    private $pLine = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the CLine for the Video.
+     *
+     * @var \DedexBundle\Entity\Ern42\CLineWithDefaultType[] $cLine
+     */
+    private $cLine = [
+        
+    ];
+
+    /**
+     * A Composite containing an Annotation Annotation which acknowledges record companies and/or other Parties giving permission for guests Artists or others featured on the Video.
+     *
+     * @var \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType[] $courtesyLine
+     */
+    private $courtesyLine = [
+        
+    ];
+
+    /**
+     * The Duration of the Video (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @var \DateInterval $duration
+     */
+    private $duration = null;
+
+    /**
+     * A Composite containing details of the Date and Place of the Event in which the Video was created. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $creationDate
+     */
+    private $creationDate = null;
+
+    /**
+     * A Composite containing details of the Date and Place of the Event in which the Video was originally mastered (in either analogue or digital form). This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $masteredDate
+     */
+    private $masteredDate = null;
+
+    /**
+     * A Composite containing details of the Date and Place of the Event in which the Video was re-mastered (usually digitally). This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @var \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType[] $remasteredDate
+     */
+    private $remasteredDate = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the Date and Place of the Event in which the Video was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @var \DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType[] $firstPublicationDate
+     */
+    private $firstPublicationDate = [
+        
+    ];
+
+    /**
+     * A Composite containing details of the classification of the Video according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @var \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType[] $parentalWarningType
+     */
+    private $parentalWarningType = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a rating for the Video.
+     *
+     * @var \DedexBundle\Entity\Ern42\AvRatingType[] $avRating
+     */
+    private $avRating = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Video.
+     *
+     * @var \DedexBundle\Entity\Ern42\RelatedReleaseType[] $relatedRelease
+     */
+    private $relatedRelease = [
+        
+    ];
+
+    /**
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Video.
+     *
+     * @var \DedexBundle\Entity\Ern42\RelatedResourceType[] $relatedResource
+     */
+    private $relatedResource = [
+        
+    ];
+
+    /**
+     * A Type of the Video indicating whether it is a Medley or a Potpourri.
+     *
+     * @var string $compositeMusicalWorkType
+     */
+    private $compositeMusicalWorkType = null;
+
+    /**
+     * A Reference for a CueSheet (specific to this Message). This is a LocalCueSheetAnchorReference starting with the letter Q.
+     *
+     * @var string[] $videoCueSheetReference
+     */
+    private $videoCueSheetReference = [
+        
+    ];
+
+    /**
+     * A Composite containing the textual Description of the reason for the Identifier being used as a proxy.
+     *
+     * @var \DedexBundle\Entity\Ern42\ReasonType $reasonForCueSheetAbsence
+     */
+    private $reasonForCueSheetAbsence = null;
+
+    /**
+     * A Flag indicating whether the Video is a Cover (=true) or not (=false). This is not legal information, but meant to help consumers to differentiate originals from covers.
+     *
+     * @var bool $isCover
+     */
+    private $isCover = null;
+
+    /**
+     * The Flag indicating whether the Video is instrumental (=true) or not (=false).
+     *
+     * @var bool $isInstrumental
+     */
+    private $isInstrumental = null;
+
+    /**
+     * The Flag indicating whether the Video contains content that is hidden in some way from the Consumer (=true) or not (=false).
+     *
+     * @var bool $containsHiddenContent
+     */
+    private $containsHiddenContent = null;
+
+    /**
+     * The Flag indicating whether the Video is remastered (=true) or not (=false).
+     *
+     * @var bool $isRemastered
+     */
+    private $isRemastered = null;
+
+    /**
+     * A Role and instrumentation for which a Party is credited.
+     *
+     * @var \DedexBundle\Entity\Ern42\DisplayCreditsType[] $displayCredits
+     */
+    private $displayCredits = [
+        
+    ];
+
+    /**
+     * The original Language of the Performance as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @var string[] $languageOfPerformance
+     */
+    private $languageOfPerformance = [
+        
+    ];
+
+    /**
+     * The Language of dubbing used in the Video as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @var string[] $languageOfDubbing
+     */
+    private $languageOfDubbing = [
+        
+    ];
+
+    /**
+     * The Language of SubTitles in the Video as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @var string[] $subTitleLanguage
+     */
+    private $subTitleLanguage = [
+        
+    ];
+
+    /**
+     * A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current Video.
+     *
+     * @var \DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType[] $resourceContainedResourceReferenceList
+     */
+    private $resourceContainedResourceReferenceList = null;
+
+    /**
+     * A Composite containing technical details of the Video.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @var \DedexBundle\Entity\Ern42\TechnicalVideoDetailsType[] $technicalDetails
+     */
+    private $technicalDetails = [
+        
+    ];
+
+    /**
+     * A Description of the melodic mode of a MusicalWork in the Video.
+     *
+     * @var string[] $raga
+     */
+    private $raga = [
+        
+    ];
+
+    /**
+     * A Description of the rhythmic pattern of a MusicalWork in the Video.
+     *
+     * @var string[] $tala
+     */
+    private $tala = [
+        
+    ];
+
+    /**
+     * A deity name relating to the Video.
+     *
+     * @var string[] $deity
+     */
+    private $deity = [
+        
+    ];
+
+    /**
+     * A Reference for a Chapter (specific to this Message). This is a LocalCollectionAnchorReference starting with the letter X.
+     *
+     * @var string[] $videoChapterReference
+     */
+    private $videoChapterReference = [
+        
+    ];
+
+    /**
+     * Gets as languageAndScriptCode
+     *
+     * The Language and script for the Elements of the Video as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getLanguageAndScriptCode()
+    {
+        return $this->languageAndScriptCode;
+    }
+
+    /**
+     * Sets a new languageAndScriptCode
+     *
+     * The Language and script for the Elements of the Video as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $languageAndScriptCode
+     * @return self
+     */
+    public function setLanguageAndScriptCode($languageAndScriptCode)
+    {
+        $this->languageAndScriptCode = $languageAndScriptCode;
+        return $this;
+    }
+
+    /**
+     * Gets as isSupplemental
+     *
+     * The Flag indicating whether the Video is provided in a addition to the Resources that form part of the Release (=true) or not (=false). If the flag is set to false (or absent) the Video is part of at least one Release in the message. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return bool
+     */
+    public function getIsSupplemental()
+    {
+        return $this->isSupplemental;
+    }
+
+    /**
+     * Sets a new isSupplemental
+     *
+     * The Flag indicating whether the Video is provided in a addition to the Resources that form part of the Release (=true) or not (=false). If the flag is set to false (or absent) the Video is part of at least one Release in the message. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param bool $isSupplemental
+     * @return self
+     */
+    public function setIsSupplemental($isSupplemental)
+    {
+        $this->isSupplemental = $isSupplemental;
+        return $this;
+    }
+
+    /**
+     * Gets as resourceReference
+     *
+     * The Identifier (specific to the Message) of the Video within the Release which contains it. This is a LocalResourceAnchor starting with the letter A.
+     *
+     * @return string
+     */
+    public function getResourceReference()
+    {
+        return $this->resourceReference;
+    }
+
+    /**
+     * Sets a new resourceReference
+     *
+     * The Identifier (specific to the Message) of the Video within the Release which contains it. This is a LocalResourceAnchor starting with the letter A.
+     *
+     * @param string $resourceReference
+     * @return self
+     */
+    public function setResourceReference($resourceReference)
+    {
+        $this->resourceReference = $resourceReference;
+        return $this;
+    }
+
+    /**
+     * Gets as type
+     *
+     * A Composite containing details of the Type of the Video.
+     *
+     * @return \DedexBundle\Entity\Ern42\VideoTypeType
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * Sets a new type
+     *
+     * A Composite containing details of the Type of the Video.
+     *
+     * @param \DedexBundle\Entity\Ern42\VideoTypeType $type
+     * @return self
+     */
+    public function setType(\DedexBundle\Entity\Ern42\VideoTypeType $type)
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    /**
+     * Adds as resourceId
+     *
+     * A Composite containing details of an Identifier of the Video.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\VideoIdType $resourceId
+     */
+    public function addToResourceId(\DedexBundle\Entity\Ern42\VideoIdType $resourceId)
+    {
+        $this->resourceId[] = $resourceId;
+        return $this;
+    }
+
+    /**
+     * isset resourceId
+     *
+     * A Composite containing details of an Identifier of the Video.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetResourceId($index)
+    {
+        return isset($this->resourceId[$index]);
+    }
+
+    /**
+     * unset resourceId
+     *
+     * A Composite containing details of an Identifier of the Video.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetResourceId($index)
+    {
+        unset($this->resourceId[$index]);
+    }
+
+    /**
+     * Gets as resourceId
+     *
+     * A Composite containing details of an Identifier of the Video.
+     *
+     * @return \DedexBundle\Entity\Ern42\VideoIdType[]
+     */
+    public function getResourceId()
+    {
+        return $this->resourceId;
+    }
+
+    /**
+     * Sets a new resourceId
+     *
+     * A Composite containing details of an Identifier of the Video.
+     *
+     * @param \DedexBundle\Entity\Ern42\VideoIdType[] $resourceId
+     * @return self
+     */
+    public function setResourceId(?array $resourceId = null)
+    {
+        $this->resourceId = $resourceId;
+        return $this;
+    }
+
+    /**
+     * Adds as workId
+     *
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the Video.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\MusicalWorkIdType $workId
+     */
+    public function addToWorkId(\DedexBundle\Entity\Ern42\MusicalWorkIdType $workId)
+    {
+        $this->workId[] = $workId;
+        return $this;
+    }
+
+    /**
+     * isset workId
+     *
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the Video.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetWorkId($index)
+    {
+        return isset($this->workId[$index]);
+    }
+
+    /**
+     * unset workId
+     *
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the Video.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetWorkId($index)
+    {
+        unset($this->workId[$index]);
+    }
+
+    /**
+     * Gets as workId
+     *
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the Video.
+     *
+     * @return \DedexBundle\Entity\Ern42\MusicalWorkIdType[]
+     */
+    public function getWorkId()
+    {
+        return $this->workId;
+    }
+
+    /**
+     * Sets a new workId
+     *
+     * A Composite containing details of a MusicalWorkId of a MusicalWork used in the Video.
+     *
+     * @param \DedexBundle\Entity\Ern42\MusicalWorkIdType[] $workId
+     * @return self
+     */
+    public function setWorkId(?array $workId = null)
+    {
+        $this->workId = $workId;
+        return $this;
+    }
+
+    /**
+     * Adds as displayTitleText
+     *
+     * A Composite containing details of a Title of the Video as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleTextType $displayTitleText
+     */
+    public function addToDisplayTitleText(\DedexBundle\Entity\Ern42\DisplayTitleTextType $displayTitleText)
+    {
+        $this->displayTitleText[] = $displayTitleText;
+        return $this;
+    }
+
+    /**
+     * isset displayTitleText
+     *
+     * A Composite containing details of a Title of the Video as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayTitleText($index)
+    {
+        return isset($this->displayTitleText[$index]);
+    }
+
+    /**
+     * unset displayTitleText
+     *
+     * A Composite containing details of a Title of the Video as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayTitleText($index)
+    {
+        unset($this->displayTitleText[$index]);
+    }
+
+    /**
+     * Gets as displayTitleText
+     *
+     * A Composite containing details of a Title of the Video as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayTitleTextType[]
+     */
+    public function getDisplayTitleText()
+    {
+        return $this->displayTitleText;
+    }
+
+    /**
+     * Sets a new displayTitleText
+     *
+     * A Composite containing details of a Title of the Video as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleTextType[] $displayTitleText
+     * @return self
+     */
+    public function setDisplayTitleText(array $displayTitleText)
+    {
+        $this->displayTitleText = $displayTitleText;
+        return $this;
+    }
+
+    /**
+     * Adds as displayTitle
+     *
+     * A Composite containing details of a Title of the Video as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleType $displayTitle
+     */
+    public function addToDisplayTitle(\DedexBundle\Entity\Ern42\DisplayTitleType $displayTitle)
+    {
+        $this->displayTitle[] = $displayTitle;
+        return $this;
+    }
+
+    /**
+     * isset displayTitle
+     *
+     * A Composite containing details of a Title of the Video as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayTitle($index)
+    {
+        return isset($this->displayTitle[$index]);
+    }
+
+    /**
+     * unset displayTitle
+     *
+     * A Composite containing details of a Title of the Video as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayTitle($index)
+    {
+        unset($this->displayTitle[$index]);
+    }
+
+    /**
+     * Gets as displayTitle
+     *
+     * A Composite containing details of a Title of the Video as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayTitleType[]
+     */
+    public function getDisplayTitle()
+    {
+        return $this->displayTitle;
+    }
+
+    /**
+     * Sets a new displayTitle
+     *
+     * A Composite containing details of a Title of the Video as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayTitleType[] $displayTitle
+     * @return self
+     */
+    public function setDisplayTitle(array $displayTitle)
+    {
+        $this->displayTitle = $displayTitle;
+        return $this;
+    }
+
+    /**
+     * Adds as additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Video. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\AdditionalTitleType $additionalTitle
+     */
+    public function addToAdditionalTitle(\DedexBundle\Entity\Ern42\AdditionalTitleType $additionalTitle)
+    {
+        $this->additionalTitle[] = $additionalTitle;
+        return $this;
+    }
+
+    /**
+     * isset additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Video. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetAdditionalTitle($index)
+    {
+        return isset($this->additionalTitle[$index]);
+    }
+
+    /**
+     * unset additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Video. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetAdditionalTitle($index)
+    {
+        unset($this->additionalTitle[$index]);
+    }
+
+    /**
+     * Gets as additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Video. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @return \DedexBundle\Entity\Ern42\AdditionalTitleType[]
+     */
+    public function getAdditionalTitle()
+    {
+        return $this->additionalTitle;
+    }
+
+    /**
+     * Sets a new additionalTitle
+     *
+     * A Composite containing details of an AdditionalTitle of the Video. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.
+     *
+     * @param \DedexBundle\Entity\Ern42\AdditionalTitleType[] $additionalTitle
+     * @return self
+     */
+    public function setAdditionalTitle(?array $additionalTitle = null)
+    {
+        $this->additionalTitle = $additionalTitle;
+        return $this;
+    }
+
+    /**
+     * Adds as versionType
+     *
+     * A Composite containing details of a Type of Version of the Video.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\VersionTypeType $versionType
+     */
+    public function addToVersionType(\DedexBundle\Entity\Ern42\VersionTypeType $versionType)
+    {
+        $this->versionType[] = $versionType;
+        return $this;
+    }
+
+    /**
+     * isset versionType
+     *
+     * A Composite containing details of a Type of Version of the Video.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetVersionType($index)
+    {
+        return isset($this->versionType[$index]);
+    }
+
+    /**
+     * unset versionType
+     *
+     * A Composite containing details of a Type of Version of the Video.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetVersionType($index)
+    {
+        unset($this->versionType[$index]);
+    }
+
+    /**
+     * Gets as versionType
+     *
+     * A Composite containing details of a Type of Version of the Video.
+     *
+     * @return \DedexBundle\Entity\Ern42\VersionTypeType[]
+     */
+    public function getVersionType()
+    {
+        return $this->versionType;
+    }
+
+    /**
+     * Sets a new versionType
+     *
+     * A Composite containing details of a Type of Version of the Video.
+     *
+     * @param \DedexBundle\Entity\Ern42\VersionTypeType[] $versionType
+     * @return self
+     */
+    public function setVersionType(?array $versionType = null)
+    {
+        $this->versionType = $versionType;
+        return $this;
+    }
+
+    /**
+     * Adds as displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType $displayArtistName
+     */
+    public function addToDisplayArtistName(\DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType $displayArtistName)
+    {
+        $this->displayArtistName[] = $displayArtistName;
+        return $this;
+    }
+
+    /**
+     * isset displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayArtistName($index)
+    {
+        return isset($this->displayArtistName[$index]);
+    }
+
+    /**
+     * unset displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayArtistName($index)
+    {
+        unset($this->displayArtistName[$index]);
+    }
+
+    /**
+     * Gets as displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType[]
+     */
+    public function getDisplayArtistName()
+    {
+        return $this->displayArtistName;
+    }
+
+    /**
+     * Sets a new displayArtistName
+     *
+     * A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType[] $displayArtistName
+     * @return self
+     */
+    public function setDisplayArtistName(array $displayArtistName)
+    {
+        $this->displayArtistName = $displayArtistName;
+        return $this;
+    }
+
+    /**
+     * Adds as displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the Video. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistType $displayArtist
+     */
+    public function addToDisplayArtist(\DedexBundle\Entity\Ern42\DisplayArtistType $displayArtist)
+    {
+        $this->displayArtist[] = $displayArtist;
+        return $this;
+    }
+
+    /**
+     * isset displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the Video. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayArtist($index)
+    {
+        return isset($this->displayArtist[$index]);
+    }
+
+    /**
+     * unset displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the Video. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayArtist($index)
+    {
+        unset($this->displayArtist[$index]);
+    }
+
+    /**
+     * Gets as displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the Video. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayArtistType[]
+     */
+    public function getDisplayArtist()
+    {
+        return $this->displayArtist;
+    }
+
+    /**
+     * Sets a new displayArtist
+     *
+     * A Composite containing details of the DisplayArtist for the Video. The DisplayArtist may be described through Name, Identifier and Roles.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayArtistType[] $displayArtist
+     * @return self
+     */
+    public function setDisplayArtist(array $displayArtist)
+    {
+        $this->displayArtist = $displayArtist;
+        return $this;
+    }
+
+    /**
+     * Adds as contributor
+     *
+     * A Composite containing details of a Contributor to the Video.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ContributorType $contributor
+     */
+    public function addToContributor(\DedexBundle\Entity\Ern42\ContributorType $contributor)
+    {
+        $this->contributor[] = $contributor;
+        return $this;
+    }
+
+    /**
+     * isset contributor
+     *
+     * A Composite containing details of a Contributor to the Video.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetContributor($index)
+    {
+        return isset($this->contributor[$index]);
+    }
+
+    /**
+     * unset contributor
+     *
+     * A Composite containing details of a Contributor to the Video.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetContributor($index)
+    {
+        unset($this->contributor[$index]);
+    }
+
+    /**
+     * Gets as contributor
+     *
+     * A Composite containing details of a Contributor to the Video.
+     *
+     * @return \DedexBundle\Entity\Ern42\ContributorType[]
+     */
+    public function getContributor()
+    {
+        return $this->contributor;
+    }
+
+    /**
+     * Sets a new contributor
+     *
+     * A Composite containing details of a Contributor to the Video.
+     *
+     * @param \DedexBundle\Entity\Ern42\ContributorType[] $contributor
+     * @return self
+     */
+    public function setContributor(?array $contributor = null)
+    {
+        $this->contributor = $contributor;
+        return $this;
+    }
+
+    /**
+     * Adds as character
+     *
+     * A Composite containing details of a Character in the Video. A Character may be described through Name, Identifier and Roles.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\CharacterType $character
+     */
+    public function addToCharacter(\DedexBundle\Entity\Ern42\CharacterType $character)
+    {
+        $this->character[] = $character;
+        return $this;
+    }
+
+    /**
+     * isset character
+     *
+     * A Composite containing details of a Character in the Video. A Character may be described through Name, Identifier and Roles.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetCharacter($index)
+    {
+        return isset($this->character[$index]);
+    }
+
+    /**
+     * unset character
+     *
+     * A Composite containing details of a Character in the Video. A Character may be described through Name, Identifier and Roles.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetCharacter($index)
+    {
+        unset($this->character[$index]);
+    }
+
+    /**
+     * Gets as character
+     *
+     * A Composite containing details of a Character in the Video. A Character may be described through Name, Identifier and Roles.
+     *
+     * @return \DedexBundle\Entity\Ern42\CharacterType[]
+     */
+    public function getCharacter()
+    {
+        return $this->character;
+    }
+
+    /**
+     * Sets a new character
+     *
+     * A Composite containing details of a Character in the Video. A Character may be described through Name, Identifier and Roles.
+     *
+     * @param \DedexBundle\Entity\Ern42\CharacterType[] $character
+     * @return self
+     */
+    public function setCharacter(?array $character = null)
+    {
+        $this->character = $character;
+        return $this;
+    }
+
+    /**
+     * Adds as resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Video.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ResourceRightsControllerType $resourceRightsController
+     */
+    public function addToResourceRightsController(\DedexBundle\Entity\Ern42\ResourceRightsControllerType $resourceRightsController)
+    {
+        $this->resourceRightsController[] = $resourceRightsController;
+        return $this;
+    }
+
+    /**
+     * isset resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Video.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetResourceRightsController($index)
+    {
+        return isset($this->resourceRightsController[$index]);
+    }
+
+    /**
+     * unset resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Video.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetResourceRightsController($index)
+    {
+        unset($this->resourceRightsController[$index]);
+    }
+
+    /**
+     * Gets as resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Video.
+     *
+     * @return \DedexBundle\Entity\Ern42\ResourceRightsControllerType[]
+     */
+    public function getResourceRightsController()
+    {
+        return $this->resourceRightsController;
+    }
+
+    /**
+     * Sets a new resourceRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Video.
+     *
+     * @param \DedexBundle\Entity\Ern42\ResourceRightsControllerType[] $resourceRightsController
+     * @return self
+     */
+    public function setResourceRightsController(?array $resourceRightsController = null)
+    {
+        $this->resourceRightsController = $resourceRightsController;
+        return $this;
+    }
+
+    /**
+     * Adds as workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\WorkRightsControllerType $workRightsController
+     */
+    public function addToWorkRightsController(\DedexBundle\Entity\Ern42\WorkRightsControllerType $workRightsController)
+    {
+        $this->workRightsController[] = $workRightsController;
+        return $this;
+    }
+
+    /**
+     * isset workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetWorkRightsController($index)
+    {
+        return isset($this->workRightsController[$index]);
+    }
+
+    /**
+     * unset workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetWorkRightsController($index)
+    {
+        unset($this->workRightsController[$index]);
+    }
+
+    /**
+     * Gets as workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @return \DedexBundle\Entity\Ern42\WorkRightsControllerType[]
+     */
+    public function getWorkRightsController()
+    {
+        return $this->workRightsController;
+    }
+
+    /**
+     * Sets a new workRightsController
+     *
+     * A Composite containing details of RightsController of Rights in the Work.
+     *
+     * @param \DedexBundle\Entity\Ern42\WorkRightsControllerType[] $workRightsController
+     * @return self
+     */
+    public function setWorkRightsController(?array $workRightsController = null)
+    {
+        $this->workRightsController = $workRightsController;
+        return $this;
+    }
+
+    /**
+     * Adds as pLine
+     *
+     * A Composite containing details of the PLine for the Video.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\PLineWithDefaultType $pLine
+     */
+    public function addToPLine(\DedexBundle\Entity\Ern42\PLineWithDefaultType $pLine)
+    {
+        $this->pLine[] = $pLine;
+        return $this;
+    }
+
+    /**
+     * isset pLine
+     *
+     * A Composite containing details of the PLine for the Video.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetPLine($index)
+    {
+        return isset($this->pLine[$index]);
+    }
+
+    /**
+     * unset pLine
+     *
+     * A Composite containing details of the PLine for the Video.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetPLine($index)
+    {
+        unset($this->pLine[$index]);
+    }
+
+    /**
+     * Gets as pLine
+     *
+     * A Composite containing details of the PLine for the Video.
+     *
+     * @return \DedexBundle\Entity\Ern42\PLineWithDefaultType[]
+     */
+    public function getPLine()
+    {
+        return $this->pLine;
+    }
+
+    /**
+     * Sets a new pLine
+     *
+     * A Composite containing details of the PLine for the Video.
+     *
+     * @param \DedexBundle\Entity\Ern42\PLineWithDefaultType[] $pLine
+     * @return self
+     */
+    public function setPLine(?array $pLine = null)
+    {
+        $this->pLine = $pLine;
+        return $this;
+    }
+
+    /**
+     * Adds as cLine
+     *
+     * A Composite containing details of the CLine for the Video.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\CLineWithDefaultType $cLine
+     */
+    public function addToCLine(\DedexBundle\Entity\Ern42\CLineWithDefaultType $cLine)
+    {
+        $this->cLine[] = $cLine;
+        return $this;
+    }
+
+    /**
+     * isset cLine
+     *
+     * A Composite containing details of the CLine for the Video.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetCLine($index)
+    {
+        return isset($this->cLine[$index]);
+    }
+
+    /**
+     * unset cLine
+     *
+     * A Composite containing details of the CLine for the Video.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetCLine($index)
+    {
+        unset($this->cLine[$index]);
+    }
+
+    /**
+     * Gets as cLine
+     *
+     * A Composite containing details of the CLine for the Video.
+     *
+     * @return \DedexBundle\Entity\Ern42\CLineWithDefaultType[]
+     */
+    public function getCLine()
+    {
+        return $this->cLine;
+    }
+
+    /**
+     * Sets a new cLine
+     *
+     * A Composite containing details of the CLine for the Video.
+     *
+     * @param \DedexBundle\Entity\Ern42\CLineWithDefaultType[] $cLine
+     * @return self
+     */
+    public function setCLine(?array $cLine = null)
+    {
+        $this->cLine = $cLine;
+        return $this;
+    }
+
+    /**
+     * Adds as courtesyLine
+     *
+     * A Composite containing an Annotation Annotation which acknowledges record companies and/or other Parties giving permission for guests Artists or others featured on the Video.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType $courtesyLine
+     */
+    public function addToCourtesyLine(\DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType $courtesyLine)
+    {
+        $this->courtesyLine[] = $courtesyLine;
+        return $this;
+    }
+
+    /**
+     * isset courtesyLine
+     *
+     * A Composite containing an Annotation Annotation which acknowledges record companies and/or other Parties giving permission for guests Artists or others featured on the Video.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetCourtesyLine($index)
+    {
+        return isset($this->courtesyLine[$index]);
+    }
+
+    /**
+     * unset courtesyLine
+     *
+     * A Composite containing an Annotation Annotation which acknowledges record companies and/or other Parties giving permission for guests Artists or others featured on the Video.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetCourtesyLine($index)
+    {
+        unset($this->courtesyLine[$index]);
+    }
+
+    /**
+     * Gets as courtesyLine
+     *
+     * A Composite containing an Annotation Annotation which acknowledges record companies and/or other Parties giving permission for guests Artists or others featured on the Video.
+     *
+     * @return \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType[]
+     */
+    public function getCourtesyLine()
+    {
+        return $this->courtesyLine;
+    }
+
+    /**
+     * Sets a new courtesyLine
+     *
+     * A Composite containing an Annotation Annotation which acknowledges record companies and/or other Parties giving permission for guests Artists or others featured on the Video.
+     *
+     * @param \DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType[] $courtesyLine
+     * @return self
+     */
+    public function setCourtesyLine(?array $courtesyLine = null)
+    {
+        $this->courtesyLine = $courtesyLine;
+        return $this;
+    }
+
+    /**
+     * Gets as duration
+     *
+     * The Duration of the Video (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @return \DateInterval
+     */
+    public function getDuration()
+    {
+        return $this->duration;
+    }
+
+    /**
+     * Sets a new duration
+     *
+     * The Duration of the Video (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).
+     *
+     * @param \DateInterval $duration
+     * @return self
+     */
+    public function setDuration(\DateInterval $duration)
+    {
+        $this->duration = $duration;
+        return $this;
+    }
+
+    /**
+     * Gets as creationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Video was created. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType
+     */
+    public function getCreationDate()
+    {
+        return $this->creationDate;
+    }
+
+    /**
+     * Sets a new creationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Video was created. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $creationDate
+     * @return self
+     */
+    public function setCreationDate(?\DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $creationDate = null)
+    {
+        $this->creationDate = $creationDate;
+        return $this;
+    }
+
+    /**
+     * Gets as masteredDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Video was originally mastered (in either analogue or digital form). This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType
+     */
+    public function getMasteredDate()
+    {
+        return $this->masteredDate;
+    }
+
+    /**
+     * Sets a new masteredDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Video was originally mastered (in either analogue or digital form). This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $masteredDate
+     * @return self
+     */
+    public function setMasteredDate(?\DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $masteredDate = null)
+    {
+        $this->masteredDate = $masteredDate;
+        return $this;
+    }
+
+    /**
+     * Adds as remasteredDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Video was re-mastered (usually digitally). This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $remasteredDate
+     */
+    public function addToRemasteredDate(\DedexBundle\Entity\Ern42\EventDateWithoutFlagsType $remasteredDate)
+    {
+        $this->remasteredDate[] = $remasteredDate;
+        return $this;
+    }
+
+    /**
+     * isset remasteredDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Video was re-mastered (usually digitally). This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRemasteredDate($index)
+    {
+        return isset($this->remasteredDate[$index]);
+    }
+
+    /**
+     * unset remasteredDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Video was re-mastered (usually digitally). This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRemasteredDate($index)
+    {
+        unset($this->remasteredDate[$index]);
+    }
+
+    /**
+     * Gets as remasteredDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Video was re-mastered (usually digitally). This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @return \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType[]
+     */
+    public function getRemasteredDate()
+    {
+        return $this->remasteredDate;
+    }
+
+    /**
+     * Sets a new remasteredDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Video was re-mastered (usually digitally). This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param \DedexBundle\Entity\Ern42\EventDateWithoutFlagsType[] $remasteredDate
+     * @return self
+     */
+    public function setRemasteredDate(?array $remasteredDate = null)
+    {
+        $this->remasteredDate = $remasteredDate;
+        return $this;
+    }
+
+    /**
+     * Adds as firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Video was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType $firstPublicationDate
+     */
+    public function addToFirstPublicationDate(\DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType $firstPublicationDate)
+    {
+        $this->firstPublicationDate[] = $firstPublicationDate;
+        return $this;
+    }
+
+    /**
+     * isset firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Video was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetFirstPublicationDate($index)
+    {
+        return isset($this->firstPublicationDate[$index]);
+    }
+
+    /**
+     * unset firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Video was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetFirstPublicationDate($index)
+    {
+        unset($this->firstPublicationDate[$index]);
+    }
+
+    /**
+     * Gets as firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Video was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @return \DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType[]
+     */
+    public function getFirstPublicationDate()
+    {
+        return $this->firstPublicationDate;
+    }
+
+    /**
+     * Sets a new firstPublicationDate
+     *
+     * A Composite containing details of the Date and Place of the Event in which the Video was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].
+     *
+     * @param \DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType[] $firstPublicationDate
+     * @return self
+     */
+    public function setFirstPublicationDate(?array $firstPublicationDate = null)
+    {
+        $this->firstPublicationDate = $firstPublicationDate;
+        return $this;
+    }
+
+    /**
+     * Adds as parentalWarningType
+     *
+     * A Composite containing details of the classification of the Video according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType $parentalWarningType
+     */
+    public function addToParentalWarningType(\DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType $parentalWarningType)
+    {
+        $this->parentalWarningType[] = $parentalWarningType;
+        return $this;
+    }
+
+    /**
+     * isset parentalWarningType
+     *
+     * A Composite containing details of the classification of the Video according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetParentalWarningType($index)
+    {
+        return isset($this->parentalWarningType[$index]);
+    }
+
+    /**
+     * unset parentalWarningType
+     *
+     * A Composite containing details of the classification of the Video according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetParentalWarningType($index)
+    {
+        unset($this->parentalWarningType[$index]);
+    }
+
+    /**
+     * Gets as parentalWarningType
+     *
+     * A Composite containing details of the classification of the Video according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @return \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType[]
+     */
+    public function getParentalWarningType()
+    {
+        return $this->parentalWarningType;
+    }
+
+    /**
+     * Sets a new parentalWarningType
+     *
+     * A Composite containing details of the classification of the Video according to advice which it carries about the level of explicitness or offensiveness of its content.
+     *
+     * @param \DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType[] $parentalWarningType
+     * @return self
+     */
+    public function setParentalWarningType(array $parentalWarningType)
+    {
+        $this->parentalWarningType = $parentalWarningType;
+        return $this;
+    }
+
+    /**
+     * Adds as avRating
+     *
+     * A Composite containing details of a rating for the Video.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\AvRatingType $avRating
+     */
+    public function addToAvRating(\DedexBundle\Entity\Ern42\AvRatingType $avRating)
+    {
+        $this->avRating[] = $avRating;
+        return $this;
+    }
+
+    /**
+     * isset avRating
+     *
+     * A Composite containing details of a rating for the Video.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetAvRating($index)
+    {
+        return isset($this->avRating[$index]);
+    }
+
+    /**
+     * unset avRating
+     *
+     * A Composite containing details of a rating for the Video.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetAvRating($index)
+    {
+        unset($this->avRating[$index]);
+    }
+
+    /**
+     * Gets as avRating
+     *
+     * A Composite containing details of a rating for the Video.
+     *
+     * @return \DedexBundle\Entity\Ern42\AvRatingType[]
+     */
+    public function getAvRating()
+    {
+        return $this->avRating;
+    }
+
+    /**
+     * Sets a new avRating
+     *
+     * A Composite containing details of a rating for the Video.
+     *
+     * @param \DedexBundle\Entity\Ern42\AvRatingType[] $avRating
+     * @return self
+     */
+    public function setAvRating(?array $avRating = null)
+    {
+        $this->avRating = $avRating;
+        return $this;
+    }
+
+    /**
+     * Adds as relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Video.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\RelatedReleaseType $relatedRelease
+     */
+    public function addToRelatedRelease(\DedexBundle\Entity\Ern42\RelatedReleaseType $relatedRelease)
+    {
+        $this->relatedRelease[] = $relatedRelease;
+        return $this;
+    }
+
+    /**
+     * isset relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Video.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRelatedRelease($index)
+    {
+        return isset($this->relatedRelease[$index]);
+    }
+
+    /**
+     * unset relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Video.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRelatedRelease($index)
+    {
+        unset($this->relatedRelease[$index]);
+    }
+
+    /**
+     * Gets as relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Video.
+     *
+     * @return \DedexBundle\Entity\Ern42\RelatedReleaseType[]
+     */
+    public function getRelatedRelease()
+    {
+        return $this->relatedRelease;
+    }
+
+    /**
+     * Sets a new relatedRelease
+     *
+     * A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Video.
+     *
+     * @param \DedexBundle\Entity\Ern42\RelatedReleaseType[] $relatedRelease
+     * @return self
+     */
+    public function setRelatedRelease(?array $relatedRelease = null)
+    {
+        $this->relatedRelease = $relatedRelease;
+        return $this;
+    }
+
+    /**
+     * Adds as relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Video.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\RelatedResourceType $relatedResource
+     */
+    public function addToRelatedResource(\DedexBundle\Entity\Ern42\RelatedResourceType $relatedResource)
+    {
+        $this->relatedResource[] = $relatedResource;
+        return $this;
+    }
+
+    /**
+     * isset relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Video.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRelatedResource($index)
+    {
+        return isset($this->relatedResource[$index]);
+    }
+
+    /**
+     * unset relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Video.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRelatedResource($index)
+    {
+        unset($this->relatedResource[$index]);
+    }
+
+    /**
+     * Gets as relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Video.
+     *
+     * @return \DedexBundle\Entity\Ern42\RelatedResourceType[]
+     */
+    public function getRelatedResource()
+    {
+        return $this->relatedResource;
+    }
+
+    /**
+     * Sets a new relatedResource
+     *
+     * A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Video.
+     *
+     * @param \DedexBundle\Entity\Ern42\RelatedResourceType[] $relatedResource
+     * @return self
+     */
+    public function setRelatedResource(?array $relatedResource = null)
+    {
+        $this->relatedResource = $relatedResource;
+        return $this;
+    }
+
+    /**
+     * Gets as compositeMusicalWorkType
+     *
+     * A Type of the Video indicating whether it is a Medley or a Potpourri.
+     *
+     * @return string
+     */
+    public function getCompositeMusicalWorkType()
+    {
+        return $this->compositeMusicalWorkType;
+    }
+
+    /**
+     * Sets a new compositeMusicalWorkType
+     *
+     * A Type of the Video indicating whether it is a Medley or a Potpourri.
+     *
+     * @param string $compositeMusicalWorkType
+     * @return self
+     */
+    public function setCompositeMusicalWorkType($compositeMusicalWorkType)
+    {
+        $this->compositeMusicalWorkType = $compositeMusicalWorkType;
+        return $this;
+    }
+
+    /**
+     * Adds as videoCueSheetReference
+     *
+     * A Reference for a CueSheet (specific to this Message). This is a LocalCueSheetAnchorReference starting with the letter Q.
+     *
+     * @return self
+     * @param string $videoCueSheetReference
+     */
+    public function addToVideoCueSheetReference($videoCueSheetReference)
+    {
+        $this->videoCueSheetReference[] = $videoCueSheetReference;
+        return $this;
+    }
+
+    /**
+     * isset videoCueSheetReference
+     *
+     * A Reference for a CueSheet (specific to this Message). This is a LocalCueSheetAnchorReference starting with the letter Q.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetVideoCueSheetReference($index)
+    {
+        return isset($this->videoCueSheetReference[$index]);
+    }
+
+    /**
+     * unset videoCueSheetReference
+     *
+     * A Reference for a CueSheet (specific to this Message). This is a LocalCueSheetAnchorReference starting with the letter Q.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetVideoCueSheetReference($index)
+    {
+        unset($this->videoCueSheetReference[$index]);
+    }
+
+    /**
+     * Gets as videoCueSheetReference
+     *
+     * A Reference for a CueSheet (specific to this Message). This is a LocalCueSheetAnchorReference starting with the letter Q.
+     *
+     * @return string[]
+     */
+    public function getVideoCueSheetReference()
+    {
+        return $this->videoCueSheetReference;
+    }
+
+    /**
+     * Sets a new videoCueSheetReference
+     *
+     * A Reference for a CueSheet (specific to this Message). This is a LocalCueSheetAnchorReference starting with the letter Q.
+     *
+     * @param string $videoCueSheetReference
+     * @return self
+     */
+    public function setVideoCueSheetReference(?array $videoCueSheetReference = null)
+    {
+        $this->videoCueSheetReference = $videoCueSheetReference;
+        return $this;
+    }
+
+    /**
+     * Gets as reasonForCueSheetAbsence
+     *
+     * A Composite containing the textual Description of the reason for the Identifier being used as a proxy.
+     *
+     * @return \DedexBundle\Entity\Ern42\ReasonType
+     */
+    public function getReasonForCueSheetAbsence()
+    {
+        return $this->reasonForCueSheetAbsence;
+    }
+
+    /**
+     * Sets a new reasonForCueSheetAbsence
+     *
+     * A Composite containing the textual Description of the reason for the Identifier being used as a proxy.
+     *
+     * @param \DedexBundle\Entity\Ern42\ReasonType $reasonForCueSheetAbsence
+     * @return self
+     */
+    public function setReasonForCueSheetAbsence(?\DedexBundle\Entity\Ern42\ReasonType $reasonForCueSheetAbsence = null)
+    {
+        $this->reasonForCueSheetAbsence = $reasonForCueSheetAbsence;
+        return $this;
+    }
+
+    /**
+     * Gets as isCover
+     *
+     * A Flag indicating whether the Video is a Cover (=true) or not (=false). This is not legal information, but meant to help consumers to differentiate originals from covers.
+     *
+     * @return bool
+     */
+    public function getIsCover()
+    {
+        return $this->isCover;
+    }
+
+    /**
+     * Sets a new isCover
+     *
+     * A Flag indicating whether the Video is a Cover (=true) or not (=false). This is not legal information, but meant to help consumers to differentiate originals from covers.
+     *
+     * @param bool $isCover
+     * @return self
+     */
+    public function setIsCover($isCover)
+    {
+        $this->isCover = $isCover;
+        return $this;
+    }
+
+    /**
+     * Gets as isInstrumental
+     *
+     * The Flag indicating whether the Video is instrumental (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getIsInstrumental()
+    {
+        return $this->isInstrumental;
+    }
+
+    /**
+     * Sets a new isInstrumental
+     *
+     * The Flag indicating whether the Video is instrumental (=true) or not (=false).
+     *
+     * @param bool $isInstrumental
+     * @return self
+     */
+    public function setIsInstrumental($isInstrumental)
+    {
+        $this->isInstrumental = $isInstrumental;
+        return $this;
+    }
+
+    /**
+     * Gets as containsHiddenContent
+     *
+     * The Flag indicating whether the Video contains content that is hidden in some way from the Consumer (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getContainsHiddenContent()
+    {
+        return $this->containsHiddenContent;
+    }
+
+    /**
+     * Sets a new containsHiddenContent
+     *
+     * The Flag indicating whether the Video contains content that is hidden in some way from the Consumer (=true) or not (=false).
+     *
+     * @param bool $containsHiddenContent
+     * @return self
+     */
+    public function setContainsHiddenContent($containsHiddenContent)
+    {
+        $this->containsHiddenContent = $containsHiddenContent;
+        return $this;
+    }
+
+    /**
+     * Gets as isRemastered
+     *
+     * The Flag indicating whether the Video is remastered (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getIsRemastered()
+    {
+        return $this->isRemastered;
+    }
+
+    /**
+     * Sets a new isRemastered
+     *
+     * The Flag indicating whether the Video is remastered (=true) or not (=false).
+     *
+     * @param bool $isRemastered
+     * @return self
+     */
+    public function setIsRemastered($isRemastered)
+    {
+        $this->isRemastered = $isRemastered;
+        return $this;
+    }
+
+    /**
+     * Adds as displayCredits
+     *
+     * A Role and instrumentation for which a Party is credited.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\DisplayCreditsType $displayCredits
+     */
+    public function addToDisplayCredits(\DedexBundle\Entity\Ern42\DisplayCreditsType $displayCredits)
+    {
+        $this->displayCredits[] = $displayCredits;
+        return $this;
+    }
+
+    /**
+     * isset displayCredits
+     *
+     * A Role and instrumentation for which a Party is credited.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDisplayCredits($index)
+    {
+        return isset($this->displayCredits[$index]);
+    }
+
+    /**
+     * unset displayCredits
+     *
+     * A Role and instrumentation for which a Party is credited.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDisplayCredits($index)
+    {
+        unset($this->displayCredits[$index]);
+    }
+
+    /**
+     * Gets as displayCredits
+     *
+     * A Role and instrumentation for which a Party is credited.
+     *
+     * @return \DedexBundle\Entity\Ern42\DisplayCreditsType[]
+     */
+    public function getDisplayCredits()
+    {
+        return $this->displayCredits;
+    }
+
+    /**
+     * Sets a new displayCredits
+     *
+     * A Role and instrumentation for which a Party is credited.
+     *
+     * @param \DedexBundle\Entity\Ern42\DisplayCreditsType[] $displayCredits
+     * @return self
+     */
+    public function setDisplayCredits(?array $displayCredits = null)
+    {
+        $this->displayCredits = $displayCredits;
+        return $this;
+    }
+
+    /**
+     * Adds as languageOfPerformance
+     *
+     * The original Language of the Performance as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @return self
+     * @param string $languageOfPerformance
+     */
+    public function addToLanguageOfPerformance($languageOfPerformance)
+    {
+        $this->languageOfPerformance[] = $languageOfPerformance;
+        return $this;
+    }
+
+    /**
+     * isset languageOfPerformance
+     *
+     * The original Language of the Performance as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetLanguageOfPerformance($index)
+    {
+        return isset($this->languageOfPerformance[$index]);
+    }
+
+    /**
+     * unset languageOfPerformance
+     *
+     * The original Language of the Performance as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetLanguageOfPerformance($index)
+    {
+        unset($this->languageOfPerformance[$index]);
+    }
+
+    /**
+     * Gets as languageOfPerformance
+     *
+     * The original Language of the Performance as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @return string[]
+     */
+    public function getLanguageOfPerformance()
+    {
+        return $this->languageOfPerformance;
+    }
+
+    /**
+     * Sets a new languageOfPerformance
+     *
+     * The original Language of the Performance as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @param string $languageOfPerformance
+     * @return self
+     */
+    public function setLanguageOfPerformance(?array $languageOfPerformance = null)
+    {
+        $this->languageOfPerformance = $languageOfPerformance;
+        return $this;
+    }
+
+    /**
+     * Adds as languageOfDubbing
+     *
+     * The Language of dubbing used in the Video as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @return self
+     * @param string $languageOfDubbing
+     */
+    public function addToLanguageOfDubbing($languageOfDubbing)
+    {
+        $this->languageOfDubbing[] = $languageOfDubbing;
+        return $this;
+    }
+
+    /**
+     * isset languageOfDubbing
+     *
+     * The Language of dubbing used in the Video as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetLanguageOfDubbing($index)
+    {
+        return isset($this->languageOfDubbing[$index]);
+    }
+
+    /**
+     * unset languageOfDubbing
+     *
+     * The Language of dubbing used in the Video as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetLanguageOfDubbing($index)
+    {
+        unset($this->languageOfDubbing[$index]);
+    }
+
+    /**
+     * Gets as languageOfDubbing
+     *
+     * The Language of dubbing used in the Video as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @return string[]
+     */
+    public function getLanguageOfDubbing()
+    {
+        return $this->languageOfDubbing;
+    }
+
+    /**
+     * Sets a new languageOfDubbing
+     *
+     * The Language of dubbing used in the Video as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @param string $languageOfDubbing
+     * @return self
+     */
+    public function setLanguageOfDubbing(?array $languageOfDubbing = null)
+    {
+        $this->languageOfDubbing = $languageOfDubbing;
+        return $this;
+    }
+
+    /**
+     * Adds as subTitleLanguage
+     *
+     * The Language of SubTitles in the Video as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @return self
+     * @param string $subTitleLanguage
+     */
+    public function addToSubTitleLanguage($subTitleLanguage)
+    {
+        $this->subTitleLanguage[] = $subTitleLanguage;
+        return $this;
+    }
+
+    /**
+     * isset subTitleLanguage
+     *
+     * The Language of SubTitles in the Video as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetSubTitleLanguage($index)
+    {
+        return isset($this->subTitleLanguage[$index]);
+    }
+
+    /**
+     * unset subTitleLanguage
+     *
+     * The Language of SubTitles in the Video as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetSubTitleLanguage($index)
+    {
+        unset($this->subTitleLanguage[$index]);
+    }
+
+    /**
+     * Gets as subTitleLanguage
+     *
+     * The Language of SubTitles in the Video as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @return string[]
+     */
+    public function getSubTitleLanguage()
+    {
+        return $this->subTitleLanguage;
+    }
+
+    /**
+     * Sets a new subTitleLanguage
+     *
+     * The Language of SubTitles in the Video as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].
+     *
+     * @param string $subTitleLanguage
+     * @return self
+     */
+    public function setSubTitleLanguage(?array $subTitleLanguage = null)
+    {
+        $this->subTitleLanguage = $subTitleLanguage;
+        return $this;
+    }
+
+    /**
+     * Adds as resourceContainedResourceReference
+     *
+     * A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current Video.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType $resourceContainedResourceReference
+     */
+    public function addToResourceContainedResourceReferenceList(\DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType $resourceContainedResourceReference)
+    {
+        $this->resourceContainedResourceReferenceList[] = $resourceContainedResourceReference;
+        return $this;
+    }
+
+    /**
+     * isset resourceContainedResourceReferenceList
+     *
+     * A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current Video.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetResourceContainedResourceReferenceList($index)
+    {
+        return isset($this->resourceContainedResourceReferenceList[$index]);
+    }
+
+    /**
+     * unset resourceContainedResourceReferenceList
+     *
+     * A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current Video.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetResourceContainedResourceReferenceList($index)
+    {
+        unset($this->resourceContainedResourceReferenceList[$index]);
+    }
+
+    /**
+     * Gets as resourceContainedResourceReferenceList
+     *
+     * A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current Video.
+     *
+     * @return \DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType[]
+     */
+    public function getResourceContainedResourceReferenceList()
+    {
+        return $this->resourceContainedResourceReferenceList;
+    }
+
+    /**
+     * Sets a new resourceContainedResourceReferenceList
+     *
+     * A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current Video.
+     *
+     * @param \DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType[] $resourceContainedResourceReferenceList
+     * @return self
+     */
+    public function setResourceContainedResourceReferenceList(?array $resourceContainedResourceReferenceList = null)
+    {
+        $this->resourceContainedResourceReferenceList = $resourceContainedResourceReferenceList;
+        return $this;
+    }
+
+    /**
+     * Adds as technicalDetails
+     *
+     * A Composite containing technical details of the Video.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\TechnicalVideoDetailsType $technicalDetails
+     */
+    public function addToTechnicalDetails(\DedexBundle\Entity\Ern42\TechnicalVideoDetailsType $technicalDetails)
+    {
+        $this->technicalDetails[] = $technicalDetails;
+        return $this;
+    }
+
+    /**
+     * isset technicalDetails
+     *
+     * A Composite containing technical details of the Video.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetTechnicalDetails($index)
+    {
+        return isset($this->technicalDetails[$index]);
+    }
+
+    /**
+     * unset technicalDetails
+     *
+     * A Composite containing technical details of the Video.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetTechnicalDetails($index)
+    {
+        unset($this->technicalDetails[$index]);
+    }
+
+    /**
+     * Gets as technicalDetails
+     *
+     * A Composite containing technical details of the Video.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @return \DedexBundle\Entity\Ern42\TechnicalVideoDetailsType[]
+     */
+    public function getTechnicalDetails()
+    {
+        return $this->technicalDetails;
+    }
+
+    /**
+     * Sets a new technicalDetails
+     *
+     * A Composite containing technical details of the Video.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries
+     *
+     * @param \DedexBundle\Entity\Ern42\TechnicalVideoDetailsType[] $technicalDetails
+     * @return self
+     */
+    public function setTechnicalDetails(?array $technicalDetails = null)
+    {
+        $this->technicalDetails = $technicalDetails;
+        return $this;
+    }
+
+    /**
+     * Adds as raga
+     *
+     * A Description of the melodic mode of a MusicalWork in the Video.
+     *
+     * @return self
+     * @param string $raga
+     */
+    public function addToRaga($raga)
+    {
+        $this->raga[] = $raga;
+        return $this;
+    }
+
+    /**
+     * isset raga
+     *
+     * A Description of the melodic mode of a MusicalWork in the Video.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRaga($index)
+    {
+        return isset($this->raga[$index]);
+    }
+
+    /**
+     * unset raga
+     *
+     * A Description of the melodic mode of a MusicalWork in the Video.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRaga($index)
+    {
+        unset($this->raga[$index]);
+    }
+
+    /**
+     * Gets as raga
+     *
+     * A Description of the melodic mode of a MusicalWork in the Video.
+     *
+     * @return string[]
+     */
+    public function getRaga()
+    {
+        return $this->raga;
+    }
+
+    /**
+     * Sets a new raga
+     *
+     * A Description of the melodic mode of a MusicalWork in the Video.
+     *
+     * @param string[] $raga
+     * @return self
+     */
+    public function setRaga(?array $raga = null)
+    {
+        $this->raga = $raga;
+        return $this;
+    }
+
+    /**
+     * Adds as tala
+     *
+     * A Description of the rhythmic pattern of a MusicalWork in the Video.
+     *
+     * @return self
+     * @param string $tala
+     */
+    public function addToTala($tala)
+    {
+        $this->tala[] = $tala;
+        return $this;
+    }
+
+    /**
+     * isset tala
+     *
+     * A Description of the rhythmic pattern of a MusicalWork in the Video.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetTala($index)
+    {
+        return isset($this->tala[$index]);
+    }
+
+    /**
+     * unset tala
+     *
+     * A Description of the rhythmic pattern of a MusicalWork in the Video.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetTala($index)
+    {
+        unset($this->tala[$index]);
+    }
+
+    /**
+     * Gets as tala
+     *
+     * A Description of the rhythmic pattern of a MusicalWork in the Video.
+     *
+     * @return string[]
+     */
+    public function getTala()
+    {
+        return $this->tala;
+    }
+
+    /**
+     * Sets a new tala
+     *
+     * A Description of the rhythmic pattern of a MusicalWork in the Video.
+     *
+     * @param string[] $tala
+     * @return self
+     */
+    public function setTala(?array $tala = null)
+    {
+        $this->tala = $tala;
+        return $this;
+    }
+
+    /**
+     * Adds as deity
+     *
+     * A deity name relating to the Video.
+     *
+     * @return self
+     * @param string $deity
+     */
+    public function addToDeity($deity)
+    {
+        $this->deity[] = $deity;
+        return $this;
+    }
+
+    /**
+     * isset deity
+     *
+     * A deity name relating to the Video.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetDeity($index)
+    {
+        return isset($this->deity[$index]);
+    }
+
+    /**
+     * unset deity
+     *
+     * A deity name relating to the Video.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetDeity($index)
+    {
+        unset($this->deity[$index]);
+    }
+
+    /**
+     * Gets as deity
+     *
+     * A deity name relating to the Video.
+     *
+     * @return string[]
+     */
+    public function getDeity()
+    {
+        return $this->deity;
+    }
+
+    /**
+     * Sets a new deity
+     *
+     * A deity name relating to the Video.
+     *
+     * @param string[] $deity
+     * @return self
+     */
+    public function setDeity(?array $deity = null)
+    {
+        $this->deity = $deity;
+        return $this;
+    }
+
+    /**
+     * Adds as videoChapterReference
+     *
+     * A Reference for a Chapter (specific to this Message). This is a LocalCollectionAnchorReference starting with the letter X.
+     *
+     * @return self
+     * @param string $videoChapterReference
+     */
+    public function addToVideoChapterReference($videoChapterReference)
+    {
+        $this->videoChapterReference[] = $videoChapterReference;
+        return $this;
+    }
+
+    /**
+     * isset videoChapterReference
+     *
+     * A Reference for a Chapter (specific to this Message). This is a LocalCollectionAnchorReference starting with the letter X.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetVideoChapterReference($index)
+    {
+        return isset($this->videoChapterReference[$index]);
+    }
+
+    /**
+     * unset videoChapterReference
+     *
+     * A Reference for a Chapter (specific to this Message). This is a LocalCollectionAnchorReference starting with the letter X.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetVideoChapterReference($index)
+    {
+        unset($this->videoChapterReference[$index]);
+    }
+
+    /**
+     * Gets as videoChapterReference
+     *
+     * A Reference for a Chapter (specific to this Message). This is a LocalCollectionAnchorReference starting with the letter X.
+     *
+     * @return string[]
+     */
+    public function getVideoChapterReference()
+    {
+        return $this->videoChapterReference;
+    }
+
+    /**
+     * Sets a new videoChapterReference
+     *
+     * A Reference for a Chapter (specific to this Message). This is a LocalCollectionAnchorReference starting with the letter X.
+     *
+     * @param string $videoChapterReference
+     * @return self
+     */
+    public function setVideoChapterReference(?array $videoChapterReference = null)
+    {
+        $this->videoChapterReference = $videoChapterReference;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/VideoTypeType.php
+++ b/src/Entity/Ern42/VideoTypeType.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing VideoTypeType
+ *
+ * A Composite containing details of a VideoType.
+ * XSD Type: VideoType
+ */
+class VideoTypeType
+{
+    /**
+     * @var string $__value
+     */
+    private $__value = null;
+
+    /**
+     * The Namespace of the VideoType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $namespace
+     */
+    private $namespace = null;
+
+    /**
+     * A UserDefined value of the VideoType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @var string $userDefinedValue
+     */
+    private $userDefinedValue = null;
+
+    /**
+     * Construct
+     *
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value($value);
+    }
+
+    /**
+     * Gets or sets the inner value
+     *
+     * @param string $value
+     * @return string
+     */
+    public function value()
+    {
+        if ($args = func_get_args()) {
+            $this->__value = $args[0];
+        }
+        return $this->__value;
+    }
+
+    /**
+     * Gets a string value
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return strval($this->__value);
+    }
+
+    /**
+     * Gets as namespace
+     *
+     * The Namespace of the VideoType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets a new namespace
+     *
+     * The Namespace of the VideoType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $namespace
+     * @return self
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
+        return $this;
+    }
+
+    /**
+     * Gets as userDefinedValue
+     *
+     * A UserDefined value of the VideoType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @return string
+     */
+    public function getUserDefinedValue()
+    {
+        return $this->userDefinedValue;
+    }
+
+    /**
+     * Sets a new userDefinedValue
+     *
+     * A UserDefined value of the VideoType. This is represented in an XML schema as an XML Attribute.
+     *
+     * @param string $userDefinedValue
+     * @return self
+     */
+    public function setUserDefinedValue($userDefinedValue)
+    {
+        $this->userDefinedValue = $userDefinedValue;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/WorkRightsControllerType.php
+++ b/src/Entity/Ern42/WorkRightsControllerType.php
@@ -1,0 +1,364 @@
+<?php
+
+namespace DedexBundle\Entity\Ern42;
+
+/**
+ * Class representing WorkRightsControllerType
+ *
+ * A Composite containing details of a RightsController for a Work. RightsControllers are typically described by Name, Identifier and Role(s).
+ * XSD Type: WorkRightsController
+ */
+class WorkRightsControllerType
+{
+    /**
+     * A Reference for a Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @var string $rightsControllerPartyReference
+     */
+    private $rightsControllerPartyReference = null;
+
+    /**
+     * A role that describes the Party involved in the administration of Rights.
+     *
+     * @var string[] $rightsControlType
+     */
+    private $rightsControlType = [
+        
+    ];
+
+    /**
+     * A type of the RightsController.
+     *
+     * @var string $rightsControllerType
+     */
+    private $rightsControllerType = null;
+
+    /**
+     * The Flag indicating whether the RightSharePercentage is unknown (=true) or not (=false).
+     *
+     * @var bool $rightShareUnknown
+     */
+    private $rightShareUnknown = null;
+
+    /**
+     * The share of the licensed Rights owned by the RightsController. RightShare information is given as a xs:decimal value with up to 6 digits (e.g. '12.5' represents 12.5%). If no information is given, 100% is assumed.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/communication-of-percentages
+     *
+     * @var float $rightSharePercentage
+     */
+    private $rightSharePercentage = null;
+
+    /**
+     * The country of registration.
+     *
+     * @var \DedexBundle\Entity\Ern42\AllTerritoryCodeType[] $territory
+     */
+    private $territory = [
+        
+    ];
+
+    /**
+     * The Date that marks the beginning of the title (in ISO 8601 format: YYYY-MM-DD).
+     *
+     * @var string $startDate
+     */
+    private $startDate = null;
+
+    /**
+     * The Date that marks the end of the title (in ISO 8601 format: YYYY-MM-DD).
+     *
+     * @var string $endDate
+     */
+    private $endDate = null;
+
+    /**
+     * Gets as rightsControllerPartyReference
+     *
+     * A Reference for a Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @return string
+     */
+    public function getRightsControllerPartyReference()
+    {
+        return $this->rightsControllerPartyReference;
+    }
+
+    /**
+     * Sets a new rightsControllerPartyReference
+     *
+     * A Reference for a Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.
+     *
+     * @param string $rightsControllerPartyReference
+     * @return self
+     */
+    public function setRightsControllerPartyReference($rightsControllerPartyReference)
+    {
+        $this->rightsControllerPartyReference = $rightsControllerPartyReference;
+        return $this;
+    }
+
+    /**
+     * Adds as rightsControlType
+     *
+     * A role that describes the Party involved in the administration of Rights.
+     *
+     * @return self
+     * @param string $rightsControlType
+     */
+    public function addToRightsControlType($rightsControlType)
+    {
+        $this->rightsControlType[] = $rightsControlType;
+        return $this;
+    }
+
+    /**
+     * isset rightsControlType
+     *
+     * A role that describes the Party involved in the administration of Rights.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetRightsControlType($index)
+    {
+        return isset($this->rightsControlType[$index]);
+    }
+
+    /**
+     * unset rightsControlType
+     *
+     * A role that describes the Party involved in the administration of Rights.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetRightsControlType($index)
+    {
+        unset($this->rightsControlType[$index]);
+    }
+
+    /**
+     * Gets as rightsControlType
+     *
+     * A role that describes the Party involved in the administration of Rights.
+     *
+     * @return string[]
+     */
+    public function getRightsControlType()
+    {
+        return $this->rightsControlType;
+    }
+
+    /**
+     * Sets a new rightsControlType
+     *
+     * A role that describes the Party involved in the administration of Rights.
+     *
+     * @param string $rightsControlType
+     * @return self
+     */
+    public function setRightsControlType(?array $rightsControlType = null)
+    {
+        $this->rightsControlType = $rightsControlType;
+        return $this;
+    }
+
+    /**
+     * Gets as rightsControllerType
+     *
+     * A type of the RightsController.
+     *
+     * @return string
+     */
+    public function getRightsControllerType()
+    {
+        return $this->rightsControllerType;
+    }
+
+    /**
+     * Sets a new rightsControllerType
+     *
+     * A type of the RightsController.
+     *
+     * @param string $rightsControllerType
+     * @return self
+     */
+    public function setRightsControllerType($rightsControllerType)
+    {
+        $this->rightsControllerType = $rightsControllerType;
+        return $this;
+    }
+
+    /**
+     * Gets as rightShareUnknown
+     *
+     * The Flag indicating whether the RightSharePercentage is unknown (=true) or not (=false).
+     *
+     * @return bool
+     */
+    public function getRightShareUnknown()
+    {
+        return $this->rightShareUnknown;
+    }
+
+    /**
+     * Sets a new rightShareUnknown
+     *
+     * The Flag indicating whether the RightSharePercentage is unknown (=true) or not (=false).
+     *
+     * @param bool $rightShareUnknown
+     * @return self
+     */
+    public function setRightShareUnknown($rightShareUnknown)
+    {
+        $this->rightShareUnknown = $rightShareUnknown;
+        return $this;
+    }
+
+    /**
+     * Gets as rightSharePercentage
+     *
+     * The share of the licensed Rights owned by the RightsController. RightShare information is given as a xs:decimal value with up to 6 digits (e.g. '12.5' represents 12.5%). If no information is given, 100% is assumed.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/communication-of-percentages
+     *
+     * @return float
+     */
+    public function getRightSharePercentage()
+    {
+        return $this->rightSharePercentage;
+    }
+
+    /**
+     * Sets a new rightSharePercentage
+     *
+     * The share of the licensed Rights owned by the RightsController. RightShare information is given as a xs:decimal value with up to 6 digits (e.g. '12.5' represents 12.5%). If no information is given, 100% is assumed.
+     * Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/communication-of-percentages
+     *
+     * @param float $rightSharePercentage
+     * @return self
+     */
+    public function setRightSharePercentage($rightSharePercentage)
+    {
+        $this->rightSharePercentage = $rightSharePercentage;
+        return $this;
+    }
+
+    /**
+     * Adds as territory
+     *
+     * The country of registration.
+     *
+     * @return self
+     * @param \DedexBundle\Entity\Ern42\AllTerritoryCodeType $territory
+     */
+    public function addToTerritory(\DedexBundle\Entity\Ern42\AllTerritoryCodeType $territory)
+    {
+        $this->territory[] = $territory;
+        return $this;
+    }
+
+    /**
+     * isset territory
+     *
+     * The country of registration.
+     *
+     * @param int|string $index
+     * @return bool
+     */
+    public function issetTerritory($index)
+    {
+        return isset($this->territory[$index]);
+    }
+
+    /**
+     * unset territory
+     *
+     * The country of registration.
+     *
+     * @param int|string $index
+     * @return void
+     */
+    public function unsetTerritory($index)
+    {
+        unset($this->territory[$index]);
+    }
+
+    /**
+     * Gets as territory
+     *
+     * The country of registration.
+     *
+     * @return \DedexBundle\Entity\Ern42\AllTerritoryCodeType[]
+     */
+    public function getTerritory()
+    {
+        return $this->territory;
+    }
+
+    /**
+     * Sets a new territory
+     *
+     * The country of registration.
+     *
+     * @param \DedexBundle\Entity\Ern42\AllTerritoryCodeType[] $territory
+     * @return self
+     */
+    public function setTerritory(?array $territory = null)
+    {
+        $this->territory = $territory;
+        return $this;
+    }
+
+    /**
+     * Gets as startDate
+     *
+     * The Date that marks the beginning of the title (in ISO 8601 format: YYYY-MM-DD).
+     *
+     * @return string
+     */
+    public function getStartDate()
+    {
+        return $this->startDate;
+    }
+
+    /**
+     * Sets a new startDate
+     *
+     * The Date that marks the beginning of the title (in ISO 8601 format: YYYY-MM-DD).
+     *
+     * @param string $startDate
+     * @return self
+     */
+    public function setStartDate($startDate)
+    {
+        $this->startDate = $startDate;
+        return $this;
+    }
+
+    /**
+     * Gets as endDate
+     *
+     * The Date that marks the end of the title (in ISO 8601 format: YYYY-MM-DD).
+     *
+     * @return string
+     */
+    public function getEndDate()
+    {
+        return $this->endDate;
+    }
+
+    /**
+     * Sets a new endDate
+     *
+     * The Date that marks the end of the title (in ISO 8601 format: YYYY-MM-DD).
+     *
+     * @param string $endDate
+     * @return self
+     */
+    public function setEndDate($endDate)
+    {
+        $this->endDate = $endDate;
+        return $this;
+    }
+}
+

--- a/src/Entity/Ern42/metadata/AdditionalTitleType.yml
+++ b/src/Entity/Ern42/metadata/AdditionalTitleType.yml
@@ -1,0 +1,75 @@
+DedexBundle\Entity\Ern42\AdditionalTitleType:
+    properties:
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        titleType:
+            expose: true
+            access_type: public_method
+            serialized_name: TitleType
+            accessor:
+                getter: getTitleType
+                setter: setTitleType
+            xml_attribute: true
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool
+        titleText:
+            expose: true
+            access_type: public_method
+            serialized_name: TitleText
+            accessor:
+                getter: getTitleText
+                setter: setTitleText
+            type: string
+        subTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: SubTitle
+            accessor:
+                getter: getSubTitle
+                setter: setSubTitle
+            xml_list:
+                inline: true
+                entry_name: SubTitle
+            type: array<DedexBundle\Entity\Ern42\DisplaySubTitleType>

--- a/src/Entity/Ern42/metadata/AdministratingRecordCompanyRoleType.yml
+++ b/src/Entity/Ern42/metadata/AdministratingRecordCompanyRoleType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\AdministratingRecordCompanyRoleType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/AdministratingRecordCompanyWithReferenceType.yml
+++ b/src/Entity/Ern42/metadata/AdministratingRecordCompanyWithReferenceType.yml
@@ -1,0 +1,18 @@
+DedexBundle\Entity\Ern42\AdministratingRecordCompanyWithReferenceType:
+    properties:
+        recordCompanyPartyReference:
+            expose: true
+            access_type: public_method
+            serialized_name: RecordCompanyPartyReference
+            accessor:
+                getter: getRecordCompanyPartyReference
+                setter: setRecordCompanyPartyReference
+            type: string
+        role:
+            expose: true
+            access_type: public_method
+            serialized_name: Role
+            accessor:
+                getter: getRole
+                setter: setRole
+            type: DedexBundle\Entity\Ern42\AdministratingRecordCompanyRoleType

--- a/src/Entity/Ern42/metadata/AffiliationType.yml
+++ b/src/Entity/Ern42/metadata/AffiliationType.yml
@@ -1,0 +1,75 @@
+DedexBundle\Entity\Ern42\AffiliationType:
+    properties:
+        companyName:
+            expose: true
+            access_type: public_method
+            serialized_name: CompanyName
+            accessor:
+                getter: getCompanyName
+                setter: setCompanyName
+            type: string
+        partyAffiliateReference:
+            expose: true
+            access_type: public_method
+            serialized_name: PartyAffiliateReference
+            accessor:
+                getter: getPartyAffiliateReference
+                setter: setPartyAffiliateReference
+            type: string
+        type:
+            expose: true
+            access_type: public_method
+            serialized_name: Type
+            accessor:
+                getter: getType
+                setter: setType
+            type: string
+        territoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: TerritoryCode
+            accessor:
+                getter: getTerritoryCode
+                setter: setTerritoryCode
+            xml_list:
+                inline: true
+                entry_name: TerritoryCode
+            type: array<DedexBundle\Entity\Ern42\CurrentTerritoryCodeType>
+        excludedTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ExcludedTerritoryCode
+            accessor:
+                getter: getExcludedTerritoryCode
+                setter: setExcludedTerritoryCode
+            xml_list:
+                inline: true
+                entry_name: ExcludedTerritoryCode
+            type: array<DedexBundle\Entity\Ern42\CurrentTerritoryCodeType>
+        validityPeriod:
+            expose: true
+            access_type: public_method
+            serialized_name: ValidityPeriod
+            accessor:
+                getter: getValidityPeriod
+                setter: setValidityPeriod
+            type: DedexBundle\Entity\Ern42\ValidityPeriodType
+        rightsType:
+            expose: true
+            access_type: public_method
+            serialized_name: RightsType
+            accessor:
+                getter: getRightsType
+                setter: setRightsType
+            xml_list:
+                inline: true
+                entry_name: RightsType
+            type: array<DedexBundle\Entity\Ern42\SimpleRightsTypeType>
+        percentageOfRightsAssignment:
+            expose: true
+            access_type: public_method
+            serialized_name: PercentageOfRightsAssignment
+            accessor:
+                getter: getPercentageOfRightsAssignment
+                setter: setPercentageOfRightsAssignment
+            type: float

--- a/src/Entity/Ern42/metadata/AllTerritoryCodeType.yml
+++ b/src/Entity/Ern42/metadata/AllTerritoryCodeType.yml
@@ -1,0 +1,19 @@
+DedexBundle\Entity\Ern42\AllTerritoryCodeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        identifierType:
+            expose: true
+            access_type: public_method
+            serialized_name: IdentifierType
+            accessor:
+                getter: getIdentifierType
+                setter: setIdentifierType
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/AspectRatioType.yml
+++ b/src/Entity/Ern42/metadata/AspectRatioType.yml
@@ -1,0 +1,19 @@
+DedexBundle\Entity\Ern42\AspectRatioType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: float
+        aspectRatioType:
+            expose: true
+            access_type: public_method
+            serialized_name: AspectRatioType
+            accessor:
+                getter: getAspectRatioType
+                setter: setAspectRatioType
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/AudioCodecTypeType.yml
+++ b/src/Entity/Ern42/metadata/AudioCodecTypeType.yml
@@ -1,0 +1,37 @@
+DedexBundle\Entity\Ern42\AudioCodecTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        version:
+            expose: true
+            access_type: public_method
+            serialized_name: Version
+            accessor:
+                getter: getVersion
+                setter: setVersion
+            xml_attribute: true
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/AvRatingType.yml
+++ b/src/Entity/Ern42/metadata/AvRatingType.yml
@@ -1,0 +1,44 @@
+DedexBundle\Entity\Ern42\AvRatingType:
+    properties:
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool
+        rating:
+            expose: true
+            access_type: public_method
+            serialized_name: Rating
+            accessor:
+                getter: getRating
+                setter: setRating
+            type: string
+        agency:
+            expose: true
+            access_type: public_method
+            serialized_name: Agency
+            accessor:
+                getter: getAgency
+                setter: setAgency
+            type: DedexBundle\Entity\Ern42\RatingAgencyType
+        reason:
+            expose: true
+            access_type: public_method
+            serialized_name: Reason
+            accessor:
+                getter: getReason
+                setter: setReason
+            type: DedexBundle\Entity\Ern42\RatingReasonType

--- a/src/Entity/Ern42/metadata/BitRateType.yml
+++ b/src/Entity/Ern42/metadata/BitRateType.yml
@@ -1,0 +1,19 @@
+DedexBundle\Entity\Ern42\BitRateType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: float
+        unitOfMeasure:
+            expose: true
+            access_type: public_method
+            serialized_name: UnitOfMeasure
+            accessor:
+                getter: getUnitOfMeasure
+                setter: setUnitOfMeasure
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/CLineType.yml
+++ b/src/Entity/Ern42/metadata/CLineType.yml
@@ -1,0 +1,35 @@
+DedexBundle\Entity\Ern42\CLineType:
+    properties:
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        year:
+            expose: true
+            access_type: public_method
+            serialized_name: Year
+            accessor:
+                getter: getYear
+                setter: setYear
+            type: int
+        cLineCompany:
+            expose: true
+            access_type: public_method
+            serialized_name: CLineCompany
+            accessor:
+                getter: getCLineCompany
+                setter: setCLineCompany
+            type: string
+        cLineText:
+            expose: true
+            access_type: public_method
+            serialized_name: CLineText
+            accessor:
+                getter: getCLineText
+                setter: setCLineText
+            type: string

--- a/src/Entity/Ern42/metadata/CLineWithDefaultType.yml
+++ b/src/Entity/Ern42/metadata/CLineWithDefaultType.yml
@@ -1,0 +1,53 @@
+DedexBundle\Entity\Ern42\CLineWithDefaultType:
+    properties:
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        year:
+            expose: true
+            access_type: public_method
+            serialized_name: Year
+            accessor:
+                getter: getYear
+                setter: setYear
+            type: int
+        cLineCompany:
+            expose: true
+            access_type: public_method
+            serialized_name: CLineCompany
+            accessor:
+                getter: getCLineCompany
+                setter: setCLineCompany
+            type: string
+        cLineText:
+            expose: true
+            access_type: public_method
+            serialized_name: CLineText
+            accessor:
+                getter: getCLineText
+                setter: setCLineText
+            type: string

--- a/src/Entity/Ern42/metadata/CarrierTypeType.yml
+++ b/src/Entity/Ern42/metadata/CarrierTypeType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\CarrierTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/CatalogNumberType.yml
+++ b/src/Entity/Ern42/metadata/CatalogNumberType.yml
@@ -1,0 +1,19 @@
+DedexBundle\Entity\Ern42\CatalogNumberType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/ChapterListType.yml
+++ b/src/Entity/Ern42/metadata/ChapterListType.yml
@@ -1,0 +1,22 @@
+DedexBundle\Entity\Ern42\ChapterListType:
+    properties:
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        chapter:
+            expose: true
+            access_type: public_method
+            serialized_name: Chapter
+            accessor:
+                getter: getChapter
+                setter: setChapter
+            xml_list:
+                inline: true
+                entry_name: Chapter
+            type: array<DedexBundle\Entity\Ern42\ChapterType>

--- a/src/Entity/Ern42/metadata/ChapterType.yml
+++ b/src/Entity/Ern42/metadata/ChapterType.yml
@@ -1,0 +1,125 @@
+DedexBundle\Entity\Ern42\ChapterType:
+    properties:
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        chapterReference:
+            expose: true
+            access_type: public_method
+            serialized_name: ChapterReference
+            accessor:
+                getter: getChapterReference
+                setter: setChapterReference
+            type: string
+        chapterId:
+            expose: true
+            access_type: public_method
+            serialized_name: ChapterId
+            accessor:
+                getter: getChapterId
+                setter: setChapterId
+            xml_list:
+                inline: true
+                entry_name: ChapterId
+            type: array<DedexBundle\Entity\Ern42\ProprietaryIdType>
+        displayTitleText:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayTitleText
+            accessor:
+                getter: getDisplayTitleText
+                setter: setDisplayTitleText
+            xml_list:
+                inline: true
+                entry_name: DisplayTitleText
+            type: array<DedexBundle\Entity\Ern42\DisplayTitleTextType>
+        displayTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayTitle
+            accessor:
+                getter: getDisplayTitle
+                setter: setDisplayTitle
+            xml_list:
+                inline: true
+                entry_name: DisplayTitle
+            type: array<DedexBundle\Entity\Ern42\DisplayTitleType>
+        additionalTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: AdditionalTitle
+            accessor:
+                getter: getAdditionalTitle
+                setter: setAdditionalTitle
+            xml_list:
+                inline: true
+                entry_name: AdditionalTitle
+            type: array<DedexBundle\Entity\Ern42\AdditionalTitleType>
+        sequenceNumber:
+            expose: true
+            access_type: public_method
+            serialized_name: SequenceNumber
+            accessor:
+                getter: getSequenceNumber
+                setter: setSequenceNumber
+            type: int
+        contributor:
+            expose: true
+            access_type: public_method
+            serialized_name: Contributor
+            accessor:
+                getter: getContributor
+                setter: setContributor
+            xml_list:
+                inline: true
+                entry_name: Contributor
+            type: array<DedexBundle\Entity\Ern42\ContributorType>
+        character:
+            expose: true
+            access_type: public_method
+            serialized_name: Character
+            accessor:
+                getter: getCharacter
+                setter: setCharacter
+            xml_list:
+                inline: true
+                entry_name: Character
+            type: array<DedexBundle\Entity\Ern42\CharacterType>
+        representativeImageReference:
+            expose: true
+            access_type: public_method
+            serialized_name: RepresentativeImageReference
+            accessor:
+                getter: getRepresentativeImageReference
+                setter: setRepresentativeImageReference
+            type: string
+        startTime:
+            expose: true
+            access_type: public_method
+            serialized_name: StartTime
+            accessor:
+                getter: getStartTime
+                setter: setStartTime
+            type: DateInterval
+        duration:
+            expose: true
+            access_type: public_method
+            serialized_name: Duration
+            accessor:
+                getter: getDuration
+                setter: setDuration
+            type: DateInterval
+        endTime:
+            expose: true
+            access_type: public_method
+            serialized_name: EndTime
+            accessor:
+                getter: getEndTime
+                setter: setEndTime
+            type: DateInterval

--- a/src/Entity/Ern42/metadata/CharacterType.yml
+++ b/src/Entity/Ern42/metadata/CharacterType.yml
@@ -1,0 +1,27 @@
+DedexBundle\Entity\Ern42\CharacterType:
+    properties:
+        sequenceNumber:
+            expose: true
+            access_type: public_method
+            serialized_name: SequenceNumber
+            accessor:
+                getter: getSequenceNumber
+                setter: setSequenceNumber
+            xml_attribute: true
+            type: int
+        characterPartyReference:
+            expose: true
+            access_type: public_method
+            serialized_name: CharacterPartyReference
+            accessor:
+                getter: getCharacterPartyReference
+                setter: setCharacterPartyReference
+            type: string
+        performer:
+            expose: true
+            access_type: public_method
+            serialized_name: Performer
+            accessor:
+                getter: getPerformer
+                setter: setPerformer
+            type: DedexBundle\Entity\Ern42\ContributorType

--- a/src/Entity/Ern42/metadata/CommercialModelTypeType.yml
+++ b/src/Entity/Ern42/metadata/CommercialModelTypeType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\CommercialModelTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/ConditionForRightsClaimPolicyType.yml
+++ b/src/Entity/Ern42/metadata/ConditionForRightsClaimPolicyType.yml
@@ -1,0 +1,42 @@
+DedexBundle\Entity\Ern42\ConditionForRightsClaimPolicyType:
+    properties:
+        value:
+            expose: true
+            access_type: public_method
+            serialized_name: Value
+            accessor:
+                getter: getValue
+                setter: setValue
+            type: float
+        unit:
+            expose: true
+            access_type: public_method
+            serialized_name: Unit
+            accessor:
+                getter: getUnit
+                setter: setUnit
+            type: string
+        referenceCreation:
+            expose: true
+            access_type: public_method
+            serialized_name: ReferenceCreation
+            accessor:
+                getter: getReferenceCreation
+                setter: setReferenceCreation
+            type: string
+        relationalRelator:
+            expose: true
+            access_type: public_method
+            serialized_name: RelationalRelator
+            accessor:
+                getter: getRelationalRelator
+                setter: setRelationalRelator
+            type: string
+        measurementType:
+            expose: true
+            access_type: public_method
+            serialized_name: MeasurementType
+            accessor:
+                getter: getMeasurementType
+                setter: setMeasurementType
+            type: string

--- a/src/Entity/Ern42/metadata/ContainerFormatType.yml
+++ b/src/Entity/Ern42/metadata/ContainerFormatType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\ContainerFormatType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/ContributorRoleType.yml
+++ b/src/Entity/Ern42/metadata/ContributorRoleType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\ContributorRoleType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/ContributorType.yml
+++ b/src/Entity/Ern42/metadata/ContributorType.yml
@@ -1,0 +1,76 @@
+DedexBundle\Entity\Ern42\ContributorType:
+    properties:
+        sequenceNumber:
+            expose: true
+            access_type: public_method
+            serialized_name: SequenceNumber
+            accessor:
+                getter: getSequenceNumber
+                setter: setSequenceNumber
+            xml_attribute: true
+            type: int
+        contributorPartyReference:
+            expose: true
+            access_type: public_method
+            serialized_name: ContributorPartyReference
+            accessor:
+                getter: getContributorPartyReference
+                setter: setContributorPartyReference
+            type: string
+        role:
+            expose: true
+            access_type: public_method
+            serialized_name: Role
+            accessor:
+                getter: getRole
+                setter: setRole
+            xml_list:
+                inline: true
+                entry_name: Role
+            type: array<DedexBundle\Entity\Ern42\ContributorRoleType>
+        instrumentType:
+            expose: true
+            access_type: public_method
+            serialized_name: InstrumentType
+            accessor:
+                getter: getInstrumentType
+                setter: setInstrumentType
+            xml_list:
+                inline: true
+                entry_name: InstrumentType
+            type: array<DedexBundle\Entity\Ern42\InstrumentTypeType>
+        hasMadeFeaturedContribution:
+            expose: true
+            access_type: public_method
+            serialized_name: HasMadeFeaturedContribution
+            accessor:
+                getter: getHasMadeFeaturedContribution
+                setter: setHasMadeFeaturedContribution
+            type: bool
+        hasMadeContractedContribution:
+            expose: true
+            access_type: public_method
+            serialized_name: HasMadeContractedContribution
+            accessor:
+                getter: getHasMadeContractedContribution
+                setter: setHasMadeContractedContribution
+            type: bool
+        isCredited:
+            expose: true
+            access_type: public_method
+            serialized_name: IsCredited
+            accessor:
+                getter: getIsCredited
+                setter: setIsCredited
+            type: DedexBundle\Entity\Ern42\IsCreditedType
+        displayCredits:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayCredits
+            accessor:
+                getter: getDisplayCredits
+                setter: setDisplayCredits
+            xml_list:
+                inline: true
+                entry_name: DisplayCredits
+            type: array<DedexBundle\Entity\Ern42\DisplayCreditsType>

--- a/src/Entity/Ern42/metadata/CoreAreaType.yml
+++ b/src/Entity/Ern42/metadata/CoreAreaType.yml
@@ -1,0 +1,18 @@
+DedexBundle\Entity\Ern42\CoreAreaType:
+    properties:
+        topLeftCorner:
+            expose: true
+            access_type: public_method
+            serialized_name: TopLeftCorner
+            accessor:
+                getter: getTopLeftCorner
+                setter: setTopLeftCorner
+            type: string
+        bottomRightCorner:
+            expose: true
+            access_type: public_method
+            serialized_name: BottomRightCorner
+            accessor:
+                getter: getBottomRightCorner
+                setter: setBottomRightCorner
+            type: string

--- a/src/Entity/Ern42/metadata/CourtesyLineWithDefaultType.yml
+++ b/src/Entity/Ern42/metadata/CourtesyLineWithDefaultType.yml
@@ -1,0 +1,37 @@
+DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool

--- a/src/Entity/Ern42/metadata/CueOriginType.yml
+++ b/src/Entity/Ern42/metadata/CueOriginType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\CueOriginType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/CueSheetTypeType.yml
+++ b/src/Entity/Ern42/metadata/CueSheetTypeType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\CueSheetTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/CueThemeTypeType.yml
+++ b/src/Entity/Ern42/metadata/CueThemeTypeType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\CueThemeTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/CueUseTypeType.yml
+++ b/src/Entity/Ern42/metadata/CueUseTypeType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\CueUseTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/CueVisualPerceptionTypeType.yml
+++ b/src/Entity/Ern42/metadata/CueVisualPerceptionTypeType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\CueVisualPerceptionTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/CueVocalTypeType.yml
+++ b/src/Entity/Ern42/metadata/CueVocalTypeType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\CueVocalTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/CurrentTerritoryCodeType.yml
+++ b/src/Entity/Ern42/metadata/CurrentTerritoryCodeType.yml
@@ -1,0 +1,19 @@
+DedexBundle\Entity\Ern42\CurrentTerritoryCodeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        identifierType:
+            expose: true
+            access_type: public_method
+            serialized_name: IdentifierType
+            accessor:
+                getter: getIdentifierType
+                setter: setIdentifierType
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/DSPType.yml
+++ b/src/Entity/Ern42/metadata/DSPType.yml
@@ -1,0 +1,43 @@
+DedexBundle\Entity\Ern42\DSPType:
+    properties:
+        partyId:
+            expose: true
+            access_type: public_method
+            serialized_name: PartyId
+            accessor:
+                getter: getPartyId
+                setter: setPartyId
+            xml_list:
+                inline: true
+                entry_name: PartyId
+            type: array<DedexBundle\Entity\Ern42\DetailedPartyIdType>
+        partyName:
+            expose: true
+            access_type: public_method
+            serialized_name: PartyName
+            accessor:
+                getter: getPartyName
+                setter: setPartyName
+            xml_list:
+                inline: true
+                entry_name: PartyName
+            type: array<DedexBundle\Entity\Ern42\PartyNameType>
+        tradingName:
+            expose: true
+            access_type: public_method
+            serialized_name: TradingName
+            accessor:
+                getter: getTradingName
+                setter: setTradingName
+            type: DedexBundle\Entity\Ern42\NameType
+        uRL:
+            expose: true
+            access_type: public_method
+            serialized_name: URL
+            accessor:
+                getter: getURL
+                setter: setURL
+            xml_list:
+                inline: true
+                entry_name: URL
+            type: array<string>

--- a/src/Entity/Ern42/metadata/DealListType.yml
+++ b/src/Entity/Ern42/metadata/DealListType.yml
@@ -1,0 +1,35 @@
+DedexBundle\Entity\Ern42\DealListType:
+    properties:
+        releaseDeal:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseDeal
+            accessor:
+                getter: getReleaseDeal
+                setter: setReleaseDeal
+            xml_list:
+                inline: true
+                entry_name: ReleaseDeal
+            type: array<DedexBundle\Entity\Ern42\ReleaseDealType>
+        releaseVisibility:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseVisibility
+            accessor:
+                getter: getReleaseVisibility
+                setter: setReleaseVisibility
+            xml_list:
+                inline: true
+                entry_name: ReleaseVisibility
+            type: array<DedexBundle\Entity\Ern42\ReleaseVisibilityType>
+        trackReleaseVisibility:
+            expose: true
+            access_type: public_method
+            serialized_name: TrackReleaseVisibility
+            accessor:
+                getter: getTrackReleaseVisibility
+                setter: setTrackReleaseVisibility
+            xml_list:
+                inline: true
+                entry_name: TrackReleaseVisibility
+            type: array<DedexBundle\Entity\Ern42\TrackReleaseVisibilityType>

--- a/src/Entity/Ern42/metadata/DealResourceReferenceListType.yml
+++ b/src/Entity/Ern42/metadata/DealResourceReferenceListType.yml
@@ -1,0 +1,13 @@
+DedexBundle\Entity\Ern42\DealResourceReferenceListType:
+    properties:
+        dealResourceReference:
+            expose: true
+            access_type: public_method
+            serialized_name: DealResourceReference
+            accessor:
+                getter: getDealResourceReference
+                setter: setDealResourceReference
+            xml_list:
+                inline: true
+                entry_name: DealResourceReference
+            type: array<string>

--- a/src/Entity/Ern42/metadata/DealTechnicalResourceDetailsReferenceListType.yml
+++ b/src/Entity/Ern42/metadata/DealTechnicalResourceDetailsReferenceListType.yml
@@ -1,0 +1,13 @@
+DedexBundle\Entity\Ern42\DealTechnicalResourceDetailsReferenceListType:
+    properties:
+        dealTechnicalResourceDetailsReference:
+            expose: true
+            access_type: public_method
+            serialized_name: DealTechnicalResourceDetailsReference
+            accessor:
+                getter: getDealTechnicalResourceDetailsReference
+                setter: setDealTechnicalResourceDetailsReference
+            xml_list:
+                inline: true
+                entry_name: DealTechnicalResourceDetailsReference
+            type: array<string>

--- a/src/Entity/Ern42/metadata/DealTermsTechnicalInstantiationType.yml
+++ b/src/Entity/Ern42/metadata/DealTermsTechnicalInstantiationType.yml
@@ -1,0 +1,26 @@
+DedexBundle\Entity\Ern42\DealTermsTechnicalInstantiationType:
+    properties:
+        videoDefinitionType:
+            expose: true
+            access_type: public_method
+            serialized_name: VideoDefinitionType
+            accessor:
+                getter: getVideoDefinitionType
+                setter: setVideoDefinitionType
+            type: DedexBundle\Entity\Ern42\VideoDefinitionTypeType
+        codingType:
+            expose: true
+            access_type: public_method
+            serialized_name: CodingType
+            accessor:
+                getter: getCodingType
+                setter: setCodingType
+            type: string
+        bitRate:
+            expose: true
+            access_type: public_method
+            serialized_name: BitRate
+            accessor:
+                getter: getBitRate
+                setter: setBitRate
+            type: DedexBundle\Entity\Ern42\BitRateType

--- a/src/Entity/Ern42/metadata/DealTermsType.yml
+++ b/src/Entity/Ern42/metadata/DealTermsType.yml
@@ -1,0 +1,191 @@
+DedexBundle\Entity\Ern42\DealTermsType:
+    properties:
+        territoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: TerritoryCode
+            accessor:
+                getter: getTerritoryCode
+                setter: setTerritoryCode
+            xml_list:
+                inline: true
+                entry_name: TerritoryCode
+            type: array<DedexBundle\Entity\Ern42\CurrentTerritoryCodeType>
+        excludedTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ExcludedTerritoryCode
+            accessor:
+                getter: getExcludedTerritoryCode
+                setter: setExcludedTerritoryCode
+            xml_list:
+                inline: true
+                entry_name: ExcludedTerritoryCode
+            type: array<DedexBundle\Entity\Ern42\CurrentTerritoryCodeType>
+        validityPeriod:
+            expose: true
+            access_type: public_method
+            serialized_name: ValidityPeriod
+            accessor:
+                getter: getValidityPeriod
+                setter: setValidityPeriod
+            xml_list:
+                inline: true
+                entry_name: ValidityPeriod
+            type: array<DedexBundle\Entity\Ern42\PeriodWithStartDateType>
+        commercialModelType:
+            expose: true
+            access_type: public_method
+            serialized_name: CommercialModelType
+            accessor:
+                getter: getCommercialModelType
+                setter: setCommercialModelType
+            xml_list:
+                inline: true
+                entry_name: CommercialModelType
+            type: array<DedexBundle\Entity\Ern42\CommercialModelTypeType>
+        useType:
+            expose: true
+            access_type: public_method
+            serialized_name: UseType
+            accessor:
+                getter: getUseType
+                setter: setUseType
+            xml_list:
+                inline: true
+                entry_name: UseType
+            type: array<DedexBundle\Entity\Ern42\DiscoverableUseTypeType>
+        userInterfaceType:
+            expose: true
+            access_type: public_method
+            serialized_name: UserInterfaceType
+            accessor:
+                getter: getUserInterfaceType
+                setter: setUserInterfaceType
+            xml_list:
+                inline: true
+                entry_name: UserInterfaceType
+            type: array<DedexBundle\Entity\Ern42\UserInterfaceTypeType>
+        carrierType:
+            expose: true
+            access_type: public_method
+            serialized_name: CarrierType
+            accessor:
+                getter: getCarrierType
+                setter: setCarrierType
+            xml_list:
+                inline: true
+                entry_name: CarrierType
+            type: array<DedexBundle\Entity\Ern42\CarrierTypeType>
+        technicalInstantiation:
+            expose: true
+            access_type: public_method
+            serialized_name: TechnicalInstantiation
+            accessor:
+                getter: getTechnicalInstantiation
+                setter: setTechnicalInstantiation
+            type: DedexBundle\Entity\Ern42\DealTermsTechnicalInstantiationType
+        numberOfUsages:
+            expose: true
+            access_type: public_method
+            serialized_name: NumberOfUsages
+            accessor:
+                getter: getNumberOfUsages
+                setter: setNumberOfUsages
+            type: int
+        distributionChannel:
+            expose: true
+            access_type: public_method
+            serialized_name: DistributionChannel
+            accessor:
+                getter: getDistributionChannel
+                setter: setDistributionChannel
+            xml_list:
+                inline: true
+                entry_name: DistributionChannel
+            type: array<DedexBundle\Entity\Ern42\DSPType>
+        excludedDistributionChannel:
+            expose: true
+            access_type: public_method
+            serialized_name: ExcludedDistributionChannel
+            accessor:
+                getter: getExcludedDistributionChannel
+                setter: setExcludedDistributionChannel
+            xml_list:
+                inline: true
+                entry_name: ExcludedDistributionChannel
+            type: array<DedexBundle\Entity\Ern42\DSPType>
+        rightsClaimPolicy:
+            expose: true
+            access_type: public_method
+            serialized_name: RightsClaimPolicy
+            accessor:
+                getter: getRightsClaimPolicy
+                setter: setRightsClaimPolicy
+            xml_list:
+                inline: true
+                entry_name: RightsClaimPolicy
+            type: array<DedexBundle\Entity\Ern42\RightsClaimPolicyType>
+        priceInformation:
+            expose: true
+            access_type: public_method
+            serialized_name: PriceInformation
+            accessor:
+                getter: getPriceInformation
+                setter: setPriceInformation
+            xml_list:
+                inline: true
+                entry_name: PriceInformation
+            type: array<DedexBundle\Entity\Ern42\PriceInformationWithTypeType>
+        isPromotional:
+            expose: true
+            access_type: public_method
+            serialized_name: IsPromotional
+            accessor:
+                getter: getIsPromotional
+                setter: setIsPromotional
+            type: bool
+        promotionalCode:
+            expose: true
+            access_type: public_method
+            serialized_name: PromotionalCode
+            accessor:
+                getter: getPromotionalCode
+                setter: setPromotionalCode
+            type: DedexBundle\Entity\Ern42\PromotionalCodeType
+        isPreOrderDeal:
+            expose: true
+            access_type: public_method
+            serialized_name: IsPreOrderDeal
+            accessor:
+                getter: getIsPreOrderDeal
+                setter: setIsPreOrderDeal
+            type: bool
+        instantGratificationResourceList:
+            expose: true
+            access_type: public_method
+            serialized_name: InstantGratificationResourceList
+            accessor:
+                getter: getInstantGratificationResourceList
+                setter: setInstantGratificationResourceList
+            type: array<string>
+            xml_list:
+                inline: false
+                entry_name: DealResourceReference
+                skip_when_empty: true
+        physicalReturns:
+            expose: true
+            access_type: public_method
+            serialized_name: PhysicalReturns
+            accessor:
+                getter: getPhysicalReturns
+                setter: setPhysicalReturns
+            type: DedexBundle\Entity\Ern42\PhysicalReturnsType
+        numberOfProductsPerCarton:
+            expose: true
+            access_type: public_method
+            serialized_name: NumberOfProductsPerCarton
+            accessor:
+                getter: getNumberOfProductsPerCarton
+                setter: setNumberOfProductsPerCarton
+            type: int

--- a/src/Entity/Ern42/metadata/DealType.yml
+++ b/src/Entity/Ern42/metadata/DealType.yml
@@ -1,0 +1,52 @@
+DedexBundle\Entity\Ern42\DealType:
+    properties:
+        dealReference:
+            expose: true
+            access_type: public_method
+            serialized_name: DealReference
+            accessor:
+                getter: getDealReference
+                setter: setDealReference
+            xml_list:
+                inline: true
+                entry_name: DealReference
+            type: array<string>
+        isCommunicatedOutOfBand:
+            expose: true
+            access_type: public_method
+            serialized_name: IsCommunicatedOutOfBand
+            accessor:
+                getter: getIsCommunicatedOutOfBand
+                setter: setIsCommunicatedOutOfBand
+            type: bool
+        dealTerms:
+            expose: true
+            access_type: public_method
+            serialized_name: DealTerms
+            accessor:
+                getter: getDealTerms
+                setter: setDealTerms
+            type: DedexBundle\Entity\Ern42\DealTermsType
+        dealTechnicalResourceDetailsReferenceList:
+            expose: true
+            access_type: public_method
+            serialized_name: DealTechnicalResourceDetailsReferenceList
+            accessor:
+                getter: getDealTechnicalResourceDetailsReferenceList
+                setter: setDealTechnicalResourceDetailsReferenceList
+            type: array<string>
+            xml_list:
+                inline: false
+                entry_name: DealTechnicalResourceDetailsReference
+                skip_when_empty: true
+        distributionChannelPage:
+            expose: true
+            access_type: public_method
+            serialized_name: DistributionChannelPage
+            accessor:
+                getter: getDistributionChannelPage
+                setter: setDistributionChannelPage
+            xml_list:
+                inline: true
+                entry_name: DistributionChannelPage
+            type: array<DedexBundle\Entity\Ern42\DistributionChannelPageType>

--- a/src/Entity/Ern42/metadata/DeityType.yml
+++ b/src/Entity/Ern42/metadata/DeityType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\DeityType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool

--- a/src/Entity/Ern42/metadata/DelegatedUsageRightsType.yml
+++ b/src/Entity/Ern42/metadata/DelegatedUsageRightsType.yml
@@ -1,0 +1,32 @@
+DedexBundle\Entity\Ern42\DelegatedUsageRightsType:
+    properties:
+        useType:
+            expose: true
+            access_type: public_method
+            serialized_name: UseType
+            accessor:
+                getter: getUseType
+                setter: setUseType
+            xml_list:
+                inline: true
+                entry_name: UseType
+            type: array<DedexBundle\Entity\Ern42\UseTypeType>
+        periodOfRightsDelegation:
+            expose: true
+            access_type: public_method
+            serialized_name: PeriodOfRightsDelegation
+            accessor:
+                getter: getPeriodOfRightsDelegation
+                setter: setPeriodOfRightsDelegation
+            type: DedexBundle\Entity\Ern42\PeriodType
+        territoryOfRightsDelegation:
+            expose: true
+            access_type: public_method
+            serialized_name: TerritoryOfRightsDelegation
+            accessor:
+                getter: getTerritoryOfRightsDelegation
+                setter: setTerritoryOfRightsDelegation
+            xml_list:
+                inline: true
+                entry_name: TerritoryOfRightsDelegation
+            type: array<DedexBundle\Entity\Ern42\AllTerritoryCodeType>

--- a/src/Entity/Ern42/metadata/DescriptionWithTerritoryType.yml
+++ b/src/Entity/Ern42/metadata/DescriptionWithTerritoryType.yml
@@ -1,0 +1,37 @@
+DedexBundle\Entity\Ern42\DescriptionWithTerritoryType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool

--- a/src/Entity/Ern42/metadata/DetailedCueSheetListType.yml
+++ b/src/Entity/Ern42/metadata/DetailedCueSheetListType.yml
@@ -1,0 +1,13 @@
+DedexBundle\Entity\Ern42\DetailedCueSheetListType:
+    properties:
+        cueSheet:
+            expose: true
+            access_type: public_method
+            serialized_name: CueSheet
+            accessor:
+                getter: getCueSheet
+                setter: setCueSheet
+            xml_list:
+                inline: true
+                entry_name: CueSheet
+            type: array<DedexBundle\Entity\Ern42\DetailedCueSheetType>

--- a/src/Entity/Ern42/metadata/DetailedCueSheetType.yml
+++ b/src/Entity/Ern42/metadata/DetailedCueSheetType.yml
@@ -1,0 +1,40 @@
+DedexBundle\Entity\Ern42\DetailedCueSheetType:
+    properties:
+        cueSheetId:
+            expose: true
+            access_type: public_method
+            serialized_name: CueSheetId
+            accessor:
+                getter: getCueSheetId
+                setter: setCueSheetId
+            xml_list:
+                inline: true
+                entry_name: CueSheetId
+            type: array<DedexBundle\Entity\Ern42\ProprietaryIdType>
+        cueSheetReference:
+            expose: true
+            access_type: public_method
+            serialized_name: CueSheetReference
+            accessor:
+                getter: getCueSheetReference
+                setter: setCueSheetReference
+            type: string
+        cueSheetType:
+            expose: true
+            access_type: public_method
+            serialized_name: CueSheetType
+            accessor:
+                getter: getCueSheetType
+                setter: setCueSheetType
+            type: DedexBundle\Entity\Ern42\CueSheetTypeType
+        cue:
+            expose: true
+            access_type: public_method
+            serialized_name: Cue
+            accessor:
+                getter: getCue
+                setter: setCue
+            xml_list:
+                inline: true
+                entry_name: Cue
+            type: array<DedexBundle\Entity\Ern42\DetailedCueType>

--- a/src/Entity/Ern42/metadata/DetailedCueType.yml
+++ b/src/Entity/Ern42/metadata/DetailedCueType.yml
@@ -1,0 +1,164 @@
+DedexBundle\Entity\Ern42\DetailedCueType:
+    properties:
+        cueUseType:
+            expose: true
+            access_type: public_method
+            serialized_name: CueUseType
+            accessor:
+                getter: getCueUseType
+                setter: setCueUseType
+            type: DedexBundle\Entity\Ern42\CueUseTypeType
+        cueThemeType:
+            expose: true
+            access_type: public_method
+            serialized_name: CueThemeType
+            accessor:
+                getter: getCueThemeType
+                setter: setCueThemeType
+            type: DedexBundle\Entity\Ern42\CueThemeTypeType
+        cueVocalType:
+            expose: true
+            access_type: public_method
+            serialized_name: CueVocalType
+            accessor:
+                getter: getCueVocalType
+                setter: setCueVocalType
+            type: DedexBundle\Entity\Ern42\CueVocalTypeType
+        cueVisualPerceptionType:
+            expose: true
+            access_type: public_method
+            serialized_name: CueVisualPerceptionType
+            accessor:
+                getter: getCueVisualPerceptionType
+                setter: setCueVisualPerceptionType
+            type: DedexBundle\Entity\Ern42\CueVisualPerceptionTypeType
+        cueOrigin:
+            expose: true
+            access_type: public_method
+            serialized_name: CueOrigin
+            accessor:
+                getter: getCueOrigin
+                setter: setCueOrigin
+            type: DedexBundle\Entity\Ern42\CueOriginType
+        resourceId:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceId
+            accessor:
+                getter: getResourceId
+                setter: setResourceId
+            type: DedexBundle\Entity\Ern42\ResourceIdType
+        workId:
+            expose: true
+            access_type: public_method
+            serialized_name: WorkId
+            accessor:
+                getter: getWorkId
+                setter: setWorkId
+            type: DedexBundle\Entity\Ern42\MusicalWorkIdType
+        displayTitleText:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayTitleText
+            accessor:
+                getter: getDisplayTitleText
+                setter: setDisplayTitleText
+            xml_list:
+                inline: true
+                entry_name: DisplayTitleText
+            type: array<DedexBundle\Entity\Ern42\DisplayTitleTextType>
+        displayTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayTitle
+            accessor:
+                getter: getDisplayTitle
+                setter: setDisplayTitle
+            xml_list:
+                inline: true
+                entry_name: DisplayTitle
+            type: array<DedexBundle\Entity\Ern42\DisplayTitleType>
+        additionalTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: AdditionalTitle
+            accessor:
+                getter: getAdditionalTitle
+                setter: setAdditionalTitle
+            xml_list:
+                inline: true
+                entry_name: AdditionalTitle
+            type: array<DedexBundle\Entity\Ern42\AdditionalTitleType>
+        contributor:
+            expose: true
+            access_type: public_method
+            serialized_name: Contributor
+            accessor:
+                getter: getContributor
+                setter: setContributor
+            xml_list:
+                inline: true
+                entry_name: Contributor
+            type: array<DedexBundle\Entity\Ern42\ContributorType>
+        isDance:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDance
+            accessor:
+                getter: getIsDance
+                setter: setIsDance
+            type: bool
+        hasMusicalContent:
+            expose: true
+            access_type: public_method
+            serialized_name: HasMusicalContent
+            accessor:
+                getter: getHasMusicalContent
+                setter: setHasMusicalContent
+            type: bool
+        pLine:
+            expose: true
+            access_type: public_method
+            serialized_name: PLine
+            accessor:
+                getter: getPLine
+                setter: setPLine
+            xml_list:
+                inline: true
+                entry_name: PLine
+            type: array<DedexBundle\Entity\Ern42\PLineType>
+        cLine:
+            expose: true
+            access_type: public_method
+            serialized_name: CLine
+            accessor:
+                getter: getCLine
+                setter: setCLine
+            xml_list:
+                inline: true
+                entry_name: CLine
+            type: array<DedexBundle\Entity\Ern42\CLineType>
+        startTime:
+            expose: true
+            access_type: public_method
+            serialized_name: StartTime
+            accessor:
+                getter: getStartTime
+                setter: setStartTime
+            type: DateInterval
+        duration:
+            expose: true
+            access_type: public_method
+            serialized_name: Duration
+            accessor:
+                getter: getDuration
+                setter: setDuration
+            type: DateInterval
+        endTime:
+            expose: true
+            access_type: public_method
+            serialized_name: EndTime
+            accessor:
+                getter: getEndTime
+                setter: setEndTime
+            type: DateInterval

--- a/src/Entity/Ern42/metadata/DetailedHashSumType.yml
+++ b/src/Entity/Ern42/metadata/DetailedHashSumType.yml
@@ -1,0 +1,42 @@
+DedexBundle\Entity\Ern42\DetailedHashSumType:
+    properties:
+        algorithm:
+            expose: true
+            access_type: public_method
+            serialized_name: Algorithm
+            accessor:
+                getter: getAlgorithm
+                setter: setAlgorithm
+            type: DedexBundle\Entity\Ern42\HashSumAlgorithmTypeType
+        version:
+            expose: true
+            access_type: public_method
+            serialized_name: Version
+            accessor:
+                getter: getVersion
+                setter: setVersion
+            type: string
+        parameter:
+            expose: true
+            access_type: public_method
+            serialized_name: Parameter
+            accessor:
+                getter: getParameter
+                setter: setParameter
+            type: string
+        dataType:
+            expose: true
+            access_type: public_method
+            serialized_name: DataType
+            accessor:
+                getter: getDataType
+                setter: setDataType
+            type: string
+        hashSumValue:
+            expose: true
+            access_type: public_method
+            serialized_name: HashSumValue
+            accessor:
+                getter: getHashSumValue
+                setter: setHashSumValue
+            type: string

--- a/src/Entity/Ern42/metadata/DetailedPartyIdType.yml
+++ b/src/Entity/Ern42/metadata/DetailedPartyIdType.yml
@@ -1,0 +1,53 @@
+DedexBundle\Entity\Ern42\DetailedPartyIdType:
+    properties:
+        iSNI:
+            expose: true
+            access_type: public_method
+            serialized_name: ISNI
+            accessor:
+                getter: getISNI
+                setter: setISNI
+            type: string
+        dPID:
+            expose: true
+            access_type: public_method
+            serialized_name: DPID
+            accessor:
+                getter: getDPID
+                setter: setDPID
+            type: string
+        ipiNameNumber:
+            expose: true
+            access_type: public_method
+            serialized_name: IpiNameNumber
+            accessor:
+                getter: getIpiNameNumber
+                setter: setIpiNameNumber
+            type: string
+        iPN:
+            expose: true
+            access_type: public_method
+            serialized_name: IPN
+            accessor:
+                getter: getIPN
+                setter: setIPN
+            type: string
+        cisacSocietyId:
+            expose: true
+            access_type: public_method
+            serialized_name: CisacSocietyId
+            accessor:
+                getter: getCisacSocietyId
+                setter: setCisacSocietyId
+            type: string
+        proprietaryId:
+            expose: true
+            access_type: public_method
+            serialized_name: ProprietaryId
+            accessor:
+                getter: getProprietaryId
+                setter: setProprietaryId
+            xml_list:
+                inline: true
+                entry_name: ProprietaryId
+            type: array<DedexBundle\Entity\Ern42\ProprietaryIdType>

--- a/src/Entity/Ern42/metadata/DetailedResourceContributorType.yml
+++ b/src/Entity/Ern42/metadata/DetailedResourceContributorType.yml
@@ -1,0 +1,82 @@
+DedexBundle\Entity\Ern42\DetailedResourceContributorType:
+    properties:
+        sequenceNumber:
+            expose: true
+            access_type: public_method
+            serialized_name: SequenceNumber
+            accessor:
+                getter: getSequenceNumber
+                setter: setSequenceNumber
+            xml_attribute: true
+            type: int
+        partyId:
+            expose: true
+            access_type: public_method
+            serialized_name: PartyId
+            accessor:
+                getter: getPartyId
+                setter: setPartyId
+            xml_list:
+                inline: true
+                entry_name: PartyId
+            type: array<DedexBundle\Entity\Ern42\DetailedPartyIdType>
+        partyName:
+            expose: true
+            access_type: public_method
+            serialized_name: PartyName
+            accessor:
+                getter: getPartyName
+                setter: setPartyName
+            xml_list:
+                inline: true
+                entry_name: PartyName
+            type: array<DedexBundle\Entity\Ern42\PartyNameType>
+        role:
+            expose: true
+            access_type: public_method
+            serialized_name: Role
+            accessor:
+                getter: getRole
+                setter: setRole
+            xml_list:
+                inline: true
+                entry_name: Role
+            type: array<DedexBundle\Entity\Ern42\ContributorRoleType>
+        instrumentType:
+            expose: true
+            access_type: public_method
+            serialized_name: InstrumentType
+            accessor:
+                getter: getInstrumentType
+                setter: setInstrumentType
+            xml_list:
+                inline: true
+                entry_name: InstrumentType
+            type: array<DedexBundle\Entity\Ern42\InstrumentTypeType>
+        hasMadeFeaturedContribution:
+            expose: true
+            access_type: public_method
+            serialized_name: HasMadeFeaturedContribution
+            accessor:
+                getter: getHasMadeFeaturedContribution
+                setter: setHasMadeFeaturedContribution
+            type: bool
+        hasMadeContractedContribution:
+            expose: true
+            access_type: public_method
+            serialized_name: HasMadeContractedContribution
+            accessor:
+                getter: getHasMadeContractedContribution
+                setter: setHasMadeContractedContribution
+            type: bool
+        displayCredits:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayCredits
+            accessor:
+                getter: getDisplayCredits
+                setter: setDisplayCredits
+            xml_list:
+                inline: true
+                entry_name: DisplayCredits
+            type: array<DedexBundle\Entity\Ern42\DisplayCreditsType>

--- a/src/Entity/Ern42/metadata/DiscoverableUseTypeType.yml
+++ b/src/Entity/Ern42/metadata/DiscoverableUseTypeType.yml
@@ -1,0 +1,37 @@
+DedexBundle\Entity\Ern42\DiscoverableUseTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        isDiscoverable:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDiscoverable
+            accessor:
+                getter: getIsDiscoverable
+                setter: setIsDiscoverable
+            xml_attribute: true
+            type: bool
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/DisplayArtistNameWithDefaultType.yml
+++ b/src/Entity/Ern42/metadata/DisplayArtistNameWithDefaultType.yml
@@ -1,0 +1,37 @@
+DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool

--- a/src/Entity/Ern42/metadata/DisplayArtistRoleType.yml
+++ b/src/Entity/Ern42/metadata/DisplayArtistRoleType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\DisplayArtistRoleType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/DisplayArtistType.yml
+++ b/src/Entity/Ern42/metadata/DisplayArtistType.yml
@@ -1,0 +1,49 @@
+DedexBundle\Entity\Ern42\DisplayArtistType:
+    properties:
+        sequenceNumber:
+            expose: true
+            access_type: public_method
+            serialized_name: SequenceNumber
+            accessor:
+                getter: getSequenceNumber
+                setter: setSequenceNumber
+            xml_attribute: true
+            type: int
+        artistPartyReference:
+            expose: true
+            access_type: public_method
+            serialized_name: ArtistPartyReference
+            accessor:
+                getter: getArtistPartyReference
+                setter: setArtistPartyReference
+            type: string
+        displayArtistRole:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayArtistRole
+            accessor:
+                getter: getDisplayArtistRole
+                setter: setDisplayArtistRole
+            type: DedexBundle\Entity\Ern42\DisplayArtistRoleType
+        artisticRole:
+            expose: true
+            access_type: public_method
+            serialized_name: ArtisticRole
+            accessor:
+                getter: getArtisticRole
+                setter: setArtisticRole
+            xml_list:
+                inline: true
+                entry_name: ArtisticRole
+            type: array<DedexBundle\Entity\Ern42\ContributorRoleType>
+        titleDisplayInformation:
+            expose: true
+            access_type: public_method
+            serialized_name: TitleDisplayInformation
+            accessor:
+                getter: getTitleDisplayInformation
+                setter: setTitleDisplayInformation
+            xml_list:
+                inline: true
+                entry_name: TitleDisplayInformation
+            type: array<DedexBundle\Entity\Ern42\TitleDisplayInformationType>

--- a/src/Entity/Ern42/metadata/DisplayCreditsType.yml
+++ b/src/Entity/Ern42/metadata/DisplayCreditsType.yml
@@ -1,0 +1,59 @@
+DedexBundle\Entity\Ern42\DisplayCreditsType:
+    properties:
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool
+        displayCreditText:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayCreditText
+            accessor:
+                getter: getDisplayCreditText
+                setter: setDisplayCreditText
+            type: string
+        displayCreditParty:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayCreditParty
+            accessor:
+                getter: getDisplayCreditParty
+                setter: setDisplayCreditParty
+            xml_list:
+                inline: true
+                entry_name: DisplayCreditParty
+            type: array<string>
+        nameUsedInDisplayCredit:
+            expose: true
+            access_type: public_method
+            serialized_name: NameUsedInDisplayCredit
+            accessor:
+                getter: getNameUsedInDisplayCredit
+                setter: setNameUsedInDisplayCredit
+            xml_list:
+                inline: true
+                entry_name: NameUsedInDisplayCredit
+            type: array<string>

--- a/src/Entity/Ern42/metadata/DisplaySubTitleType.yml
+++ b/src/Entity/Ern42/metadata/DisplaySubTitleType.yml
@@ -1,0 +1,37 @@
+DedexBundle\Entity\Ern42\DisplaySubTitleType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        sequenceNumber:
+            expose: true
+            access_type: public_method
+            serialized_name: SequenceNumber
+            accessor:
+                getter: getSequenceNumber
+                setter: setSequenceNumber
+            xml_attribute: true
+            type: int
+        isDisplayedInTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDisplayedInTitle
+            accessor:
+                getter: getIsDisplayedInTitle
+                setter: setIsDisplayedInTitle
+            xml_attribute: true
+            type: bool
+        subTitleType:
+            expose: true
+            access_type: public_method
+            serialized_name: SubTitleType
+            accessor:
+                getter: getSubTitleType
+                setter: setSubTitleType
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/DisplayTitleTextType.yml
+++ b/src/Entity/Ern42/metadata/DisplayTitleTextType.yml
@@ -1,0 +1,37 @@
+DedexBundle\Entity\Ern42\DisplayTitleTextType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool

--- a/src/Entity/Ern42/metadata/DisplayTitleType.yml
+++ b/src/Entity/Ern42/metadata/DisplayTitleType.yml
@@ -1,0 +1,48 @@
+DedexBundle\Entity\Ern42\DisplayTitleType:
+    properties:
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool
+        titleText:
+            expose: true
+            access_type: public_method
+            serialized_name: TitleText
+            accessor:
+                getter: getTitleText
+                setter: setTitleText
+            type: string
+        subTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: SubTitle
+            accessor:
+                getter: getSubTitle
+                setter: setSubTitle
+            xml_list:
+                inline: true
+                entry_name: SubTitle
+            type: array<DedexBundle\Entity\Ern42\DisplaySubTitleType>

--- a/src/Entity/Ern42/metadata/DistributionChannelPageType.yml
+++ b/src/Entity/Ern42/metadata/DistributionChannelPageType.yml
@@ -1,0 +1,37 @@
+DedexBundle\Entity\Ern42\DistributionChannelPageType:
+    properties:
+        partyId:
+            expose: true
+            access_type: public_method
+            serialized_name: PartyId
+            accessor:
+                getter: getPartyId
+                setter: setPartyId
+            xml_list:
+                inline: true
+                entry_name: PartyId
+            type: array<DedexBundle\Entity\Ern42\DetailedPartyIdType>
+        pageName:
+            expose: true
+            access_type: public_method
+            serialized_name: PageName
+            accessor:
+                getter: getPageName
+                setter: setPageName
+            type: DedexBundle\Entity\Ern42\NameType
+        uRL:
+            expose: true
+            access_type: public_method
+            serialized_name: URL
+            accessor:
+                getter: getURL
+                setter: setURL
+            type: string
+        userName:
+            expose: true
+            access_type: public_method
+            serialized_name: UserName
+            accessor:
+                getter: getUserName
+                setter: setUserName
+            type: string

--- a/src/Entity/Ern42/metadata/EventDateTimeType.yml
+++ b/src/Entity/Ern42/metadata/EventDateTimeType.yml
@@ -1,0 +1,64 @@
+DedexBundle\Entity\Ern42\EventDateTimeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: GoetasWebservices\Xsd\XsdToPhp\XMLSchema\DateTime
+        isApproximate:
+            expose: true
+            access_type: public_method
+            serialized_name: IsApproximate
+            accessor:
+                getter: getIsApproximate
+                setter: setIsApproximate
+            xml_attribute: true
+            type: bool
+        isBefore:
+            expose: true
+            access_type: public_method
+            serialized_name: IsBefore
+            accessor:
+                getter: getIsBefore
+                setter: setIsBefore
+            xml_attribute: true
+            type: bool
+        isAfter:
+            expose: true
+            access_type: public_method
+            serialized_name: IsAfter
+            accessor:
+                getter: getIsAfter
+                setter: setIsAfter
+            xml_attribute: true
+            type: bool
+        territoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: TerritoryCode
+            accessor:
+                getter: getTerritoryCode
+                setter: setTerritoryCode
+            xml_attribute: true
+            type: string
+        locationDescription:
+            expose: true
+            access_type: public_method
+            serialized_name: LocationDescription
+            accessor:
+                getter: getLocationDescription
+                setter: setLocationDescription
+            xml_attribute: true
+            type: string
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/EventDateTimeWithoutFlagsType.yml
+++ b/src/Entity/Ern42/metadata/EventDateTimeWithoutFlagsType.yml
@@ -1,0 +1,46 @@
+DedexBundle\Entity\Ern42\EventDateTimeWithoutFlagsType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: GoetasWebservices\Xsd\XsdToPhp\XMLSchema\DateTime
+        isApproximate:
+            expose: true
+            access_type: public_method
+            serialized_name: IsApproximate
+            accessor:
+                getter: getIsApproximate
+                setter: setIsApproximate
+            xml_attribute: true
+            type: bool
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        locationDescription:
+            expose: true
+            access_type: public_method
+            serialized_name: LocationDescription
+            accessor:
+                getter: getLocationDescription
+                setter: setLocationDescription
+            xml_attribute: true
+            type: string
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/EventDateType.yml
+++ b/src/Entity/Ern42/metadata/EventDateType.yml
@@ -1,0 +1,64 @@
+DedexBundle\Entity\Ern42\EventDateType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        isApproximate:
+            expose: true
+            access_type: public_method
+            serialized_name: IsApproximate
+            accessor:
+                getter: getIsApproximate
+                setter: setIsApproximate
+            xml_attribute: true
+            type: bool
+        isBefore:
+            expose: true
+            access_type: public_method
+            serialized_name: IsBefore
+            accessor:
+                getter: getIsBefore
+                setter: setIsBefore
+            xml_attribute: true
+            type: bool
+        isAfter:
+            expose: true
+            access_type: public_method
+            serialized_name: IsAfter
+            accessor:
+                getter: getIsAfter
+                setter: setIsAfter
+            xml_attribute: true
+            type: bool
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        locationDescription:
+            expose: true
+            access_type: public_method
+            serialized_name: LocationDescription
+            accessor:
+                getter: getLocationDescription
+                setter: setLocationDescription
+            xml_attribute: true
+            type: string
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/EventDateWithCurrentTerritoryType.yml
+++ b/src/Entity/Ern42/metadata/EventDateWithCurrentTerritoryType.yml
@@ -1,0 +1,46 @@
+DedexBundle\Entity\Ern42\EventDateWithCurrentTerritoryType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        isApproximate:
+            expose: true
+            access_type: public_method
+            serialized_name: IsApproximate
+            accessor:
+                getter: getIsApproximate
+                setter: setIsApproximate
+            xml_attribute: true
+            type: bool
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        locationDescription:
+            expose: true
+            access_type: public_method
+            serialized_name: LocationDescription
+            accessor:
+                getter: getLocationDescription
+                setter: setLocationDescription
+            xml_attribute: true
+            type: string
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/EventDateWithDefaultType.yml
+++ b/src/Entity/Ern42/metadata/EventDateWithDefaultType.yml
@@ -1,0 +1,37 @@
+DedexBundle\Entity\Ern42\EventDateWithDefaultType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        isApproximate:
+            expose: true
+            access_type: public_method
+            serialized_name: IsApproximate
+            accessor:
+                getter: getIsApproximate
+                setter: setIsApproximate
+            xml_attribute: true
+            type: bool
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool

--- a/src/Entity/Ern42/metadata/EventDateWithoutFlagsType.yml
+++ b/src/Entity/Ern42/metadata/EventDateWithoutFlagsType.yml
@@ -1,0 +1,46 @@
+DedexBundle\Entity\Ern42\EventDateWithoutFlagsType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        isApproximate:
+            expose: true
+            access_type: public_method
+            serialized_name: IsApproximate
+            accessor:
+                getter: getIsApproximate
+                setter: setIsApproximate
+            xml_attribute: true
+            type: bool
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        locationDescription:
+            expose: true
+            access_type: public_method
+            serialized_name: LocationDescription
+            accessor:
+                getter: getLocationDescription
+                setter: setLocationDescription
+            xml_attribute: true
+            type: string
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/ExtentType.yml
+++ b/src/Entity/Ern42/metadata/ExtentType.yml
@@ -1,0 +1,19 @@
+DedexBundle\Entity\Ern42\ExtentType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: float
+        unitOfMeasure:
+            expose: true
+            access_type: public_method
+            serialized_name: UnitOfMeasure
+            accessor:
+                getter: getUnitOfMeasure
+                setter: setUnitOfMeasure
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/ExternalResourceLinkType.yml
+++ b/src/Entity/Ern42/metadata/ExternalResourceLinkType.yml
@@ -1,0 +1,48 @@
+DedexBundle\Entity\Ern42\ExternalResourceLinkType:
+    properties:
+        uRL:
+            expose: true
+            access_type: public_method
+            serialized_name: URL
+            accessor:
+                getter: getURL
+                setter: setURL
+            xml_list:
+                inline: true
+                entry_name: URL
+            type: array<string>
+        validityPeriod:
+            expose: true
+            access_type: public_method
+            serialized_name: ValidityPeriod
+            accessor:
+                getter: getValidityPeriod
+                setter: setValidityPeriod
+            type: DedexBundle\Entity\Ern42\PeriodWithoutFlagsType
+        externalLink:
+            expose: true
+            access_type: public_method
+            serialized_name: ExternalLink
+            accessor:
+                getter: getExternalLink
+                setter: setExternalLink
+            type: string
+        externallyLinkedResourceType:
+            expose: true
+            access_type: public_method
+            serialized_name: ExternallyLinkedResourceType
+            accessor:
+                getter: getExternallyLinkedResourceType
+                setter: setExternallyLinkedResourceType
+            xml_list:
+                inline: true
+                entry_name: ExternallyLinkedResourceType
+            type: array<DedexBundle\Entity\Ern42\ExternallyLinkedResourceTypeType>
+        fileFormat:
+            expose: true
+            access_type: public_method
+            serialized_name: FileFormat
+            accessor:
+                getter: getFileFormat
+                setter: setFileFormat
+            type: string

--- a/src/Entity/Ern42/metadata/ExternallyLinkedResourceTypeType.yml
+++ b/src/Entity/Ern42/metadata/ExternallyLinkedResourceTypeType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\ExternallyLinkedResourceTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/FileType.yml
+++ b/src/Entity/Ern42/metadata/FileType.yml
@@ -1,0 +1,26 @@
+DedexBundle\Entity\Ern42\FileType:
+    properties:
+        uRI:
+            expose: true
+            access_type: public_method
+            serialized_name: URI
+            accessor:
+                getter: getURI
+                setter: setURI
+            type: string
+        hashSum:
+            expose: true
+            access_type: public_method
+            serialized_name: HashSum
+            accessor:
+                getter: getHashSum
+                setter: setHashSum
+            type: DedexBundle\Entity\Ern42\DetailedHashSumType
+        fileSize:
+            expose: true
+            access_type: public_method
+            serialized_name: FileSize
+            accessor:
+                getter: getFileSize
+                setter: setFileSize
+            type: float

--- a/src/Entity/Ern42/metadata/FingerprintAlgorithmTypeType.yml
+++ b/src/Entity/Ern42/metadata/FingerprintAlgorithmTypeType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\FingerprintAlgorithmTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/FingerprintType.yml
+++ b/src/Entity/Ern42/metadata/FingerprintType.yml
@@ -1,0 +1,50 @@
+DedexBundle\Entity\Ern42\FingerprintType:
+    properties:
+        algorithm:
+            expose: true
+            access_type: public_method
+            serialized_name: Algorithm
+            accessor:
+                getter: getAlgorithm
+                setter: setAlgorithm
+            type: DedexBundle\Entity\Ern42\FingerprintAlgorithmTypeType
+        version:
+            expose: true
+            access_type: public_method
+            serialized_name: Version
+            accessor:
+                getter: getVersion
+                setter: setVersion
+            type: string
+        parameter:
+            expose: true
+            access_type: public_method
+            serialized_name: Parameter
+            accessor:
+                getter: getParameter
+                setter: setParameter
+            type: string
+        file:
+            expose: true
+            access_type: public_method
+            serialized_name: File
+            accessor:
+                getter: getFile
+                setter: setFile
+            type: DedexBundle\Entity\Ern42\FileType
+        dataType:
+            expose: true
+            access_type: public_method
+            serialized_name: DataType
+            accessor:
+                getter: getDataType
+                setter: setDataType
+            type: string
+        fingerprintValue:
+            expose: true
+            access_type: public_method
+            serialized_name: FingerprintValue
+            accessor:
+                getter: getFingerprintValue
+                setter: setFingerprintValue
+            type: string

--- a/src/Entity/Ern42/metadata/FirstPublicationDateType.yml
+++ b/src/Entity/Ern42/metadata/FirstPublicationDateType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\FirstPublicationDateType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool

--- a/src/Entity/Ern42/metadata/FrameRateType.yml
+++ b/src/Entity/Ern42/metadata/FrameRateType.yml
@@ -1,0 +1,19 @@
+DedexBundle\Entity\Ern42\FrameRateType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: float
+        unitOfMeasure:
+            expose: true
+            access_type: public_method
+            serialized_name: UnitOfMeasure
+            accessor:
+                getter: getUnitOfMeasure
+                setter: setUnitOfMeasure
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/FulfillmentDateWithTerritoryType.yml
+++ b/src/Entity/Ern42/metadata/FulfillmentDateWithTerritoryType.yml
@@ -1,0 +1,39 @@
+DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType:
+    properties:
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool
+        fulfillmentDate:
+            expose: true
+            access_type: public_method
+            serialized_name: FulfillmentDate
+            accessor:
+                getter: getFulfillmentDate
+                setter: setFulfillmentDate
+            type: string
+        resourceReleaseReference:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceReleaseReference
+            accessor:
+                getter: getResourceReleaseReference
+                setter: setResourceReleaseReference
+            xml_list:
+                inline: true
+                entry_name: ResourceReleaseReference
+            type: array<string>

--- a/src/Entity/Ern42/metadata/GenreCategoryType.yml
+++ b/src/Entity/Ern42/metadata/GenreCategoryType.yml
@@ -1,0 +1,30 @@
+DedexBundle\Entity\Ern42\GenreCategoryType:
+    properties:
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        value:
+            expose: true
+            access_type: public_method
+            serialized_name: Value
+            accessor:
+                getter: getValue
+                setter: setValue
+            type: DedexBundle\Entity\Ern42\GenreCategoryValueType
+        description:
+            expose: true
+            access_type: public_method
+            serialized_name: Description
+            accessor:
+                getter: getDescription
+                setter: setDescription
+            xml_list:
+                inline: true
+                entry_name: Description
+            type: array<DedexBundle\Entity\Ern42\TextWithoutTerritoryType>

--- a/src/Entity/Ern42/metadata/GenreCategoryValueType.yml
+++ b/src/Entity/Ern42/metadata/GenreCategoryValueType.yml
@@ -1,0 +1,37 @@
+DedexBundle\Entity\Ern42\GenreCategoryValueType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/GenreWithTerritoryType.yml
+++ b/src/Entity/Ern42/metadata/GenreWithTerritoryType.yml
@@ -1,0 +1,68 @@
+DedexBundle\Entity\Ern42\GenreWithTerritoryType:
+    properties:
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool
+        genreText:
+            expose: true
+            access_type: public_method
+            serialized_name: GenreText
+            accessor:
+                getter: getGenreText
+                setter: setGenreText
+            type: string
+        subGenre:
+            expose: true
+            access_type: public_method
+            serialized_name: SubGenre
+            accessor:
+                getter: getSubGenre
+                setter: setSubGenre
+            type: string
+        genreCategory:
+            expose: true
+            access_type: public_method
+            serialized_name: GenreCategory
+            accessor:
+                getter: getGenreCategory
+                setter: setGenreCategory
+            xml_list:
+                inline: true
+                entry_name: GenreCategory
+            type: array<DedexBundle\Entity\Ern42\GenreCategoryType>
+        subGenreCategory:
+            expose: true
+            access_type: public_method
+            serialized_name: SubGenreCategory
+            accessor:
+                getter: getSubGenreCategory
+                setter: setSubGenreCategory
+            type: array<DedexBundle\Entity\Ern42\SubGenreCategoryValueType>
+            xml_list:
+                inline: false
+                entry_name: Value
+                skip_when_empty: true

--- a/src/Entity/Ern42/metadata/HashSumAlgorithmTypeType.yml
+++ b/src/Entity/Ern42/metadata/HashSumAlgorithmTypeType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\HashSumAlgorithmTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/ImageCodecTypeType.yml
+++ b/src/Entity/Ern42/metadata/ImageCodecTypeType.yml
@@ -1,0 +1,37 @@
+DedexBundle\Entity\Ern42\ImageCodecTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        version:
+            expose: true
+            access_type: public_method
+            serialized_name: Version
+            accessor:
+                getter: getVersion
+                setter: setVersion
+            xml_attribute: true
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/ImageType.yml
+++ b/src/Entity/Ern42/metadata/ImageType.yml
@@ -1,0 +1,250 @@
+DedexBundle\Entity\Ern42\ImageType:
+    properties:
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        isSupplemental:
+            expose: true
+            access_type: public_method
+            serialized_name: IsSupplemental
+            accessor:
+                getter: getIsSupplemental
+                setter: setIsSupplemental
+            xml_attribute: true
+            type: bool
+        resourceReference:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceReference
+            accessor:
+                getter: getResourceReference
+                setter: setResourceReference
+            type: string
+        type:
+            expose: true
+            access_type: public_method
+            serialized_name: Type
+            accessor:
+                getter: getType
+                setter: setType
+            type: DedexBundle\Entity\Ern42\ImageTypeType
+        resourceId:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceId
+            accessor:
+                getter: getResourceId
+                setter: setResourceId
+            xml_list:
+                inline: true
+                entry_name: ResourceId
+            type: array<DedexBundle\Entity\Ern42\ResourceProprietaryIdType>
+        displayTitleText:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayTitleText
+            accessor:
+                getter: getDisplayTitleText
+                setter: setDisplayTitleText
+            xml_list:
+                inline: true
+                entry_name: DisplayTitleText
+            type: array<DedexBundle\Entity\Ern42\DisplayTitleTextType>
+        displayTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayTitle
+            accessor:
+                getter: getDisplayTitle
+                setter: setDisplayTitle
+            xml_list:
+                inline: true
+                entry_name: DisplayTitle
+            type: array<DedexBundle\Entity\Ern42\DisplayTitleType>
+        additionalTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: AdditionalTitle
+            accessor:
+                getter: getAdditionalTitle
+                setter: setAdditionalTitle
+            xml_list:
+                inline: true
+                entry_name: AdditionalTitle
+            type: array<DedexBundle\Entity\Ern42\AdditionalTitleType>
+        versionType:
+            expose: true
+            access_type: public_method
+            serialized_name: VersionType
+            accessor:
+                getter: getVersionType
+                setter: setVersionType
+            xml_list:
+                inline: true
+                entry_name: VersionType
+            type: array<DedexBundle\Entity\Ern42\VersionTypeType>
+        displayArtistName:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayArtistName
+            accessor:
+                getter: getDisplayArtistName
+                setter: setDisplayArtistName
+            xml_list:
+                inline: true
+                entry_name: DisplayArtistName
+            type: array<DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType>
+        displayArtist:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayArtist
+            accessor:
+                getter: getDisplayArtist
+                setter: setDisplayArtist
+            xml_list:
+                inline: true
+                entry_name: DisplayArtist
+            type: array<DedexBundle\Entity\Ern42\DisplayArtistType>
+        contributor:
+            expose: true
+            access_type: public_method
+            serialized_name: Contributor
+            accessor:
+                getter: getContributor
+                setter: setContributor
+            xml_list:
+                inline: true
+                entry_name: Contributor
+            type: array<DedexBundle\Entity\Ern42\ContributorType>
+        resourceRightsController:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceRightsController
+            accessor:
+                getter: getResourceRightsController
+                setter: setResourceRightsController
+            xml_list:
+                inline: true
+                entry_name: ResourceRightsController
+            type: array<DedexBundle\Entity\Ern42\ResourceRightsControllerType>
+        workRightsController:
+            expose: true
+            access_type: public_method
+            serialized_name: WorkRightsController
+            accessor:
+                getter: getWorkRightsController
+                setter: setWorkRightsController
+            xml_list:
+                inline: true
+                entry_name: WorkRightsController
+            type: array<DedexBundle\Entity\Ern42\WorkRightsControllerType>
+        cLine:
+            expose: true
+            access_type: public_method
+            serialized_name: CLine
+            accessor:
+                getter: getCLine
+                setter: setCLine
+            xml_list:
+                inline: true
+                entry_name: CLine
+            type: array<DedexBundle\Entity\Ern42\CLineWithDefaultType>
+        courtesyLine:
+            expose: true
+            access_type: public_method
+            serialized_name: CourtesyLine
+            accessor:
+                getter: getCourtesyLine
+                setter: setCourtesyLine
+            xml_list:
+                inline: true
+                entry_name: CourtesyLine
+            type: array<DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType>
+        creationDate:
+            expose: true
+            access_type: public_method
+            serialized_name: CreationDate
+            accessor:
+                getter: getCreationDate
+                setter: setCreationDate
+            type: DedexBundle\Entity\Ern42\EventDateWithoutFlagsType
+        firstPublicationDate:
+            expose: true
+            access_type: public_method
+            serialized_name: FirstPublicationDate
+            accessor:
+                getter: getFirstPublicationDate
+                setter: setFirstPublicationDate
+            xml_list:
+                inline: true
+                entry_name: FirstPublicationDate
+            type: array<DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType>
+        parentalWarningType:
+            expose: true
+            access_type: public_method
+            serialized_name: ParentalWarningType
+            accessor:
+                getter: getParentalWarningType
+                setter: setParentalWarningType
+            xml_list:
+                inline: true
+                entry_name: ParentalWarningType
+            type: array<DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType>
+        relatedRelease:
+            expose: true
+            access_type: public_method
+            serialized_name: RelatedRelease
+            accessor:
+                getter: getRelatedRelease
+                setter: setRelatedRelease
+            xml_list:
+                inline: true
+                entry_name: RelatedRelease
+            type: array<DedexBundle\Entity\Ern42\RelatedReleaseType>
+        relatedResource:
+            expose: true
+            access_type: public_method
+            serialized_name: RelatedResource
+            accessor:
+                getter: getRelatedResource
+                setter: setRelatedResource
+            xml_list:
+                inline: true
+                entry_name: RelatedResource
+            type: array<DedexBundle\Entity\Ern42\RelatedResourceType>
+        containsHiddenContent:
+            expose: true
+            access_type: public_method
+            serialized_name: ContainsHiddenContent
+            accessor:
+                getter: getContainsHiddenContent
+                setter: setContainsHiddenContent
+            type: bool
+        description:
+            expose: true
+            access_type: public_method
+            serialized_name: Description
+            accessor:
+                getter: getDescription
+                setter: setDescription
+            xml_list:
+                inline: true
+                entry_name: Description
+            type: array<DedexBundle\Entity\Ern42\DescriptionWithTerritoryType>
+        technicalDetails:
+            expose: true
+            access_type: public_method
+            serialized_name: TechnicalDetails
+            accessor:
+                getter: getTechnicalDetails
+                setter: setTechnicalDetails
+            xml_list:
+                inline: true
+                entry_name: TechnicalDetails
+            type: array<DedexBundle\Entity\Ern42\TechnicalImageDetailsType>

--- a/src/Entity/Ern42/metadata/ImageTypeType.yml
+++ b/src/Entity/Ern42/metadata/ImageTypeType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\ImageTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/InstrumentTypeType.yml
+++ b/src/Entity/Ern42/metadata/InstrumentTypeType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\InstrumentTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/IsCreditedType.yml
+++ b/src/Entity/Ern42/metadata/IsCreditedType.yml
@@ -1,0 +1,19 @@
+DedexBundle\Entity\Ern42\IsCreditedType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: bool
+        mayBeShared:
+            expose: true
+            access_type: public_method
+            serialized_name: MayBeShared
+            accessor:
+                getter: getMayBeShared
+                setter: setMayBeShared
+            xml_attribute: true
+            type: bool

--- a/src/Entity/Ern42/metadata/KeywordsWithTerritoryType.yml
+++ b/src/Entity/Ern42/metadata/KeywordsWithTerritoryType.yml
@@ -1,0 +1,37 @@
+DedexBundle\Entity\Ern42\KeywordsWithTerritoryType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool

--- a/src/Entity/Ern42/metadata/LinkedReleaseResourceReferenceType.yml
+++ b/src/Entity/Ern42/metadata/LinkedReleaseResourceReferenceType.yml
@@ -1,0 +1,46 @@
+DedexBundle\Entity\Ern42\LinkedReleaseResourceReferenceType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        linkDescription:
+            expose: true
+            access_type: public_method
+            serialized_name: LinkDescription
+            accessor:
+                getter: getLinkDescription
+                setter: setLinkDescription
+            xml_attribute: true
+            type: string
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/LocationAndDateOfSessionType.yml
+++ b/src/Entity/Ern42/metadata/LocationAndDateOfSessionType.yml
@@ -1,0 +1,51 @@
+DedexBundle\Entity\Ern42\LocationAndDateOfSessionType:
+    properties:
+        sessionType:
+            expose: true
+            access_type: public_method
+            serialized_name: SessionType
+            accessor:
+                getter: getSessionType
+                setter: setSessionType
+            xml_list:
+                inline: true
+                entry_name: SessionType
+            type: array<DedexBundle\Entity\Ern42\SessionTypeType>
+        period:
+            expose: true
+            access_type: public_method
+            serialized_name: Period
+            accessor:
+                getter: getPeriod
+                setter: setPeriod
+            type: DedexBundle\Entity\Ern42\PeriodType
+        venue:
+            expose: true
+            access_type: public_method
+            serialized_name: Venue
+            accessor:
+                getter: getVenue
+                setter: setVenue
+            xml_list:
+                inline: true
+                entry_name: Venue
+            type: array<DedexBundle\Entity\Ern42\VenueType>
+        comment:
+            expose: true
+            access_type: public_method
+            serialized_name: Comment
+            accessor:
+                getter: getComment
+                setter: setComment
+            type: DedexBundle\Entity\Ern42\TextWithFormatType
+        contributor:
+            expose: true
+            access_type: public_method
+            serialized_name: Contributor
+            accessor:
+                getter: getContributor
+                setter: setContributor
+            xml_list:
+                inline: true
+                entry_name: Contributor
+            type: array<DedexBundle\Entity\Ern42\PartyWithRoleType>

--- a/src/Entity/Ern42/metadata/MarketingCommentType.yml
+++ b/src/Entity/Ern42/metadata/MarketingCommentType.yml
@@ -1,0 +1,37 @@
+DedexBundle\Entity\Ern42\MarketingCommentType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool

--- a/src/Entity/Ern42/metadata/MessageAuditTrailEventType.yml
+++ b/src/Entity/Ern42/metadata/MessageAuditTrailEventType.yml
@@ -1,0 +1,18 @@
+DedexBundle\Entity\Ern42\MessageAuditTrailEventType:
+    properties:
+        messagingPartyDescriptor:
+            expose: true
+            access_type: public_method
+            serialized_name: MessagingPartyDescriptor
+            accessor:
+                getter: getMessagingPartyDescriptor
+                setter: setMessagingPartyDescriptor
+            type: DedexBundle\Entity\Ern42\MessagingPartyWithoutCodeType
+        dateTime:
+            expose: true
+            access_type: public_method
+            serialized_name: DateTime
+            accessor:
+                getter: getDateTime
+                setter: setDateTime
+            type: GoetasWebservices\Xsd\XsdToPhp\XMLSchema\DateTime

--- a/src/Entity/Ern42/metadata/MessageAuditTrailType.yml
+++ b/src/Entity/Ern42/metadata/MessageAuditTrailType.yml
@@ -1,0 +1,13 @@
+DedexBundle\Entity\Ern42\MessageAuditTrailType:
+    properties:
+        messageAuditTrailEvent:
+            expose: true
+            access_type: public_method
+            serialized_name: MessageAuditTrailEvent
+            accessor:
+                getter: getMessageAuditTrailEvent
+                setter: setMessageAuditTrailEvent
+            xml_list:
+                inline: true
+                entry_name: MessageAuditTrailEvent
+            type: array<DedexBundle\Entity\Ern42\MessageAuditTrailEventType>

--- a/src/Entity/Ern42/metadata/MessageHeaderType.yml
+++ b/src/Entity/Ern42/metadata/MessageHeaderType.yml
@@ -1,0 +1,81 @@
+DedexBundle\Entity\Ern42\MessageHeaderType:
+    properties:
+        messageThreadId:
+            expose: true
+            access_type: public_method
+            serialized_name: MessageThreadId
+            accessor:
+                getter: getMessageThreadId
+                setter: setMessageThreadId
+            type: string
+        messageId:
+            expose: true
+            access_type: public_method
+            serialized_name: MessageId
+            accessor:
+                getter: getMessageId
+                setter: setMessageId
+            type: string
+        messageFileName:
+            expose: true
+            access_type: public_method
+            serialized_name: MessageFileName
+            accessor:
+                getter: getMessageFileName
+                setter: setMessageFileName
+            type: string
+        messageSender:
+            expose: true
+            access_type: public_method
+            serialized_name: MessageSender
+            accessor:
+                getter: getMessageSender
+                setter: setMessageSender
+            type: DedexBundle\Entity\Ern42\MessagingPartyWithoutCodeType
+        sentOnBehalfOf:
+            expose: true
+            access_type: public_method
+            serialized_name: SentOnBehalfOf
+            accessor:
+                getter: getSentOnBehalfOf
+                setter: setSentOnBehalfOf
+            type: DedexBundle\Entity\Ern42\MessagingPartyWithoutCodeType
+        messageRecipient:
+            expose: true
+            access_type: public_method
+            serialized_name: MessageRecipient
+            accessor:
+                getter: getMessageRecipient
+                setter: setMessageRecipient
+            xml_list:
+                inline: true
+                entry_name: MessageRecipient
+            type: array<DedexBundle\Entity\Ern42\MessagingPartyWithoutCodeType>
+        messageCreatedDateTime:
+            expose: true
+            access_type: public_method
+            serialized_name: MessageCreatedDateTime
+            accessor:
+                getter: getMessageCreatedDateTime
+                setter: setMessageCreatedDateTime
+            type: GoetasWebservices\Xsd\XsdToPhp\XMLSchema\DateTime
+        messageAuditTrail:
+            expose: true
+            access_type: public_method
+            serialized_name: MessageAuditTrail
+            accessor:
+                getter: getMessageAuditTrail
+                setter: setMessageAuditTrail
+            type: array<DedexBundle\Entity\Ern42\MessageAuditTrailEventType>
+            xml_list:
+                inline: false
+                entry_name: MessageAuditTrailEvent
+                skip_when_empty: true
+        messageControlType:
+            expose: true
+            access_type: public_method
+            serialized_name: MessageControlType
+            accessor:
+                getter: getMessageControlType
+                setter: setMessageControlType
+            type: string

--- a/src/Entity/Ern42/metadata/MessagingPartyWithoutCodeType.yml
+++ b/src/Entity/Ern42/metadata/MessagingPartyWithoutCodeType.yml
@@ -1,0 +1,26 @@
+DedexBundle\Entity\Ern42\MessagingPartyWithoutCodeType:
+    properties:
+        partyId:
+            expose: true
+            access_type: public_method
+            serialized_name: PartyId
+            accessor:
+                getter: getPartyId
+                setter: setPartyId
+            type: string
+        partyName:
+            expose: true
+            access_type: public_method
+            serialized_name: PartyName
+            accessor:
+                getter: getPartyName
+                setter: setPartyName
+            type: DedexBundle\Entity\Ern42\PartyNameWithoutCodeType
+        tradingName:
+            expose: true
+            access_type: public_method
+            serialized_name: TradingName
+            accessor:
+                getter: getTradingName
+                setter: setTradingName
+            type: string

--- a/src/Entity/Ern42/metadata/MusicalWorkIdType.yml
+++ b/src/Entity/Ern42/metadata/MusicalWorkIdType.yml
@@ -1,0 +1,49 @@
+DedexBundle\Entity\Ern42\MusicalWorkIdType:
+    properties:
+        isReplaced:
+            expose: true
+            access_type: public_method
+            serialized_name: IsReplaced
+            accessor:
+                getter: getIsReplaced
+                setter: setIsReplaced
+            xml_attribute: true
+            type: bool
+        iSWC:
+            expose: true
+            access_type: public_method
+            serialized_name: ISWC
+            accessor:
+                getter: getISWC
+                setter: setISWC
+            type: string
+        opusNumber:
+            expose: true
+            access_type: public_method
+            serialized_name: OpusNumber
+            accessor:
+                getter: getOpusNumber
+                setter: setOpusNumber
+            type: string
+        composerCatalogNumber:
+            expose: true
+            access_type: public_method
+            serialized_name: ComposerCatalogNumber
+            accessor:
+                getter: getComposerCatalogNumber
+                setter: setComposerCatalogNumber
+            xml_list:
+                inline: true
+                entry_name: ComposerCatalogNumber
+            type: array<string>
+        proprietaryId:
+            expose: true
+            access_type: public_method
+            serialized_name: ProprietaryId
+            accessor:
+                getter: getProprietaryId
+                setter: setProprietaryId
+            xml_list:
+                inline: true
+                entry_name: ProprietaryId
+            type: array<DedexBundle\Entity\Ern42\ProprietaryIdType>

--- a/src/Entity/Ern42/metadata/NameType.yml
+++ b/src/Entity/Ern42/metadata/NameType.yml
@@ -1,0 +1,19 @@
+DedexBundle\Entity\Ern42\NameType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/NewReleaseMessage.NewReleaseMessageAnonymousPHPType.yml
+++ b/src/Entity/Ern42/metadata/NewReleaseMessage.NewReleaseMessageAnonymousPHPType.yml
@@ -1,0 +1,116 @@
+DedexBundle\Entity\Ern42\NewReleaseMessage\NewReleaseMessageAnonymousPHPType:
+    properties:
+        releaseProfileVersionId:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseProfileVersionId
+            accessor:
+                getter: getReleaseProfileVersionId
+                setter: setReleaseProfileVersionId
+            xml_attribute: true
+            type: string
+        releaseProfileVariantVersionId:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseProfileVariantVersionId
+            accessor:
+                getter: getReleaseProfileVariantVersionId
+                setter: setReleaseProfileVariantVersionId
+            xml_attribute: true
+            type: string
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        messageHeader:
+            expose: true
+            access_type: public_method
+            serialized_name: MessageHeader
+            accessor:
+                getter: getMessageHeader
+                setter: setMessageHeader
+            type: DedexBundle\Entity\Ern42\MessageHeaderType
+        releaseAdmin:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseAdmin
+            accessor:
+                getter: getReleaseAdmin
+                setter: setReleaseAdmin
+            xml_list:
+                inline: true
+                entry_name: ReleaseAdmin
+            type: array<DedexBundle\Entity\Ern42\ReleaseAdminType>
+        partyList:
+            expose: true
+            access_type: public_method
+            serialized_name: PartyList
+            accessor:
+                getter: getPartyList
+                setter: setPartyList
+            type: array<DedexBundle\Entity\Ern42\PartyType>
+            xml_list:
+                inline: false
+                entry_name: Party
+                skip_when_empty: false
+        cueSheetList:
+            expose: true
+            access_type: public_method
+            serialized_name: CueSheetList
+            accessor:
+                getter: getCueSheetList
+                setter: setCueSheetList
+            type: array<DedexBundle\Entity\Ern42\DetailedCueSheetType>
+            xml_list:
+                inline: false
+                entry_name: CueSheet
+                skip_when_empty: true
+        resourceList:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceList
+            accessor:
+                getter: getResourceList
+                setter: setResourceList
+            type: DedexBundle\Entity\Ern42\ResourceListType
+        chapterList:
+            expose: true
+            access_type: public_method
+            serialized_name: ChapterList
+            accessor:
+                getter: getChapterList
+                setter: setChapterList
+            type: DedexBundle\Entity\Ern42\ChapterListType
+        releaseList:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseList
+            accessor:
+                getter: getReleaseList
+                setter: setReleaseList
+            type: DedexBundle\Entity\Ern42\ReleaseListType
+        dealList:
+            expose: true
+            access_type: public_method
+            serialized_name: DealList
+            accessor:
+                getter: getDealList
+                setter: setDealList
+            type: DedexBundle\Entity\Ern42\DealListType
+        supplementalDocumentList:
+            expose: true
+            access_type: public_method
+            serialized_name: SupplementalDocumentList
+            accessor:
+                getter: getSupplementalDocumentList
+                setter: setSupplementalDocumentList
+            type: array<DedexBundle\Entity\Ern42\FileType>
+            xml_list:
+                inline: false
+                entry_name: SupplementalDocument
+                skip_when_empty: true

--- a/src/Entity/Ern42/metadata/NewReleaseMessage.yml
+++ b/src/Entity/Ern42/metadata/NewReleaseMessage.yml
@@ -1,0 +1,3 @@
+DedexBundle\Entity\Ern42\NewReleaseMessage:
+    xml_root_name: 'ns-8b1800c5:NewReleaseMessage'
+    xml_root_namespace: 'http://ddex.net/xml/ern/42'

--- a/src/Entity/Ern42/metadata/OperatingSystemTypeType.yml
+++ b/src/Entity/Ern42/metadata/OperatingSystemTypeType.yml
@@ -1,0 +1,37 @@
+DedexBundle\Entity\Ern42\OperatingSystemTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        version:
+            expose: true
+            access_type: public_method
+            serialized_name: Version
+            accessor:
+                getter: getVersion
+                setter: setVersion
+            xml_attribute: true
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/PLineType.yml
+++ b/src/Entity/Ern42/metadata/PLineType.yml
@@ -1,0 +1,44 @@
+DedexBundle\Entity\Ern42\PLineType:
+    properties:
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        pLineType:
+            expose: true
+            access_type: public_method
+            serialized_name: PLineType
+            accessor:
+                getter: getPLineType
+                setter: setPLineType
+            xml_attribute: true
+            type: string
+        year:
+            expose: true
+            access_type: public_method
+            serialized_name: Year
+            accessor:
+                getter: getYear
+                setter: setYear
+            type: int
+        pLineCompany:
+            expose: true
+            access_type: public_method
+            serialized_name: PLineCompany
+            accessor:
+                getter: getPLineCompany
+                setter: setPLineCompany
+            type: string
+        pLineText:
+            expose: true
+            access_type: public_method
+            serialized_name: PLineText
+            accessor:
+                getter: getPLineText
+                setter: setPLineText
+            type: string

--- a/src/Entity/Ern42/metadata/PLineWithDefaultType.yml
+++ b/src/Entity/Ern42/metadata/PLineWithDefaultType.yml
@@ -1,0 +1,53 @@
+DedexBundle\Entity\Ern42\PLineWithDefaultType:
+    properties:
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        year:
+            expose: true
+            access_type: public_method
+            serialized_name: Year
+            accessor:
+                getter: getYear
+                setter: setYear
+            type: int
+        pLineCompany:
+            expose: true
+            access_type: public_method
+            serialized_name: PLineCompany
+            accessor:
+                getter: getPLineCompany
+                setter: setPLineCompany
+            type: string
+        pLineText:
+            expose: true
+            access_type: public_method
+            serialized_name: PLineText
+            accessor:
+                getter: getPLineText
+                setter: setPLineText
+            type: string

--- a/src/Entity/Ern42/metadata/ParentalWarningTypeWithTerritoryType.yml
+++ b/src/Entity/Ern42/metadata/ParentalWarningTypeWithTerritoryType.yml
@@ -1,0 +1,46 @@
+DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool

--- a/src/Entity/Ern42/metadata/PartyListType.yml
+++ b/src/Entity/Ern42/metadata/PartyListType.yml
@@ -1,0 +1,13 @@
+DedexBundle\Entity\Ern42\PartyListType:
+    properties:
+        party:
+            expose: true
+            access_type: public_method
+            serialized_name: Party
+            accessor:
+                getter: getParty
+                setter: setParty
+            xml_list:
+                inline: true
+                entry_name: Party
+            type: array<DedexBundle\Entity\Ern42\PartyType>

--- a/src/Entity/Ern42/metadata/PartyNameType.yml
+++ b/src/Entity/Ern42/metadata/PartyNameType.yml
@@ -1,0 +1,67 @@
+DedexBundle\Entity\Ern42\PartyNameType:
+    properties:
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        fullName:
+            expose: true
+            access_type: public_method
+            serialized_name: FullName
+            accessor:
+                getter: getFullName
+                setter: setFullName
+            type: DedexBundle\Entity\Ern42\NameType
+        fullNameAsciiTranscribed:
+            expose: true
+            access_type: public_method
+            serialized_name: FullNameAsciiTranscribed
+            accessor:
+                getter: getFullNameAsciiTranscribed
+                setter: setFullNameAsciiTranscribed
+            type: string
+        fullNameIndexed:
+            expose: true
+            access_type: public_method
+            serialized_name: FullNameIndexed
+            accessor:
+                getter: getFullNameIndexed
+                setter: setFullNameIndexed
+            type: DedexBundle\Entity\Ern42\NameType
+        namesBeforeKeyName:
+            expose: true
+            access_type: public_method
+            serialized_name: NamesBeforeKeyName
+            accessor:
+                getter: getNamesBeforeKeyName
+                setter: setNamesBeforeKeyName
+            type: DedexBundle\Entity\Ern42\NameType
+        keyName:
+            expose: true
+            access_type: public_method
+            serialized_name: KeyName
+            accessor:
+                getter: getKeyName
+                setter: setKeyName
+            type: DedexBundle\Entity\Ern42\NameType
+        namesAfterKeyName:
+            expose: true
+            access_type: public_method
+            serialized_name: NamesAfterKeyName
+            accessor:
+                getter: getNamesAfterKeyName
+                setter: setNamesAfterKeyName
+            type: DedexBundle\Entity\Ern42\NameType
+        abbreviatedName:
+            expose: true
+            access_type: public_method
+            serialized_name: AbbreviatedName
+            accessor:
+                getter: getAbbreviatedName
+                setter: setAbbreviatedName
+            type: DedexBundle\Entity\Ern42\NameType

--- a/src/Entity/Ern42/metadata/PartyNameWithTerritoryType.yml
+++ b/src/Entity/Ern42/metadata/PartyNameWithTerritoryType.yml
@@ -1,0 +1,112 @@
+DedexBundle\Entity\Ern42\PartyNameWithTerritoryType:
+    properties:
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        isNickname:
+            expose: true
+            access_type: public_method
+            serialized_name: IsNickname
+            accessor:
+                getter: getIsNickname
+                setter: setIsNickname
+            xml_attribute: true
+            type: bool
+        isStageName:
+            expose: true
+            access_type: public_method
+            serialized_name: IsStageName
+            accessor:
+                getter: getIsStageName
+                setter: setIsStageName
+            xml_attribute: true
+            type: bool
+        isLegalName:
+            expose: true
+            access_type: public_method
+            serialized_name: IsLegalName
+            accessor:
+                getter: getIsLegalName
+                setter: setIsLegalName
+            xml_attribute: true
+            type: bool
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool
+        fullName:
+            expose: true
+            access_type: public_method
+            serialized_name: FullName
+            accessor:
+                getter: getFullName
+                setter: setFullName
+            type: DedexBundle\Entity\Ern42\NameType
+        fullNameAsciiTranscribed:
+            expose: true
+            access_type: public_method
+            serialized_name: FullNameAsciiTranscribed
+            accessor:
+                getter: getFullNameAsciiTranscribed
+                setter: setFullNameAsciiTranscribed
+            type: string
+        fullNameIndexed:
+            expose: true
+            access_type: public_method
+            serialized_name: FullNameIndexed
+            accessor:
+                getter: getFullNameIndexed
+                setter: setFullNameIndexed
+            type: DedexBundle\Entity\Ern42\NameType
+        namesBeforeKeyName:
+            expose: true
+            access_type: public_method
+            serialized_name: NamesBeforeKeyName
+            accessor:
+                getter: getNamesBeforeKeyName
+                setter: setNamesBeforeKeyName
+            type: DedexBundle\Entity\Ern42\NameType
+        keyName:
+            expose: true
+            access_type: public_method
+            serialized_name: KeyName
+            accessor:
+                getter: getKeyName
+                setter: setKeyName
+            type: DedexBundle\Entity\Ern42\NameType
+        namesAfterKeyName:
+            expose: true
+            access_type: public_method
+            serialized_name: NamesAfterKeyName
+            accessor:
+                getter: getNamesAfterKeyName
+                setter: setNamesAfterKeyName
+            type: DedexBundle\Entity\Ern42\NameType
+        abbreviatedName:
+            expose: true
+            access_type: public_method
+            serialized_name: AbbreviatedName
+            accessor:
+                getter: getAbbreviatedName
+                setter: setAbbreviatedName
+            type: DedexBundle\Entity\Ern42\NameType

--- a/src/Entity/Ern42/metadata/PartyNameWithoutCodeType.yml
+++ b/src/Entity/Ern42/metadata/PartyNameWithoutCodeType.yml
@@ -1,0 +1,58 @@
+DedexBundle\Entity\Ern42\PartyNameWithoutCodeType:
+    properties:
+        fullName:
+            expose: true
+            access_type: public_method
+            serialized_name: FullName
+            accessor:
+                getter: getFullName
+                setter: setFullName
+            type: string
+        fullNameAsciiTranscribed:
+            expose: true
+            access_type: public_method
+            serialized_name: FullNameAsciiTranscribed
+            accessor:
+                getter: getFullNameAsciiTranscribed
+                setter: setFullNameAsciiTranscribed
+            type: string
+        fullNameIndexed:
+            expose: true
+            access_type: public_method
+            serialized_name: FullNameIndexed
+            accessor:
+                getter: getFullNameIndexed
+                setter: setFullNameIndexed
+            type: string
+        namesBeforeKeyName:
+            expose: true
+            access_type: public_method
+            serialized_name: NamesBeforeKeyName
+            accessor:
+                getter: getNamesBeforeKeyName
+                setter: setNamesBeforeKeyName
+            type: string
+        keyName:
+            expose: true
+            access_type: public_method
+            serialized_name: KeyName
+            accessor:
+                getter: getKeyName
+                setter: setKeyName
+            type: string
+        namesAfterKeyName:
+            expose: true
+            access_type: public_method
+            serialized_name: NamesAfterKeyName
+            accessor:
+                getter: getNamesAfterKeyName
+                setter: setNamesAfterKeyName
+            type: string
+        abbreviatedName:
+            expose: true
+            access_type: public_method
+            serialized_name: AbbreviatedName
+            accessor:
+                getter: getAbbreviatedName
+                setter: setAbbreviatedName
+            type: string

--- a/src/Entity/Ern42/metadata/PartyRelationshipTypeType.yml
+++ b/src/Entity/Ern42/metadata/PartyRelationshipTypeType.yml
@@ -1,0 +1,37 @@
+DedexBundle\Entity\Ern42\PartyRelationshipTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string
+        mayBeShared:
+            expose: true
+            access_type: public_method
+            serialized_name: MayBeShared
+            accessor:
+                getter: getMayBeShared
+                setter: setMayBeShared
+            xml_attribute: true
+            type: bool

--- a/src/Entity/Ern42/metadata/PartyType.yml
+++ b/src/Entity/Ern42/metadata/PartyType.yml
@@ -1,0 +1,65 @@
+DedexBundle\Entity\Ern42\PartyType:
+    properties:
+        partyReference:
+            expose: true
+            access_type: public_method
+            serialized_name: PartyReference
+            accessor:
+                getter: getPartyReference
+                setter: setPartyReference
+            type: string
+        partyId:
+            expose: true
+            access_type: public_method
+            serialized_name: PartyId
+            accessor:
+                getter: getPartyId
+                setter: setPartyId
+            xml_list:
+                inline: true
+                entry_name: PartyId
+            type: array<DedexBundle\Entity\Ern42\DetailedPartyIdType>
+        partyName:
+            expose: true
+            access_type: public_method
+            serialized_name: PartyName
+            accessor:
+                getter: getPartyName
+                setter: setPartyName
+            xml_list:
+                inline: true
+                entry_name: PartyName
+            type: array<DedexBundle\Entity\Ern42\PartyNameWithTerritoryType>
+        affiliation:
+            expose: true
+            access_type: public_method
+            serialized_name: Affiliation
+            accessor:
+                getter: getAffiliation
+                setter: setAffiliation
+            xml_list:
+                inline: true
+                entry_name: Affiliation
+            type: array<DedexBundle\Entity\Ern42\AffiliationType>
+        relatedParty:
+            expose: true
+            access_type: public_method
+            serialized_name: RelatedParty
+            accessor:
+                getter: getRelatedParty
+                setter: setRelatedParty
+            xml_list:
+                inline: true
+                entry_name: RelatedParty
+            type: array<DedexBundle\Entity\Ern42\RelatedPartyType>
+        artistProfilePage:
+            expose: true
+            access_type: public_method
+            serialized_name: ArtistProfilePage
+            accessor:
+                getter: getArtistProfilePage
+                setter: setArtistProfilePage
+            xml_list:
+                inline: true
+                entry_name: ArtistProfilePage
+            type: array<string>

--- a/src/Entity/Ern42/metadata/PartyWithRoleType.yml
+++ b/src/Entity/Ern42/metadata/PartyWithRoleType.yml
@@ -1,0 +1,61 @@
+DedexBundle\Entity\Ern42\PartyWithRoleType:
+    properties:
+        iSNI:
+            expose: true
+            access_type: public_method
+            serialized_name: ISNI
+            accessor:
+                getter: getISNI
+                setter: setISNI
+            type: string
+        dPID:
+            expose: true
+            access_type: public_method
+            serialized_name: DPID
+            accessor:
+                getter: getDPID
+                setter: setDPID
+            type: string
+        ipiNameNumber:
+            expose: true
+            access_type: public_method
+            serialized_name: IpiNameNumber
+            accessor:
+                getter: getIpiNameNumber
+                setter: setIpiNameNumber
+            type: string
+        iPN:
+            expose: true
+            access_type: public_method
+            serialized_name: IPN
+            accessor:
+                getter: getIPN
+                setter: setIPN
+            type: string
+        proprietaryId:
+            expose: true
+            access_type: public_method
+            serialized_name: ProprietaryId
+            accessor:
+                getter: getProprietaryId
+                setter: setProprietaryId
+            xml_list:
+                inline: true
+                entry_name: ProprietaryId
+            type: array<DedexBundle\Entity\Ern42\ProprietaryIdType>
+        partyName:
+            expose: true
+            access_type: public_method
+            serialized_name: PartyName
+            accessor:
+                getter: getPartyName
+                setter: setPartyName
+            type: DedexBundle\Entity\Ern42\PartyNameWithTerritoryType
+        role:
+            expose: true
+            access_type: public_method
+            serialized_name: Role
+            accessor:
+                getter: getRole
+                setter: setRole
+            type: DedexBundle\Entity\Ern42\ResourceContributorRoleType

--- a/src/Entity/Ern42/metadata/PercentageType.yml
+++ b/src/Entity/Ern42/metadata/PercentageType.yml
@@ -1,0 +1,19 @@
+DedexBundle\Entity\Ern42\PercentageType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: float
+        hasMaxValueOfOne:
+            expose: true
+            access_type: public_method
+            serialized_name: HasMaxValueOfOne
+            accessor:
+                getter: getHasMaxValueOfOne
+                setter: setHasMaxValueOfOne
+            xml_attribute: true
+            type: bool

--- a/src/Entity/Ern42/metadata/PeriodType.yml
+++ b/src/Entity/Ern42/metadata/PeriodType.yml
@@ -1,0 +1,34 @@
+DedexBundle\Entity\Ern42\PeriodType:
+    properties:
+        startDate:
+            expose: true
+            access_type: public_method
+            serialized_name: StartDate
+            accessor:
+                getter: getStartDate
+                setter: setStartDate
+            type: DedexBundle\Entity\Ern42\EventDateType
+        endDate:
+            expose: true
+            access_type: public_method
+            serialized_name: EndDate
+            accessor:
+                getter: getEndDate
+                setter: setEndDate
+            type: DedexBundle\Entity\Ern42\EventDateType
+        startDateTime:
+            expose: true
+            access_type: public_method
+            serialized_name: StartDateTime
+            accessor:
+                getter: getStartDateTime
+                setter: setStartDateTime
+            type: DedexBundle\Entity\Ern42\EventDateTimeType
+        endDateTime:
+            expose: true
+            access_type: public_method
+            serialized_name: EndDateTime
+            accessor:
+                getter: getEndDateTime
+                setter: setEndDateTime
+            type: DedexBundle\Entity\Ern42\EventDateTimeType

--- a/src/Entity/Ern42/metadata/PeriodWithStartDateType.yml
+++ b/src/Entity/Ern42/metadata/PeriodWithStartDateType.yml
@@ -1,0 +1,34 @@
+DedexBundle\Entity\Ern42\PeriodWithStartDateType:
+    properties:
+        startDate:
+            expose: true
+            access_type: public_method
+            serialized_name: StartDate
+            accessor:
+                getter: getStartDate
+                setter: setStartDate
+            type: DedexBundle\Entity\Ern42\EventDateWithCurrentTerritoryType
+        endDate:
+            expose: true
+            access_type: public_method
+            serialized_name: EndDate
+            accessor:
+                getter: getEndDate
+                setter: setEndDate
+            type: DedexBundle\Entity\Ern42\EventDateWithCurrentTerritoryType
+        startDateTime:
+            expose: true
+            access_type: public_method
+            serialized_name: StartDateTime
+            accessor:
+                getter: getStartDateTime
+                setter: setStartDateTime
+            type: DedexBundle\Entity\Ern42\EventDateTimeWithoutFlagsType
+        endDateTime:
+            expose: true
+            access_type: public_method
+            serialized_name: EndDateTime
+            accessor:
+                getter: getEndDateTime
+                setter: setEndDateTime
+            type: DedexBundle\Entity\Ern42\EventDateTimeWithoutFlagsType

--- a/src/Entity/Ern42/metadata/PeriodWithoutFlagsType.yml
+++ b/src/Entity/Ern42/metadata/PeriodWithoutFlagsType.yml
@@ -1,0 +1,34 @@
+DedexBundle\Entity\Ern42\PeriodWithoutFlagsType:
+    properties:
+        startDate:
+            expose: true
+            access_type: public_method
+            serialized_name: StartDate
+            accessor:
+                getter: getStartDate
+                setter: setStartDate
+            type: DedexBundle\Entity\Ern42\EventDateWithCurrentTerritoryType
+        endDate:
+            expose: true
+            access_type: public_method
+            serialized_name: EndDate
+            accessor:
+                getter: getEndDate
+                setter: setEndDate
+            type: DedexBundle\Entity\Ern42\EventDateWithCurrentTerritoryType
+        startDateTime:
+            expose: true
+            access_type: public_method
+            serialized_name: StartDateTime
+            accessor:
+                getter: getStartDateTime
+                setter: setStartDateTime
+            type: DedexBundle\Entity\Ern42\EventDateTimeWithoutFlagsType
+        endDateTime:
+            expose: true
+            access_type: public_method
+            serialized_name: EndDateTime
+            accessor:
+                getter: getEndDateTime
+                setter: setEndDateTime
+            type: DedexBundle\Entity\Ern42\EventDateTimeWithoutFlagsType

--- a/src/Entity/Ern42/metadata/PhysicalReturnsType.yml
+++ b/src/Entity/Ern42/metadata/PhysicalReturnsType.yml
@@ -1,0 +1,18 @@
+DedexBundle\Entity\Ern42\PhysicalReturnsType:
+    properties:
+        physicalReturnsAllowed:
+            expose: true
+            access_type: public_method
+            serialized_name: PhysicalReturnsAllowed
+            accessor:
+                getter: getPhysicalReturnsAllowed
+                setter: setPhysicalReturnsAllowed
+            type: bool
+        latestDateForPhysicalReturns:
+            expose: true
+            access_type: public_method
+            serialized_name: LatestDateForPhysicalReturns
+            accessor:
+                getter: getLatestDateForPhysicalReturns
+                setter: setLatestDateForPhysicalReturns
+            type: string

--- a/src/Entity/Ern42/metadata/PrefixType.yml
+++ b/src/Entity/Ern42/metadata/PrefixType.yml
@@ -1,0 +1,19 @@
+DedexBundle\Entity\Ern42\PrefixType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/PreviewDetailsType.yml
+++ b/src/Entity/Ern42/metadata/PreviewDetailsType.yml
@@ -1,0 +1,26 @@
+DedexBundle\Entity\Ern42\PreviewDetailsType:
+    properties:
+        topLeftCorner:
+            expose: true
+            access_type: public_method
+            serialized_name: TopLeftCorner
+            accessor:
+                getter: getTopLeftCorner
+                setter: setTopLeftCorner
+            type: string
+        bottomRightCorner:
+            expose: true
+            access_type: public_method
+            serialized_name: BottomRightCorner
+            accessor:
+                getter: getBottomRightCorner
+                setter: setBottomRightCorner
+            type: string
+        expressionType:
+            expose: true
+            access_type: public_method
+            serialized_name: ExpressionType
+            accessor:
+                getter: getExpressionType
+                setter: setExpressionType
+            type: string

--- a/src/Entity/Ern42/metadata/PriceInformationWithTypeType.yml
+++ b/src/Entity/Ern42/metadata/PriceInformationWithTypeType.yml
@@ -1,0 +1,61 @@
+DedexBundle\Entity\Ern42\PriceInformationWithTypeType:
+    properties:
+        priceType:
+            expose: true
+            access_type: public_method
+            serialized_name: PriceType
+            accessor:
+                getter: getPriceType
+                setter: setPriceType
+            xml_attribute: true
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string
+        priceCode:
+            expose: true
+            access_type: public_method
+            serialized_name: PriceCode
+            accessor:
+                getter: getPriceCode
+                setter: setPriceCode
+            type: DedexBundle\Entity\Ern42\PriceTypeType
+        wholesalePricePerUnit:
+            expose: true
+            access_type: public_method
+            serialized_name: WholesalePricePerUnit
+            accessor:
+                getter: getWholesalePricePerUnit
+                setter: setWholesalePricePerUnit
+            type: DedexBundle\Entity\Ern42\PriceType
+        bulkOrderWholesalePricePerUnit:
+            expose: true
+            access_type: public_method
+            serialized_name: BulkOrderWholesalePricePerUnit
+            accessor:
+                getter: getBulkOrderWholesalePricePerUnit
+                setter: setBulkOrderWholesalePricePerUnit
+            type: DedexBundle\Entity\Ern42\PriceType
+        suggestedRetailPrice:
+            expose: true
+            access_type: public_method
+            serialized_name: SuggestedRetailPrice
+            accessor:
+                getter: getSuggestedRetailPrice
+                setter: setSuggestedRetailPrice
+            type: DedexBundle\Entity\Ern42\PriceType

--- a/src/Entity/Ern42/metadata/PriceType.yml
+++ b/src/Entity/Ern42/metadata/PriceType.yml
@@ -1,0 +1,19 @@
+DedexBundle\Entity\Ern42\PriceType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: float
+        currencyCode:
+            expose: true
+            access_type: public_method
+            serialized_name: CurrencyCode
+            accessor:
+                getter: getCurrencyCode
+                setter: setCurrencyCode
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/PriceTypeType.yml
+++ b/src/Entity/Ern42/metadata/PriceTypeType.yml
@@ -1,0 +1,19 @@
+DedexBundle\Entity\Ern42\PriceTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/PromotionalCodeType.yml
+++ b/src/Entity/Ern42/metadata/PromotionalCodeType.yml
@@ -1,0 +1,19 @@
+DedexBundle\Entity\Ern42\PromotionalCodeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/ProprietaryIdType.yml
+++ b/src/Entity/Ern42/metadata/ProprietaryIdType.yml
@@ -1,0 +1,19 @@
+DedexBundle\Entity\Ern42\ProprietaryIdType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/PurgeReleaseMessage.PurgeReleaseMessageAnonymousPHPType.yml
+++ b/src/Entity/Ern42/metadata/PurgeReleaseMessage.PurgeReleaseMessageAnonymousPHPType.yml
@@ -1,0 +1,27 @@
+DedexBundle\Entity\Ern42\PurgeReleaseMessage\PurgeReleaseMessageAnonymousPHPType:
+    properties:
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        messageHeader:
+            expose: true
+            access_type: public_method
+            serialized_name: MessageHeader
+            accessor:
+                getter: getMessageHeader
+                setter: setMessageHeader
+            type: DedexBundle\Entity\Ern42\MessageHeaderType
+        purgedRelease:
+            expose: true
+            access_type: public_method
+            serialized_name: PurgedRelease
+            accessor:
+                getter: getPurgedRelease
+                setter: setPurgedRelease
+            type: DedexBundle\Entity\Ern42\PurgedReleaseType

--- a/src/Entity/Ern42/metadata/PurgeReleaseMessage.yml
+++ b/src/Entity/Ern42/metadata/PurgeReleaseMessage.yml
@@ -1,0 +1,3 @@
+DedexBundle\Entity\Ern42\PurgeReleaseMessage:
+    xml_root_name: 'ns-8b1800c5:PurgeReleaseMessage'
+    xml_root_namespace: 'http://ddex.net/xml/ern/42'

--- a/src/Entity/Ern42/metadata/PurgedReleaseType.yml
+++ b/src/Entity/Ern42/metadata/PurgedReleaseType.yml
@@ -1,0 +1,32 @@
+DedexBundle\Entity\Ern42\PurgedReleaseType:
+    properties:
+        releaseId:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseId
+            accessor:
+                getter: getReleaseId
+                setter: setReleaseId
+            type: DedexBundle\Entity\Ern42\ReleaseIdType
+        title:
+            expose: true
+            access_type: public_method
+            serialized_name: Title
+            accessor:
+                getter: getTitle
+                setter: setTitle
+            xml_list:
+                inline: true
+                entry_name: Title
+            type: array<DedexBundle\Entity\Ern42\TitleType>
+        contributor:
+            expose: true
+            access_type: public_method
+            serialized_name: Contributor
+            accessor:
+                getter: getContributor
+                setter: setContributor
+            xml_list:
+                inline: true
+                entry_name: Contributor
+            type: array<DedexBundle\Entity\Ern42\DetailedResourceContributorType>

--- a/src/Entity/Ern42/metadata/PurposeType.yml
+++ b/src/Entity/Ern42/metadata/PurposeType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\PurposeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/RagaType.yml
+++ b/src/Entity/Ern42/metadata/RagaType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\RagaType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool

--- a/src/Entity/Ern42/metadata/RatingAgencyType.yml
+++ b/src/Entity/Ern42/metadata/RatingAgencyType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\RatingAgencyType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/RatingReasonType.yml
+++ b/src/Entity/Ern42/metadata/RatingReasonType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\RatingReasonType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/ReasonType.yml
+++ b/src/Entity/Ern42/metadata/ReasonType.yml
@@ -1,0 +1,19 @@
+DedexBundle\Entity\Ern42\ReasonType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/RelatedPartyType.yml
+++ b/src/Entity/Ern42/metadata/RelatedPartyType.yml
@@ -1,0 +1,18 @@
+DedexBundle\Entity\Ern42\RelatedPartyType:
+    properties:
+        partyRelatedPartyReference:
+            expose: true
+            access_type: public_method
+            serialized_name: PartyRelatedPartyReference
+            accessor:
+                getter: getPartyRelatedPartyReference
+                setter: setPartyRelatedPartyReference
+            type: string
+        partyRelationshipType:
+            expose: true
+            access_type: public_method
+            serialized_name: PartyRelationshipType
+            accessor:
+                getter: getPartyRelationshipType
+                setter: setPartyRelationshipType
+            type: DedexBundle\Entity\Ern42\PartyRelationshipTypeType

--- a/src/Entity/Ern42/metadata/RelatedReleaseType.yml
+++ b/src/Entity/Ern42/metadata/RelatedReleaseType.yml
@@ -1,0 +1,89 @@
+DedexBundle\Entity\Ern42\RelatedReleaseType:
+    properties:
+        releaseRelationshipType:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseRelationshipType
+            accessor:
+                getter: getReleaseRelationshipType
+                setter: setReleaseRelationshipType
+            type: DedexBundle\Entity\Ern42\ReleaseRelationshipTypeType
+        releaseId:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseId
+            accessor:
+                getter: getReleaseId
+                setter: setReleaseId
+            type: DedexBundle\Entity\Ern42\ReleaseIdType
+        displayTitleText:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayTitleText
+            accessor:
+                getter: getDisplayTitleText
+                setter: setDisplayTitleText
+            xml_list:
+                inline: true
+                entry_name: DisplayTitleText
+            type: array<DedexBundle\Entity\Ern42\DisplayTitleTextType>
+        displayTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayTitle
+            accessor:
+                getter: getDisplayTitle
+                setter: setDisplayTitle
+            xml_list:
+                inline: true
+                entry_name: DisplayTitle
+            type: array<DedexBundle\Entity\Ern42\DisplayTitleType>
+        additionalTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: AdditionalTitle
+            accessor:
+                getter: getAdditionalTitle
+                setter: setAdditionalTitle
+            xml_list:
+                inline: true
+                entry_name: AdditionalTitle
+            type: array<DedexBundle\Entity\Ern42\AdditionalTitleType>
+        displayArtistName:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayArtistName
+            accessor:
+                getter: getDisplayArtistName
+                setter: setDisplayArtistName
+            xml_list:
+                inline: true
+                entry_name: DisplayArtistName
+            type: array<DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType>
+        releaseLabelReference:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseLabelReference
+            accessor:
+                getter: getReleaseLabelReference
+                setter: setReleaseLabelReference
+            xml_list:
+                inline: true
+                entry_name: ReleaseLabelReference
+            type: array<DedexBundle\Entity\Ern42\ReleaseLabelReferenceType>
+        releaseDate:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseDate
+            accessor:
+                getter: getReleaseDate
+                setter: setReleaseDate
+            type: DedexBundle\Entity\Ern42\EventDateWithoutFlagsType
+        originalReleaseDate:
+            expose: true
+            access_type: public_method
+            serialized_name: OriginalReleaseDate
+            accessor:
+                getter: getOriginalReleaseDate
+                setter: setOriginalReleaseDate
+            type: DedexBundle\Entity\Ern42\EventDateWithoutFlagsType

--- a/src/Entity/Ern42/metadata/RelatedResourceType.yml
+++ b/src/Entity/Ern42/metadata/RelatedResourceType.yml
@@ -1,0 +1,37 @@
+DedexBundle\Entity\Ern42\RelatedResourceType:
+    properties:
+        resourceRelationshipType:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceRelationshipType
+            accessor:
+                getter: getResourceRelationshipType
+                setter: setResourceRelationshipType
+            type: string
+        resourceRelatedResourceReference:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceRelatedResourceReference
+            accessor:
+                getter: getResourceRelatedResourceReference
+                setter: setResourceRelatedResourceReference
+            type: string
+        resourceId:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceId
+            accessor:
+                getter: getResourceId
+                setter: setResourceId
+            type: DedexBundle\Entity\Ern42\ResourceIdType
+        timing:
+            expose: true
+            access_type: public_method
+            serialized_name: Timing
+            accessor:
+                getter: getTiming
+                setter: setTiming
+            xml_list:
+                inline: true
+                entry_name: Timing
+            type: array<DedexBundle\Entity\Ern42\TimingType>

--- a/src/Entity/Ern42/metadata/ReleaseAdminType.yml
+++ b/src/Entity/Ern42/metadata/ReleaseAdminType.yml
@@ -1,0 +1,29 @@
+DedexBundle\Entity\Ern42\ReleaseAdminType:
+    properties:
+        releaseAdminId:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseAdminId
+            accessor:
+                getter: getReleaseAdminId
+                setter: setReleaseAdminId
+            type: string
+        personnelDescription:
+            expose: true
+            access_type: public_method
+            serialized_name: PersonnelDescription
+            accessor:
+                getter: getPersonnelDescription
+                setter: setPersonnelDescription
+            type: string
+        systemDescription:
+            expose: true
+            access_type: public_method
+            serialized_name: SystemDescription
+            accessor:
+                getter: getSystemDescription
+                setter: setSystemDescription
+            xml_list:
+                inline: true
+                entry_name: SystemDescription
+            type: array<string>

--- a/src/Entity/Ern42/metadata/ReleaseDealType.yml
+++ b/src/Entity/Ern42/metadata/ReleaseDealType.yml
@@ -1,0 +1,24 @@
+DedexBundle\Entity\Ern42\ReleaseDealType:
+    properties:
+        dealReleaseReference:
+            expose: true
+            access_type: public_method
+            serialized_name: DealReleaseReference
+            accessor:
+                getter: getDealReleaseReference
+                setter: setDealReleaseReference
+            xml_list:
+                inline: true
+                entry_name: DealReleaseReference
+            type: array<string>
+        deal:
+            expose: true
+            access_type: public_method
+            serialized_name: Deal
+            accessor:
+                getter: getDeal
+                setter: setDeal
+            xml_list:
+                inline: true
+                entry_name: Deal
+            type: array<DedexBundle\Entity\Ern42\DealType>

--- a/src/Entity/Ern42/metadata/ReleaseIdType.yml
+++ b/src/Entity/Ern42/metadata/ReleaseIdType.yml
@@ -1,0 +1,37 @@
+DedexBundle\Entity\Ern42\ReleaseIdType:
+    properties:
+        gRid:
+            expose: true
+            access_type: public_method
+            serialized_name: GRid
+            accessor:
+                getter: getGRid
+                setter: setGRid
+            type: string
+        iCPN:
+            expose: true
+            access_type: public_method
+            serialized_name: ICPN
+            accessor:
+                getter: getICPN
+                setter: setICPN
+            type: string
+        catalogNumber:
+            expose: true
+            access_type: public_method
+            serialized_name: CatalogNumber
+            accessor:
+                getter: getCatalogNumber
+                setter: setCatalogNumber
+            type: DedexBundle\Entity\Ern42\CatalogNumberType
+        proprietaryId:
+            expose: true
+            access_type: public_method
+            serialized_name: ProprietaryId
+            accessor:
+                getter: getProprietaryId
+                setter: setProprietaryId
+            xml_list:
+                inline: true
+                entry_name: ProprietaryId
+            type: array<DedexBundle\Entity\Ern42\ProprietaryIdType>

--- a/src/Entity/Ern42/metadata/ReleaseLabelReferenceType.yml
+++ b/src/Entity/Ern42/metadata/ReleaseLabelReferenceType.yml
@@ -1,0 +1,64 @@
+DedexBundle\Entity\Ern42\ReleaseLabelReferenceType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool
+        labelType:
+            expose: true
+            access_type: public_method
+            serialized_name: LabelType
+            accessor:
+                getter: getLabelType
+                setter: setLabelType
+            xml_attribute: true
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/ReleaseLabelReferenceWithPartyType.yml
+++ b/src/Entity/Ern42/metadata/ReleaseLabelReferenceWithPartyType.yml
@@ -1,0 +1,73 @@
+DedexBundle\Entity\Ern42\ReleaseLabelReferenceWithPartyType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool
+        labelType:
+            expose: true
+            access_type: public_method
+            serialized_name: LabelType
+            accessor:
+                getter: getLabelType
+                setter: setLabelType
+            xml_attribute: true
+            type: string
+        accessControlParty:
+            expose: true
+            access_type: public_method
+            serialized_name: AccessControlParty
+            accessor:
+                getter: getAccessControlParty
+                setter: setAccessControlParty
+            xml_attribute: true
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/ReleaseListType.yml
+++ b/src/Entity/Ern42/metadata/ReleaseListType.yml
@@ -1,0 +1,21 @@
+DedexBundle\Entity\Ern42\ReleaseListType:
+    properties:
+        release:
+            expose: true
+            access_type: public_method
+            serialized_name: Release
+            accessor:
+                getter: getRelease
+                setter: setRelease
+            type: DedexBundle\Entity\Ern42\ReleaseType
+        trackRelease:
+            expose: true
+            access_type: public_method
+            serialized_name: TrackRelease
+            accessor:
+                getter: getTrackRelease
+                setter: setTrackRelease
+            xml_list:
+                inline: true
+                entry_name: TrackRelease
+            type: array<DedexBundle\Entity\Ern42\TrackReleaseType>

--- a/src/Entity/Ern42/metadata/ReleaseRelationshipTypeType.yml
+++ b/src/Entity/Ern42/metadata/ReleaseRelationshipTypeType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\ReleaseRelationshipTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/ReleaseType.yml
+++ b/src/Entity/Ern42/metadata/ReleaseType.yml
@@ -1,0 +1,374 @@
+DedexBundle\Entity\Ern42\ReleaseType:
+    properties:
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        releaseReference:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseReference
+            accessor:
+                getter: getReleaseReference
+                setter: setReleaseReference
+            type: string
+        releaseType:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseType
+            accessor:
+                getter: getReleaseType
+                setter: setReleaseType
+            xml_list:
+                inline: true
+                entry_name: ReleaseType
+            type: array<DedexBundle\Entity\Ern42\ReleaseTypeForReleaseNotificationType>
+        releaseId:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseId
+            accessor:
+                getter: getReleaseId
+                setter: setReleaseId
+            type: DedexBundle\Entity\Ern42\ReleaseIdType
+        displayTitleText:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayTitleText
+            accessor:
+                getter: getDisplayTitleText
+                setter: setDisplayTitleText
+            xml_list:
+                inline: true
+                entry_name: DisplayTitleText
+            type: array<DedexBundle\Entity\Ern42\DisplayTitleTextType>
+        displayTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayTitle
+            accessor:
+                getter: getDisplayTitle
+                setter: setDisplayTitle
+            xml_list:
+                inline: true
+                entry_name: DisplayTitle
+            type: array<DedexBundle\Entity\Ern42\DisplayTitleType>
+        additionalTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: AdditionalTitle
+            accessor:
+                getter: getAdditionalTitle
+                setter: setAdditionalTitle
+            xml_list:
+                inline: true
+                entry_name: AdditionalTitle
+            type: array<DedexBundle\Entity\Ern42\AdditionalTitleType>
+        displayArtistName:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayArtistName
+            accessor:
+                getter: getDisplayArtistName
+                setter: setDisplayArtistName
+            xml_list:
+                inline: true
+                entry_name: DisplayArtistName
+            type: array<DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType>
+        displayArtist:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayArtist
+            accessor:
+                getter: getDisplayArtist
+                setter: setDisplayArtist
+            xml_list:
+                inline: true
+                entry_name: DisplayArtist
+            type: array<DedexBundle\Entity\Ern42\DisplayArtistType>
+        releaseLabelReference:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseLabelReference
+            accessor:
+                getter: getReleaseLabelReference
+                setter: setReleaseLabelReference
+            xml_list:
+                inline: true
+                entry_name: ReleaseLabelReference
+            type: array<DedexBundle\Entity\Ern42\ReleaseLabelReferenceWithPartyType>
+        administratingRecordCompany:
+            expose: true
+            access_type: public_method
+            serialized_name: AdministratingRecordCompany
+            accessor:
+                getter: getAdministratingRecordCompany
+                setter: setAdministratingRecordCompany
+            xml_list:
+                inline: true
+                entry_name: AdministratingRecordCompany
+            type: array<DedexBundle\Entity\Ern42\AdministratingRecordCompanyWithReferenceType>
+        pLine:
+            expose: true
+            access_type: public_method
+            serialized_name: PLine
+            accessor:
+                getter: getPLine
+                setter: setPLine
+            xml_list:
+                inline: true
+                entry_name: PLine
+            type: array<DedexBundle\Entity\Ern42\PLineWithDefaultType>
+        cLine:
+            expose: true
+            access_type: public_method
+            serialized_name: CLine
+            accessor:
+                getter: getCLine
+                setter: setCLine
+            xml_list:
+                inline: true
+                entry_name: CLine
+            type: array<DedexBundle\Entity\Ern42\CLineWithDefaultType>
+        courtesyLine:
+            expose: true
+            access_type: public_method
+            serialized_name: CourtesyLine
+            accessor:
+                getter: getCourtesyLine
+                setter: setCourtesyLine
+            xml_list:
+                inline: true
+                entry_name: CourtesyLine
+            type: array<DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType>
+        duration:
+            expose: true
+            access_type: public_method
+            serialized_name: Duration
+            accessor:
+                getter: getDuration
+                setter: setDuration
+            type: DateInterval
+        genre:
+            expose: true
+            access_type: public_method
+            serialized_name: Genre
+            accessor:
+                getter: getGenre
+                setter: setGenre
+            xml_list:
+                inline: true
+                entry_name: Genre
+            type: array<DedexBundle\Entity\Ern42\GenreWithTerritoryType>
+        releaseDate:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseDate
+            accessor:
+                getter: getReleaseDate
+                setter: setReleaseDate
+            xml_list:
+                inline: true
+                entry_name: ReleaseDate
+            type: array<DedexBundle\Entity\Ern42\EventDateWithDefaultType>
+        originalReleaseDate:
+            expose: true
+            access_type: public_method
+            serialized_name: OriginalReleaseDate
+            accessor:
+                getter: getOriginalReleaseDate
+                setter: setOriginalReleaseDate
+            xml_list:
+                inline: true
+                entry_name: OriginalReleaseDate
+            type: array<DedexBundle\Entity\Ern42\EventDateWithDefaultType>
+        releaseVisibilityReference:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseVisibilityReference
+            accessor:
+                getter: getReleaseVisibilityReference
+                setter: setReleaseVisibilityReference
+            type: string
+        parentalWarningType:
+            expose: true
+            access_type: public_method
+            serialized_name: ParentalWarningType
+            accessor:
+                getter: getParentalWarningType
+                setter: setParentalWarningType
+            xml_list:
+                inline: true
+                entry_name: ParentalWarningType
+            type: array<DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType>
+        avRating:
+            expose: true
+            access_type: public_method
+            serialized_name: AvRating
+            accessor:
+                getter: getAvRating
+                setter: setAvRating
+            xml_list:
+                inline: true
+                entry_name: AvRating
+            type: array<DedexBundle\Entity\Ern42\AvRatingType>
+        relatedRelease:
+            expose: true
+            access_type: public_method
+            serialized_name: RelatedRelease
+            accessor:
+                getter: getRelatedRelease
+                setter: setRelatedRelease
+            xml_list:
+                inline: true
+                entry_name: RelatedRelease
+            type: array<DedexBundle\Entity\Ern42\RelatedReleaseType>
+        relatedResource:
+            expose: true
+            access_type: public_method
+            serialized_name: RelatedResource
+            accessor:
+                getter: getRelatedResource
+                setter: setRelatedResource
+            xml_list:
+                inline: true
+                entry_name: RelatedResource
+            type: array<DedexBundle\Entity\Ern42\RelatedResourceType>
+        isSingleArtistCompilation:
+            expose: true
+            access_type: public_method
+            serialized_name: IsSingleArtistCompilation
+            accessor:
+                getter: getIsSingleArtistCompilation
+                setter: setIsSingleArtistCompilation
+            type: bool
+        isMultiArtistCompilation:
+            expose: true
+            access_type: public_method
+            serialized_name: IsMultiArtistCompilation
+            accessor:
+                getter: getIsMultiArtistCompilation
+                setter: setIsMultiArtistCompilation
+            type: bool
+        resourceGroup:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceGroup
+            accessor:
+                getter: getResourceGroup
+                setter: setResourceGroup
+            type: DedexBundle\Entity\Ern42\ResourceGroupType
+        externalResourceLink:
+            expose: true
+            access_type: public_method
+            serialized_name: ExternalResourceLink
+            accessor:
+                getter: getExternalResourceLink
+                setter: setExternalResourceLink
+            xml_list:
+                inline: true
+                entry_name: ExternalResourceLink
+            type: array<DedexBundle\Entity\Ern42\ExternalResourceLinkType>
+        targetURL:
+            expose: true
+            access_type: public_method
+            serialized_name: TargetURL
+            accessor:
+                getter: getTargetURL
+                setter: setTargetURL
+            type: string
+        keywords:
+            expose: true
+            access_type: public_method
+            serialized_name: Keywords
+            accessor:
+                getter: getKeywords
+                setter: setKeywords
+            xml_list:
+                inline: true
+                entry_name: Keywords
+            type: array<DedexBundle\Entity\Ern42\KeywordsWithTerritoryType>
+        synopsis:
+            expose: true
+            access_type: public_method
+            serialized_name: Synopsis
+            accessor:
+                getter: getSynopsis
+                setter: setSynopsis
+            xml_list:
+                inline: true
+                entry_name: Synopsis
+            type: array<DedexBundle\Entity\Ern42\SynopsisWithTerritoryType>
+        raga:
+            expose: true
+            access_type: public_method
+            serialized_name: Raga
+            accessor:
+                getter: getRaga
+                setter: setRaga
+            xml_list:
+                inline: true
+                entry_name: Raga
+            type: array<DedexBundle\Entity\Ern42\RagaType>
+        tala:
+            expose: true
+            access_type: public_method
+            serialized_name: Tala
+            accessor:
+                getter: getTala
+                setter: setTala
+            xml_list:
+                inline: true
+                entry_name: Tala
+            type: array<DedexBundle\Entity\Ern42\TalaType>
+        deity:
+            expose: true
+            access_type: public_method
+            serialized_name: Deity
+            accessor:
+                getter: getDeity
+                setter: setDeity
+            xml_list:
+                inline: true
+                entry_name: Deity
+            type: array<DedexBundle\Entity\Ern42\DeityType>
+        hiResMusicDescription:
+            expose: true
+            access_type: public_method
+            serialized_name: HiResMusicDescription
+            accessor:
+                getter: getHiResMusicDescription
+                setter: setHiResMusicDescription
+            type: string
+        isSoundtrack:
+            expose: true
+            access_type: public_method
+            serialized_name: IsSoundtrack
+            accessor:
+                getter: getIsSoundtrack
+                setter: setIsSoundtrack
+            type: bool
+        isHiResMusic:
+            expose: true
+            access_type: public_method
+            serialized_name: IsHiResMusic
+            accessor:
+                getter: getIsHiResMusic
+                setter: setIsHiResMusic
+            type: bool
+        marketingComment:
+            expose: true
+            access_type: public_method
+            serialized_name: MarketingComment
+            accessor:
+                getter: getMarketingComment
+                setter: setMarketingComment
+            xml_list:
+                inline: true
+                entry_name: MarketingComment
+            type: array<DedexBundle\Entity\Ern42\MarketingCommentType>

--- a/src/Entity/Ern42/metadata/ReleaseTypeForReleaseNotificationType.yml
+++ b/src/Entity/Ern42/metadata/ReleaseTypeForReleaseNotificationType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\ReleaseTypeForReleaseNotificationType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/ReleaseVisibilityType.yml
+++ b/src/Entity/Ern42/metadata/ReleaseVisibilityType.yml
@@ -1,0 +1,34 @@
+DedexBundle\Entity\Ern42\ReleaseVisibilityType:
+    properties:
+        visibilityReference:
+            expose: true
+            access_type: public_method
+            serialized_name: VisibilityReference
+            accessor:
+                getter: getVisibilityReference
+                setter: setVisibilityReference
+            type: string
+        releaseDisplayStartDateTime:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseDisplayStartDateTime
+            accessor:
+                getter: getReleaseDisplayStartDateTime
+                setter: setReleaseDisplayStartDateTime
+            type: GoetasWebservices\Xsd\XsdToPhp\XMLSchema\DateTime
+        coverArtPreviewStartDateTime:
+            expose: true
+            access_type: public_method
+            serialized_name: CoverArtPreviewStartDateTime
+            accessor:
+                getter: getCoverArtPreviewStartDateTime
+                setter: setCoverArtPreviewStartDateTime
+            type: GoetasWebservices\Xsd\XsdToPhp\XMLSchema\DateTime
+        fullTrackListingPreviewStartDateTime:
+            expose: true
+            access_type: public_method
+            serialized_name: FullTrackListingPreviewStartDateTime
+            accessor:
+                getter: getFullTrackListingPreviewStartDateTime
+                setter: setFullTrackListingPreviewStartDateTime
+            type: GoetasWebservices\Xsd\XsdToPhp\XMLSchema\DateTime

--- a/src/Entity/Ern42/metadata/ResourceContainedResourceReferenceListType.yml
+++ b/src/Entity/Ern42/metadata/ResourceContainedResourceReferenceListType.yml
@@ -1,0 +1,13 @@
+DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceListType:
+    properties:
+        resourceContainedResourceReference:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceContainedResourceReference
+            accessor:
+                getter: getResourceContainedResourceReference
+                setter: setResourceContainedResourceReference
+            xml_list:
+                inline: true
+                entry_name: ResourceContainedResourceReference
+            type: array<DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType>

--- a/src/Entity/Ern42/metadata/ResourceContainedResourceReferenceType.yml
+++ b/src/Entity/Ern42/metadata/ResourceContainedResourceReferenceType.yml
@@ -1,0 +1,34 @@
+DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType:
+    properties:
+        resourceContainedResourceReference:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceContainedResourceReference
+            accessor:
+                getter: getResourceContainedResourceReference
+                setter: setResourceContainedResourceReference
+            type: string
+        durationUsed:
+            expose: true
+            access_type: public_method
+            serialized_name: DurationUsed
+            accessor:
+                getter: getDurationUsed
+                setter: setDurationUsed
+            type: DateInterval
+        startPoint:
+            expose: true
+            access_type: public_method
+            serialized_name: StartPoint
+            accessor:
+                getter: getStartPoint
+                setter: setStartPoint
+            type: float
+        purpose:
+            expose: true
+            access_type: public_method
+            serialized_name: Purpose
+            accessor:
+                getter: getPurpose
+                setter: setPurpose
+            type: DedexBundle\Entity\Ern42\PurposeType

--- a/src/Entity/Ern42/metadata/ResourceContributorRoleType.yml
+++ b/src/Entity/Ern42/metadata/ResourceContributorRoleType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\ResourceContributorRoleType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/ResourceGroupContentItemType.yml
+++ b/src/Entity/Ern42/metadata/ResourceGroupContentItemType.yml
@@ -1,0 +1,69 @@
+DedexBundle\Entity\Ern42\ResourceGroupContentItemType:
+    properties:
+        sequenceNumber:
+            expose: true
+            access_type: public_method
+            serialized_name: SequenceNumber
+            accessor:
+                getter: getSequenceNumber
+                setter: setSequenceNumber
+            type: int
+        noDisplaySequence:
+            expose: true
+            access_type: public_method
+            serialized_name: NoDisplaySequence
+            accessor:
+                getter: getNoDisplaySequence
+                setter: setNoDisplaySequence
+            type: bool
+        displaySequence:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplaySequence
+            accessor:
+                getter: getDisplaySequence
+                setter: setDisplaySequence
+            type: string
+        releaseResourceReference:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseResourceReference
+            accessor:
+                getter: getReleaseResourceReference
+                setter: setReleaseResourceReference
+            type: string
+        linkedReleaseResourceReference:
+            expose: true
+            access_type: public_method
+            serialized_name: LinkedReleaseResourceReference
+            accessor:
+                getter: getLinkedReleaseResourceReference
+                setter: setLinkedReleaseResourceReference
+            xml_list:
+                inline: true
+                entry_name: LinkedReleaseResourceReference
+            type: array<DedexBundle\Entity\Ern42\LinkedReleaseResourceReferenceType>
+        isBonusResource:
+            expose: true
+            access_type: public_method
+            serialized_name: IsBonusResource
+            accessor:
+                getter: getIsBonusResource
+                setter: setIsBonusResource
+            type: bool
+        isInstantGratificationResource:
+            expose: true
+            access_type: public_method
+            serialized_name: IsInstantGratificationResource
+            accessor:
+                getter: getIsInstantGratificationResource
+                setter: setIsInstantGratificationResource
+            type: bool
+        isPreOrderIncentiveResource:
+            expose: true
+            access_type: public_method
+            serialized_name: IsPreOrderIncentiveResource
+            accessor:
+                getter: getIsPreOrderIncentiveResource
+                setter: setIsPreOrderIncentiveResource
+            type: bool

--- a/src/Entity/Ern42/metadata/ResourceGroupType.yml
+++ b/src/Entity/Ern42/metadata/ResourceGroupType.yml
@@ -1,0 +1,138 @@
+DedexBundle\Entity\Ern42\ResourceGroupType:
+    properties:
+        displayTitleText:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayTitleText
+            accessor:
+                getter: getDisplayTitleText
+                setter: setDisplayTitleText
+            xml_list:
+                inline: true
+                entry_name: DisplayTitleText
+            type: array<DedexBundle\Entity\Ern42\DisplayTitleTextType>
+        displayTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayTitle
+            accessor:
+                getter: getDisplayTitle
+                setter: setDisplayTitle
+            xml_list:
+                inline: true
+                entry_name: DisplayTitle
+            type: array<DedexBundle\Entity\Ern42\DisplayTitleType>
+        additionalTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: AdditionalTitle
+            accessor:
+                getter: getAdditionalTitle
+                setter: setAdditionalTitle
+            xml_list:
+                inline: true
+                entry_name: AdditionalTitle
+            type: array<DedexBundle\Entity\Ern42\AdditionalTitleType>
+        sequenceNumber:
+            expose: true
+            access_type: public_method
+            serialized_name: SequenceNumber
+            accessor:
+                getter: getSequenceNumber
+                setter: setSequenceNumber
+            type: int
+        noDisplaySequence:
+            expose: true
+            access_type: public_method
+            serialized_name: NoDisplaySequence
+            accessor:
+                getter: getNoDisplaySequence
+                setter: setNoDisplaySequence
+            type: bool
+        displaySequence:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplaySequence
+            accessor:
+                getter: getDisplaySequence
+                setter: setDisplaySequence
+            type: string
+        displayArtist:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayArtist
+            accessor:
+                getter: getDisplayArtist
+                setter: setDisplayArtist
+            xml_list:
+                inline: true
+                entry_name: DisplayArtist
+            type: array<DedexBundle\Entity\Ern42\DisplayArtistType>
+        carrierType:
+            expose: true
+            access_type: public_method
+            serialized_name: CarrierType
+            accessor:
+                getter: getCarrierType
+                setter: setCarrierType
+            xml_list:
+                inline: true
+                entry_name: CarrierType
+            type: array<DedexBundle\Entity\Ern42\CarrierTypeType>
+        duration:
+            expose: true
+            access_type: public_method
+            serialized_name: Duration
+            accessor:
+                getter: getDuration
+                setter: setDuration
+            type: DateInterval
+        resourceGroupReleaseReference:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceGroupReleaseReference
+            accessor:
+                getter: getResourceGroupReleaseReference
+                setter: setResourceGroupReleaseReference
+            type: string
+        releaseId:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseId
+            accessor:
+                getter: getReleaseId
+                setter: setReleaseId
+            type: DedexBundle\Entity\Ern42\ReleaseIdType
+        resourceGroup:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceGroup
+            accessor:
+                getter: getResourceGroup
+                setter: setResourceGroup
+            xml_list:
+                inline: true
+                entry_name: ResourceGroup
+            type: array<DedexBundle\Entity\Ern42\ResourceSubGroupType>
+        resourceGroupContentItem:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceGroupContentItem
+            accessor:
+                getter: getResourceGroupContentItem
+                setter: setResourceGroupContentItem
+            xml_list:
+                inline: true
+                entry_name: ResourceGroupContentItem
+            type: array<DedexBundle\Entity\Ern42\ResourceGroupContentItemType>
+        linkedReleaseResourceReference:
+            expose: true
+            access_type: public_method
+            serialized_name: LinkedReleaseResourceReference
+            accessor:
+                getter: getLinkedReleaseResourceReference
+                setter: setLinkedReleaseResourceReference
+            xml_list:
+                inline: true
+                entry_name: LinkedReleaseResourceReference
+            type: array<DedexBundle\Entity\Ern42\LinkedReleaseResourceReferenceType>

--- a/src/Entity/Ern42/metadata/ResourceIdType.yml
+++ b/src/Entity/Ern42/metadata/ResourceIdType.yml
@@ -1,0 +1,86 @@
+DedexBundle\Entity\Ern42\ResourceIdType:
+    properties:
+        isReplaced:
+            expose: true
+            access_type: public_method
+            serialized_name: IsReplaced
+            accessor:
+                getter: getIsReplaced
+                setter: setIsReplaced
+            xml_attribute: true
+            type: bool
+        iSRC:
+            expose: true
+            access_type: public_method
+            serialized_name: ISRC
+            accessor:
+                getter: getISRC
+                setter: setISRC
+            type: string
+        iSMN:
+            expose: true
+            access_type: public_method
+            serialized_name: ISMN
+            accessor:
+                getter: getISMN
+                setter: setISMN
+            type: string
+        iSAN:
+            expose: true
+            access_type: public_method
+            serialized_name: ISAN
+            accessor:
+                getter: getISAN
+                setter: setISAN
+            type: string
+        vISAN:
+            expose: true
+            access_type: public_method
+            serialized_name: VISAN
+            accessor:
+                getter: getVISAN
+                setter: setVISAN
+            type: string
+        iSBN:
+            expose: true
+            access_type: public_method
+            serialized_name: ISBN
+            accessor:
+                getter: getISBN
+                setter: setISBN
+            type: string
+        iSSN:
+            expose: true
+            access_type: public_method
+            serialized_name: ISSN
+            accessor:
+                getter: getISSN
+                setter: setISSN
+            type: string
+        sICI:
+            expose: true
+            access_type: public_method
+            serialized_name: SICI
+            accessor:
+                getter: getSICI
+                setter: setSICI
+            type: string
+        catalogNumber:
+            expose: true
+            access_type: public_method
+            serialized_name: CatalogNumber
+            accessor:
+                getter: getCatalogNumber
+                setter: setCatalogNumber
+            type: DedexBundle\Entity\Ern42\CatalogNumberType
+        proprietaryId:
+            expose: true
+            access_type: public_method
+            serialized_name: ProprietaryId
+            accessor:
+                getter: getProprietaryId
+                setter: setProprietaryId
+            xml_list:
+                inline: true
+                entry_name: ProprietaryId
+            type: array<DedexBundle\Entity\Ern42\ProprietaryIdType>

--- a/src/Entity/Ern42/metadata/ResourceListType.yml
+++ b/src/Entity/Ern42/metadata/ResourceListType.yml
@@ -1,0 +1,68 @@
+DedexBundle\Entity\Ern42\ResourceListType:
+    properties:
+        soundRecording:
+            expose: true
+            access_type: public_method
+            serialized_name: SoundRecording
+            accessor:
+                getter: getSoundRecording
+                setter: setSoundRecording
+            xml_list:
+                inline: true
+                entry_name: SoundRecording
+            type: array<DedexBundle\Entity\Ern42\SoundRecordingType>
+        video:
+            expose: true
+            access_type: public_method
+            serialized_name: Video
+            accessor:
+                getter: getVideo
+                setter: setVideo
+            xml_list:
+                inline: true
+                entry_name: Video
+            type: array<DedexBundle\Entity\Ern42\VideoType>
+        image:
+            expose: true
+            access_type: public_method
+            serialized_name: Image
+            accessor:
+                getter: getImage
+                setter: setImage
+            xml_list:
+                inline: true
+                entry_name: Image
+            type: array<DedexBundle\Entity\Ern42\ImageType>
+        text:
+            expose: true
+            access_type: public_method
+            serialized_name: Text
+            accessor:
+                getter: getText
+                setter: setText
+            xml_list:
+                inline: true
+                entry_name: Text
+            type: array<DedexBundle\Entity\Ern42\TextType>
+        sheetMusic:
+            expose: true
+            access_type: public_method
+            serialized_name: SheetMusic
+            accessor:
+                getter: getSheetMusic
+                setter: setSheetMusic
+            xml_list:
+                inline: true
+                entry_name: SheetMusic
+            type: array<DedexBundle\Entity\Ern42\SheetMusicType>
+        software:
+            expose: true
+            access_type: public_method
+            serialized_name: Software
+            accessor:
+                getter: getSoftware
+                setter: setSoftware
+            xml_list:
+                inline: true
+                entry_name: Software
+            type: array<DedexBundle\Entity\Ern42\SoftwareType>

--- a/src/Entity/Ern42/metadata/ResourceProprietaryIdType.yml
+++ b/src/Entity/Ern42/metadata/ResourceProprietaryIdType.yml
@@ -1,0 +1,22 @@
+DedexBundle\Entity\Ern42\ResourceProprietaryIdType:
+    properties:
+        isReplaced:
+            expose: true
+            access_type: public_method
+            serialized_name: IsReplaced
+            accessor:
+                getter: getIsReplaced
+                setter: setIsReplaced
+            xml_attribute: true
+            type: bool
+        proprietaryId:
+            expose: true
+            access_type: public_method
+            serialized_name: ProprietaryId
+            accessor:
+                getter: getProprietaryId
+                setter: setProprietaryId
+            xml_list:
+                inline: true
+                entry_name: ProprietaryId
+            type: array<DedexBundle\Entity\Ern42\ProprietaryIdType>

--- a/src/Entity/Ern42/metadata/ResourceRightsControllerType.yml
+++ b/src/Entity/Ern42/metadata/ResourceRightsControllerType.yml
@@ -1,0 +1,57 @@
+DedexBundle\Entity\Ern42\ResourceRightsControllerType:
+    properties:
+        sequenceNumber:
+            expose: true
+            access_type: public_method
+            serialized_name: SequenceNumber
+            accessor:
+                getter: getSequenceNumber
+                setter: setSequenceNumber
+            xml_attribute: true
+            type: int
+        rightsControllerPartyReference:
+            expose: true
+            access_type: public_method
+            serialized_name: RightsControllerPartyReference
+            accessor:
+                getter: getRightsControllerPartyReference
+                setter: setRightsControllerPartyReference
+            type: string
+        rightsControlType:
+            expose: true
+            access_type: public_method
+            serialized_name: RightsControlType
+            accessor:
+                getter: getRightsControlType
+                setter: setRightsControlType
+            xml_list:
+                inline: true
+                entry_name: RightsControlType
+            type: array<string>
+        rightShareUnknown:
+            expose: true
+            access_type: public_method
+            serialized_name: RightShareUnknown
+            accessor:
+                getter: getRightShareUnknown
+                setter: setRightShareUnknown
+            type: bool
+        rightSharePercentage:
+            expose: true
+            access_type: public_method
+            serialized_name: RightSharePercentage
+            accessor:
+                getter: getRightSharePercentage
+                setter: setRightSharePercentage
+            type: DedexBundle\Entity\Ern42\PercentageType
+        delegatedUsageRights:
+            expose: true
+            access_type: public_method
+            serialized_name: DelegatedUsageRights
+            accessor:
+                getter: getDelegatedUsageRights
+                setter: setDelegatedUsageRights
+            xml_list:
+                inline: true
+                entry_name: DelegatedUsageRights
+            type: array<DedexBundle\Entity\Ern42\DelegatedUsageRightsType>

--- a/src/Entity/Ern42/metadata/ResourceSubGroupType.yml
+++ b/src/Entity/Ern42/metadata/ResourceSubGroupType.yml
@@ -1,0 +1,147 @@
+DedexBundle\Entity\Ern42\ResourceSubGroupType:
+    properties:
+        resourceGroupType:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceGroupType
+            accessor:
+                getter: getResourceGroupType
+                setter: setResourceGroupType
+            xml_attribute: true
+            type: string
+        displayTitleText:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayTitleText
+            accessor:
+                getter: getDisplayTitleText
+                setter: setDisplayTitleText
+            xml_list:
+                inline: true
+                entry_name: DisplayTitleText
+            type: array<DedexBundle\Entity\Ern42\DisplayTitleTextType>
+        displayTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayTitle
+            accessor:
+                getter: getDisplayTitle
+                setter: setDisplayTitle
+            xml_list:
+                inline: true
+                entry_name: DisplayTitle
+            type: array<DedexBundle\Entity\Ern42\DisplayTitleType>
+        additionalTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: AdditionalTitle
+            accessor:
+                getter: getAdditionalTitle
+                setter: setAdditionalTitle
+            xml_list:
+                inline: true
+                entry_name: AdditionalTitle
+            type: array<DedexBundle\Entity\Ern42\AdditionalTitleType>
+        sequenceNumber:
+            expose: true
+            access_type: public_method
+            serialized_name: SequenceNumber
+            accessor:
+                getter: getSequenceNumber
+                setter: setSequenceNumber
+            type: int
+        noDisplaySequence:
+            expose: true
+            access_type: public_method
+            serialized_name: NoDisplaySequence
+            accessor:
+                getter: getNoDisplaySequence
+                setter: setNoDisplaySequence
+            type: bool
+        displaySequence:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplaySequence
+            accessor:
+                getter: getDisplaySequence
+                setter: setDisplaySequence
+            type: string
+        displayArtist:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayArtist
+            accessor:
+                getter: getDisplayArtist
+                setter: setDisplayArtist
+            xml_list:
+                inline: true
+                entry_name: DisplayArtist
+            type: array<DedexBundle\Entity\Ern42\DisplayArtistType>
+        carrierType:
+            expose: true
+            access_type: public_method
+            serialized_name: CarrierType
+            accessor:
+                getter: getCarrierType
+                setter: setCarrierType
+            xml_list:
+                inline: true
+                entry_name: CarrierType
+            type: array<DedexBundle\Entity\Ern42\CarrierTypeType>
+        duration:
+            expose: true
+            access_type: public_method
+            serialized_name: Duration
+            accessor:
+                getter: getDuration
+                setter: setDuration
+            type: DateInterval
+        resourceGroupReleaseReference:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceGroupReleaseReference
+            accessor:
+                getter: getResourceGroupReleaseReference
+                setter: setResourceGroupReleaseReference
+            type: string
+        releaseId:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseId
+            accessor:
+                getter: getReleaseId
+                setter: setReleaseId
+            type: DedexBundle\Entity\Ern42\ReleaseIdType
+        resourceGroup:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceGroup
+            accessor:
+                getter: getResourceGroup
+                setter: setResourceGroup
+            xml_list:
+                inline: true
+                entry_name: ResourceGroup
+            type: array<DedexBundle\Entity\Ern42\ResourceSubGroupType>
+        resourceGroupContentItem:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceGroupContentItem
+            accessor:
+                getter: getResourceGroupContentItem
+                setter: setResourceGroupContentItem
+            xml_list:
+                inline: true
+                entry_name: ResourceGroupContentItem
+            type: array<DedexBundle\Entity\Ern42\ResourceGroupContentItemType>
+        linkedReleaseResourceReference:
+            expose: true
+            access_type: public_method
+            serialized_name: LinkedReleaseResourceReference
+            accessor:
+                getter: getLinkedReleaseResourceReference
+                setter: setLinkedReleaseResourceReference
+            xml_list:
+                inline: true
+                entry_name: LinkedReleaseResourceReference
+            type: array<DedexBundle\Entity\Ern42\LinkedReleaseResourceReferenceType>

--- a/src/Entity/Ern42/metadata/RightsClaimPolicyType.yml
+++ b/src/Entity/Ern42/metadata/RightsClaimPolicyType.yml
@@ -1,0 +1,21 @@
+DedexBundle\Entity\Ern42\RightsClaimPolicyType:
+    properties:
+        condition:
+            expose: true
+            access_type: public_method
+            serialized_name: Condition
+            accessor:
+                getter: getCondition
+                setter: setCondition
+            xml_list:
+                inline: true
+                entry_name: Condition
+            type: array<DedexBundle\Entity\Ern42\ConditionForRightsClaimPolicyType>
+        rightsClaimPolicyType:
+            expose: true
+            access_type: public_method
+            serialized_name: RightsClaimPolicyType
+            accessor:
+                getter: getRightsClaimPolicyType
+                setter: setRightsClaimPolicyType
+            type: string

--- a/src/Entity/Ern42/metadata/SamplingRateType.yml
+++ b/src/Entity/Ern42/metadata/SamplingRateType.yml
@@ -1,0 +1,19 @@
+DedexBundle\Entity\Ern42\SamplingRateType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: float
+        unitOfMeasure:
+            expose: true
+            access_type: public_method
+            serialized_name: UnitOfMeasure
+            accessor:
+                getter: getUnitOfMeasure
+                setter: setUnitOfMeasure
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/SessionTypeType.yml
+++ b/src/Entity/Ern42/metadata/SessionTypeType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\SessionTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/SheetMusicCodecTypeType.yml
+++ b/src/Entity/Ern42/metadata/SheetMusicCodecTypeType.yml
@@ -1,0 +1,37 @@
+DedexBundle\Entity\Ern42\SheetMusicCodecTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        version:
+            expose: true
+            access_type: public_method
+            serialized_name: Version
+            accessor:
+                getter: getVersion
+                setter: setVersion
+            xml_attribute: true
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/SheetMusicIdType.yml
+++ b/src/Entity/Ern42/metadata/SheetMusicIdType.yml
@@ -1,0 +1,30 @@
+DedexBundle\Entity\Ern42\SheetMusicIdType:
+    properties:
+        isReplaced:
+            expose: true
+            access_type: public_method
+            serialized_name: IsReplaced
+            accessor:
+                getter: getIsReplaced
+                setter: setIsReplaced
+            xml_attribute: true
+            type: bool
+        iSMN:
+            expose: true
+            access_type: public_method
+            serialized_name: ISMN
+            accessor:
+                getter: getISMN
+                setter: setISMN
+            type: string
+        proprietaryId:
+            expose: true
+            access_type: public_method
+            serialized_name: ProprietaryId
+            accessor:
+                getter: getProprietaryId
+                setter: setProprietaryId
+            xml_list:
+                inline: true
+                entry_name: ProprietaryId
+            type: array<DedexBundle\Entity\Ern42\ProprietaryIdType>

--- a/src/Entity/Ern42/metadata/SheetMusicType.yml
+++ b/src/Entity/Ern42/metadata/SheetMusicType.yml
@@ -1,0 +1,270 @@
+DedexBundle\Entity\Ern42\SheetMusicType:
+    properties:
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        isSupplemental:
+            expose: true
+            access_type: public_method
+            serialized_name: IsSupplemental
+            accessor:
+                getter: getIsSupplemental
+                setter: setIsSupplemental
+            xml_attribute: true
+            type: bool
+        resourceReference:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceReference
+            accessor:
+                getter: getResourceReference
+                setter: setResourceReference
+            type: string
+        type:
+            expose: true
+            access_type: public_method
+            serialized_name: Type
+            accessor:
+                getter: getType
+                setter: setType
+            type: DedexBundle\Entity\Ern42\SheetMusicTypeType
+        resourceId:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceId
+            accessor:
+                getter: getResourceId
+                setter: setResourceId
+            xml_list:
+                inline: true
+                entry_name: ResourceId
+            type: array<DedexBundle\Entity\Ern42\SheetMusicIdType>
+        workId:
+            expose: true
+            access_type: public_method
+            serialized_name: WorkId
+            accessor:
+                getter: getWorkId
+                setter: setWorkId
+            xml_list:
+                inline: true
+                entry_name: WorkId
+            type: array<DedexBundle\Entity\Ern42\MusicalWorkIdType>
+        displayTitleText:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayTitleText
+            accessor:
+                getter: getDisplayTitleText
+                setter: setDisplayTitleText
+            xml_list:
+                inline: true
+                entry_name: DisplayTitleText
+            type: array<DedexBundle\Entity\Ern42\DisplayTitleTextType>
+        displayTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayTitle
+            accessor:
+                getter: getDisplayTitle
+                setter: setDisplayTitle
+            xml_list:
+                inline: true
+                entry_name: DisplayTitle
+            type: array<DedexBundle\Entity\Ern42\DisplayTitleType>
+        additionalTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: AdditionalTitle
+            accessor:
+                getter: getAdditionalTitle
+                setter: setAdditionalTitle
+            xml_list:
+                inline: true
+                entry_name: AdditionalTitle
+            type: array<DedexBundle\Entity\Ern42\AdditionalTitleType>
+        versionType:
+            expose: true
+            access_type: public_method
+            serialized_name: VersionType
+            accessor:
+                getter: getVersionType
+                setter: setVersionType
+            xml_list:
+                inline: true
+                entry_name: VersionType
+            type: array<DedexBundle\Entity\Ern42\VersionTypeType>
+        displayArtistName:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayArtistName
+            accessor:
+                getter: getDisplayArtistName
+                setter: setDisplayArtistName
+            xml_list:
+                inline: true
+                entry_name: DisplayArtistName
+            type: array<DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType>
+        displayArtist:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayArtist
+            accessor:
+                getter: getDisplayArtist
+                setter: setDisplayArtist
+            xml_list:
+                inline: true
+                entry_name: DisplayArtist
+            type: array<DedexBundle\Entity\Ern42\DisplayArtistType>
+        contributor:
+            expose: true
+            access_type: public_method
+            serialized_name: Contributor
+            accessor:
+                getter: getContributor
+                setter: setContributor
+            xml_list:
+                inline: true
+                entry_name: Contributor
+            type: array<DedexBundle\Entity\Ern42\ContributorType>
+        resourceRightsController:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceRightsController
+            accessor:
+                getter: getResourceRightsController
+                setter: setResourceRightsController
+            xml_list:
+                inline: true
+                entry_name: ResourceRightsController
+            type: array<DedexBundle\Entity\Ern42\ResourceRightsControllerType>
+        workRightsController:
+            expose: true
+            access_type: public_method
+            serialized_name: WorkRightsController
+            accessor:
+                getter: getWorkRightsController
+                setter: setWorkRightsController
+            xml_list:
+                inline: true
+                entry_name: WorkRightsController
+            type: array<DedexBundle\Entity\Ern42\WorkRightsControllerType>
+        cLine:
+            expose: true
+            access_type: public_method
+            serialized_name: CLine
+            accessor:
+                getter: getCLine
+                setter: setCLine
+            xml_list:
+                inline: true
+                entry_name: CLine
+            type: array<DedexBundle\Entity\Ern42\CLineWithDefaultType>
+        courtesyLine:
+            expose: true
+            access_type: public_method
+            serialized_name: CourtesyLine
+            accessor:
+                getter: getCourtesyLine
+                setter: setCourtesyLine
+            xml_list:
+                inline: true
+                entry_name: CourtesyLine
+            type: array<DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType>
+        creationDate:
+            expose: true
+            access_type: public_method
+            serialized_name: CreationDate
+            accessor:
+                getter: getCreationDate
+                setter: setCreationDate
+            type: DedexBundle\Entity\Ern42\EventDateWithoutFlagsType
+        firstPublicationDate:
+            expose: true
+            access_type: public_method
+            serialized_name: FirstPublicationDate
+            accessor:
+                getter: getFirstPublicationDate
+                setter: setFirstPublicationDate
+            xml_list:
+                inline: true
+                entry_name: FirstPublicationDate
+            type: array<DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType>
+        parentalWarningType:
+            expose: true
+            access_type: public_method
+            serialized_name: ParentalWarningType
+            accessor:
+                getter: getParentalWarningType
+                setter: setParentalWarningType
+            xml_list:
+                inline: true
+                entry_name: ParentalWarningType
+            type: array<DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType>
+        relatedRelease:
+            expose: true
+            access_type: public_method
+            serialized_name: RelatedRelease
+            accessor:
+                getter: getRelatedRelease
+                setter: setRelatedRelease
+            xml_list:
+                inline: true
+                entry_name: RelatedRelease
+            type: array<DedexBundle\Entity\Ern42\RelatedReleaseType>
+        relatedResource:
+            expose: true
+            access_type: public_method
+            serialized_name: RelatedResource
+            accessor:
+                getter: getRelatedResource
+                setter: setRelatedResource
+            xml_list:
+                inline: true
+                entry_name: RelatedResource
+            type: array<DedexBundle\Entity\Ern42\RelatedResourceType>
+        containsHiddenContent:
+            expose: true
+            access_type: public_method
+            serialized_name: ContainsHiddenContent
+            accessor:
+                getter: getContainsHiddenContent
+                setter: setContainsHiddenContent
+            type: bool
+        languageOfLyrics:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageOfLyrics
+            accessor:
+                getter: getLanguageOfLyrics
+                setter: setLanguageOfLyrics
+            type: string
+        resourceContainedResourceReferenceList:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceContainedResourceReferenceList
+            accessor:
+                getter: getResourceContainedResourceReferenceList
+                setter: setResourceContainedResourceReferenceList
+            type: array<DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType>
+            xml_list:
+                inline: false
+                entry_name: ResourceContainedResourceReference
+                skip_when_empty: true
+        technicalDetails:
+            expose: true
+            access_type: public_method
+            serialized_name: TechnicalDetails
+            accessor:
+                getter: getTechnicalDetails
+                setter: setTechnicalDetails
+            xml_list:
+                inline: true
+                entry_name: TechnicalDetails
+            type: array<DedexBundle\Entity\Ern42\TechnicalSheetMusicDetailsType>

--- a/src/Entity/Ern42/metadata/SheetMusicTypeType.yml
+++ b/src/Entity/Ern42/metadata/SheetMusicTypeType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\SheetMusicTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/SimpleRightsTypeType.yml
+++ b/src/Entity/Ern42/metadata/SimpleRightsTypeType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\SimpleRightsTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/SoftwareType.yml
+++ b/src/Entity/Ern42/metadata/SoftwareType.yml
@@ -1,0 +1,273 @@
+DedexBundle\Entity\Ern42\SoftwareType:
+    properties:
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        isSupplemental:
+            expose: true
+            access_type: public_method
+            serialized_name: IsSupplemental
+            accessor:
+                getter: getIsSupplemental
+                setter: setIsSupplemental
+            xml_attribute: true
+            type: bool
+        resourceReference:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceReference
+            accessor:
+                getter: getResourceReference
+                setter: setResourceReference
+            type: string
+        type:
+            expose: true
+            access_type: public_method
+            serialized_name: Type
+            accessor:
+                getter: getType
+                setter: setType
+            type: DedexBundle\Entity\Ern42\SoftwareTypeType
+        resourceId:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceId
+            accessor:
+                getter: getResourceId
+                setter: setResourceId
+            xml_list:
+                inline: true
+                entry_name: ResourceId
+            type: array<DedexBundle\Entity\Ern42\ResourceProprietaryIdType>
+        workId:
+            expose: true
+            access_type: public_method
+            serialized_name: WorkId
+            accessor:
+                getter: getWorkId
+                setter: setWorkId
+            xml_list:
+                inline: true
+                entry_name: WorkId
+            type: array<DedexBundle\Entity\Ern42\MusicalWorkIdType>
+        displayTitleText:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayTitleText
+            accessor:
+                getter: getDisplayTitleText
+                setter: setDisplayTitleText
+            xml_list:
+                inline: true
+                entry_name: DisplayTitleText
+            type: array<DedexBundle\Entity\Ern42\DisplayTitleTextType>
+        displayTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayTitle
+            accessor:
+                getter: getDisplayTitle
+                setter: setDisplayTitle
+            xml_list:
+                inline: true
+                entry_name: DisplayTitle
+            type: array<DedexBundle\Entity\Ern42\DisplayTitleType>
+        additionalTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: AdditionalTitle
+            accessor:
+                getter: getAdditionalTitle
+                setter: setAdditionalTitle
+            xml_list:
+                inline: true
+                entry_name: AdditionalTitle
+            type: array<DedexBundle\Entity\Ern42\AdditionalTitleType>
+        versionType:
+            expose: true
+            access_type: public_method
+            serialized_name: VersionType
+            accessor:
+                getter: getVersionType
+                setter: setVersionType
+            xml_list:
+                inline: true
+                entry_name: VersionType
+            type: array<DedexBundle\Entity\Ern42\VersionTypeType>
+        displayArtistName:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayArtistName
+            accessor:
+                getter: getDisplayArtistName
+                setter: setDisplayArtistName
+            xml_list:
+                inline: true
+                entry_name: DisplayArtistName
+            type: array<DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType>
+        displayArtist:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayArtist
+            accessor:
+                getter: getDisplayArtist
+                setter: setDisplayArtist
+            xml_list:
+                inline: true
+                entry_name: DisplayArtist
+            type: array<DedexBundle\Entity\Ern42\DisplayArtistType>
+        contributor:
+            expose: true
+            access_type: public_method
+            serialized_name: Contributor
+            accessor:
+                getter: getContributor
+                setter: setContributor
+            xml_list:
+                inline: true
+                entry_name: Contributor
+            type: array<DedexBundle\Entity\Ern42\ContributorType>
+        resourceRightsController:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceRightsController
+            accessor:
+                getter: getResourceRightsController
+                setter: setResourceRightsController
+            xml_list:
+                inline: true
+                entry_name: ResourceRightsController
+            type: array<DedexBundle\Entity\Ern42\ResourceRightsControllerType>
+        workRightsController:
+            expose: true
+            access_type: public_method
+            serialized_name: WorkRightsController
+            accessor:
+                getter: getWorkRightsController
+                setter: setWorkRightsController
+            xml_list:
+                inline: true
+                entry_name: WorkRightsController
+            type: array<DedexBundle\Entity\Ern42\WorkRightsControllerType>
+        pLine:
+            expose: true
+            access_type: public_method
+            serialized_name: PLine
+            accessor:
+                getter: getPLine
+                setter: setPLine
+            xml_list:
+                inline: true
+                entry_name: PLine
+            type: array<DedexBundle\Entity\Ern42\PLineWithDefaultType>
+        cLine:
+            expose: true
+            access_type: public_method
+            serialized_name: CLine
+            accessor:
+                getter: getCLine
+                setter: setCLine
+            xml_list:
+                inline: true
+                entry_name: CLine
+            type: array<DedexBundle\Entity\Ern42\CLineWithDefaultType>
+        courtesyLine:
+            expose: true
+            access_type: public_method
+            serialized_name: CourtesyLine
+            accessor:
+                getter: getCourtesyLine
+                setter: setCourtesyLine
+            xml_list:
+                inline: true
+                entry_name: CourtesyLine
+            type: array<DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType>
+        creationDate:
+            expose: true
+            access_type: public_method
+            serialized_name: CreationDate
+            accessor:
+                getter: getCreationDate
+                setter: setCreationDate
+            type: DedexBundle\Entity\Ern42\EventDateWithoutFlagsType
+        firstPublicationDate:
+            expose: true
+            access_type: public_method
+            serialized_name: FirstPublicationDate
+            accessor:
+                getter: getFirstPublicationDate
+                setter: setFirstPublicationDate
+            xml_list:
+                inline: true
+                entry_name: FirstPublicationDate
+            type: array<DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType>
+        parentalWarningType:
+            expose: true
+            access_type: public_method
+            serialized_name: ParentalWarningType
+            accessor:
+                getter: getParentalWarningType
+                setter: setParentalWarningType
+            xml_list:
+                inline: true
+                entry_name: ParentalWarningType
+            type: array<DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType>
+        relatedRelease:
+            expose: true
+            access_type: public_method
+            serialized_name: RelatedRelease
+            accessor:
+                getter: getRelatedRelease
+                setter: setRelatedRelease
+            xml_list:
+                inline: true
+                entry_name: RelatedRelease
+            type: array<DedexBundle\Entity\Ern42\RelatedReleaseType>
+        relatedResource:
+            expose: true
+            access_type: public_method
+            serialized_name: RelatedResource
+            accessor:
+                getter: getRelatedResource
+                setter: setRelatedResource
+            xml_list:
+                inline: true
+                entry_name: RelatedResource
+            type: array<DedexBundle\Entity\Ern42\RelatedResourceType>
+        containsHiddenContent:
+            expose: true
+            access_type: public_method
+            serialized_name: ContainsHiddenContent
+            accessor:
+                getter: getContainsHiddenContent
+                setter: setContainsHiddenContent
+            type: bool
+        resourceContainedResourceReferenceList:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceContainedResourceReferenceList
+            accessor:
+                getter: getResourceContainedResourceReferenceList
+                setter: setResourceContainedResourceReferenceList
+            type: array<DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType>
+            xml_list:
+                inline: false
+                entry_name: ResourceContainedResourceReference
+                skip_when_empty: true
+        technicalDetails:
+            expose: true
+            access_type: public_method
+            serialized_name: TechnicalDetails
+            accessor:
+                getter: getTechnicalDetails
+                setter: setTechnicalDetails
+            xml_list:
+                inline: true
+                entry_name: TechnicalDetails
+            type: array<DedexBundle\Entity\Ern42\TechnicalSoftwareDetailsType>

--- a/src/Entity/Ern42/metadata/SoftwareTypeType.yml
+++ b/src/Entity/Ern42/metadata/SoftwareTypeType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\SoftwareTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/SoundRecordingIdType.yml
+++ b/src/Entity/Ern42/metadata/SoundRecordingIdType.yml
@@ -1,0 +1,38 @@
+DedexBundle\Entity\Ern42\SoundRecordingIdType:
+    properties:
+        isReplaced:
+            expose: true
+            access_type: public_method
+            serialized_name: IsReplaced
+            accessor:
+                getter: getIsReplaced
+                setter: setIsReplaced
+            xml_attribute: true
+            type: bool
+        iSRC:
+            expose: true
+            access_type: public_method
+            serialized_name: ISRC
+            accessor:
+                getter: getISRC
+                setter: setISRC
+            type: string
+        catalogNumber:
+            expose: true
+            access_type: public_method
+            serialized_name: CatalogNumber
+            accessor:
+                getter: getCatalogNumber
+                setter: setCatalogNumber
+            type: DedexBundle\Entity\Ern42\CatalogNumberType
+        proprietaryId:
+            expose: true
+            access_type: public_method
+            serialized_name: ProprietaryId
+            accessor:
+                getter: getProprietaryId
+                setter: setProprietaryId
+            xml_list:
+                inline: true
+                entry_name: ProprietaryId
+            type: array<DedexBundle\Entity\Ern42\ProprietaryIdType>

--- a/src/Entity/Ern42/metadata/SoundRecordingPreviewDetailsType.yml
+++ b/src/Entity/Ern42/metadata/SoundRecordingPreviewDetailsType.yml
@@ -1,0 +1,50 @@
+DedexBundle\Entity\Ern42\SoundRecordingPreviewDetailsType:
+    properties:
+        startPoint:
+            expose: true
+            access_type: public_method
+            serialized_name: StartPoint
+            accessor:
+                getter: getStartPoint
+                setter: setStartPoint
+            type: float
+        endPoint:
+            expose: true
+            access_type: public_method
+            serialized_name: EndPoint
+            accessor:
+                getter: getEndPoint
+                setter: setEndPoint
+            type: float
+        duration:
+            expose: true
+            access_type: public_method
+            serialized_name: Duration
+            accessor:
+                getter: getDuration
+                setter: setDuration
+            type: DateInterval
+        topLeftCorner:
+            expose: true
+            access_type: public_method
+            serialized_name: TopLeftCorner
+            accessor:
+                getter: getTopLeftCorner
+                setter: setTopLeftCorner
+            type: string
+        bottomRightCorner:
+            expose: true
+            access_type: public_method
+            serialized_name: BottomRightCorner
+            accessor:
+                getter: getBottomRightCorner
+                setter: setBottomRightCorner
+            type: string
+        expressionType:
+            expose: true
+            access_type: public_method
+            serialized_name: ExpressionType
+            accessor:
+                getter: getExpressionType
+                setter: setExpressionType
+            type: string

--- a/src/Entity/Ern42/metadata/SoundRecordingType.yml
+++ b/src/Entity/Ern42/metadata/SoundRecordingType.yml
@@ -1,0 +1,426 @@
+DedexBundle\Entity\Ern42\SoundRecordingType:
+    properties:
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        isSupplemental:
+            expose: true
+            access_type: public_method
+            serialized_name: IsSupplemental
+            accessor:
+                getter: getIsSupplemental
+                setter: setIsSupplemental
+            xml_attribute: true
+            type: bool
+        resourceReference:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceReference
+            accessor:
+                getter: getResourceReference
+                setter: setResourceReference
+            type: string
+        type:
+            expose: true
+            access_type: public_method
+            serialized_name: Type
+            accessor:
+                getter: getType
+                setter: setType
+            type: DedexBundle\Entity\Ern42\SoundRecordingTypeType
+        resourceId:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceId
+            accessor:
+                getter: getResourceId
+                setter: setResourceId
+            xml_list:
+                inline: true
+                entry_name: ResourceId
+            type: array<DedexBundle\Entity\Ern42\SoundRecordingIdType>
+        workId:
+            expose: true
+            access_type: public_method
+            serialized_name: WorkId
+            accessor:
+                getter: getWorkId
+                setter: setWorkId
+            xml_list:
+                inline: true
+                entry_name: WorkId
+            type: array<DedexBundle\Entity\Ern42\MusicalWorkIdType>
+        displayTitleText:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayTitleText
+            accessor:
+                getter: getDisplayTitleText
+                setter: setDisplayTitleText
+            xml_list:
+                inline: true
+                entry_name: DisplayTitleText
+            type: array<DedexBundle\Entity\Ern42\DisplayTitleTextType>
+        displayTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayTitle
+            accessor:
+                getter: getDisplayTitle
+                setter: setDisplayTitle
+            xml_list:
+                inline: true
+                entry_name: DisplayTitle
+            type: array<DedexBundle\Entity\Ern42\DisplayTitleType>
+        additionalTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: AdditionalTitle
+            accessor:
+                getter: getAdditionalTitle
+                setter: setAdditionalTitle
+            xml_list:
+                inline: true
+                entry_name: AdditionalTitle
+            type: array<DedexBundle\Entity\Ern42\AdditionalTitleType>
+        versionType:
+            expose: true
+            access_type: public_method
+            serialized_name: VersionType
+            accessor:
+                getter: getVersionType
+                setter: setVersionType
+            xml_list:
+                inline: true
+                entry_name: VersionType
+            type: array<DedexBundle\Entity\Ern42\VersionTypeType>
+        displayArtistName:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayArtistName
+            accessor:
+                getter: getDisplayArtistName
+                setter: setDisplayArtistName
+            xml_list:
+                inline: true
+                entry_name: DisplayArtistName
+            type: array<DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType>
+        displayArtist:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayArtist
+            accessor:
+                getter: getDisplayArtist
+                setter: setDisplayArtist
+            xml_list:
+                inline: true
+                entry_name: DisplayArtist
+            type: array<DedexBundle\Entity\Ern42\DisplayArtistType>
+        contributor:
+            expose: true
+            access_type: public_method
+            serialized_name: Contributor
+            accessor:
+                getter: getContributor
+                setter: setContributor
+            xml_list:
+                inline: true
+                entry_name: Contributor
+            type: array<DedexBundle\Entity\Ern42\ContributorType>
+        character:
+            expose: true
+            access_type: public_method
+            serialized_name: Character
+            accessor:
+                getter: getCharacter
+                setter: setCharacter
+            xml_list:
+                inline: true
+                entry_name: Character
+            type: array<DedexBundle\Entity\Ern42\CharacterType>
+        resourceRightsController:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceRightsController
+            accessor:
+                getter: getResourceRightsController
+                setter: setResourceRightsController
+            xml_list:
+                inline: true
+                entry_name: ResourceRightsController
+            type: array<DedexBundle\Entity\Ern42\ResourceRightsControllerType>
+        workRightsController:
+            expose: true
+            access_type: public_method
+            serialized_name: WorkRightsController
+            accessor:
+                getter: getWorkRightsController
+                setter: setWorkRightsController
+            xml_list:
+                inline: true
+                entry_name: WorkRightsController
+            type: array<DedexBundle\Entity\Ern42\WorkRightsControllerType>
+        pLine:
+            expose: true
+            access_type: public_method
+            serialized_name: PLine
+            accessor:
+                getter: getPLine
+                setter: setPLine
+            xml_list:
+                inline: true
+                entry_name: PLine
+            type: array<DedexBundle\Entity\Ern42\PLineWithDefaultType>
+        courtesyLine:
+            expose: true
+            access_type: public_method
+            serialized_name: CourtesyLine
+            accessor:
+                getter: getCourtesyLine
+                setter: setCourtesyLine
+            xml_list:
+                inline: true
+                entry_name: CourtesyLine
+            type: array<DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType>
+        duration:
+            expose: true
+            access_type: public_method
+            serialized_name: Duration
+            accessor:
+                getter: getDuration
+                setter: setDuration
+            type: DateInterval
+        creationDate:
+            expose: true
+            access_type: public_method
+            serialized_name: CreationDate
+            accessor:
+                getter: getCreationDate
+                setter: setCreationDate
+            type: DedexBundle\Entity\Ern42\EventDateWithoutFlagsType
+        masteredDate:
+            expose: true
+            access_type: public_method
+            serialized_name: MasteredDate
+            accessor:
+                getter: getMasteredDate
+                setter: setMasteredDate
+            type: DedexBundle\Entity\Ern42\EventDateWithoutFlagsType
+        remasteredDate:
+            expose: true
+            access_type: public_method
+            serialized_name: RemasteredDate
+            accessor:
+                getter: getRemasteredDate
+                setter: setRemasteredDate
+            type: DedexBundle\Entity\Ern42\EventDateWithoutFlagsType
+        firstPublicationDate:
+            expose: true
+            access_type: public_method
+            serialized_name: FirstPublicationDate
+            accessor:
+                getter: getFirstPublicationDate
+                setter: setFirstPublicationDate
+            xml_list:
+                inline: true
+                entry_name: FirstPublicationDate
+            type: array<DedexBundle\Entity\Ern42\FirstPublicationDateType>
+        locationAndDateOfSession:
+            expose: true
+            access_type: public_method
+            serialized_name: LocationAndDateOfSession
+            accessor:
+                getter: getLocationAndDateOfSession
+                setter: setLocationAndDateOfSession
+            xml_list:
+                inline: true
+                entry_name: LocationAndDateOfSession
+            type: array<DedexBundle\Entity\Ern42\LocationAndDateOfSessionType>
+        parentalWarningType:
+            expose: true
+            access_type: public_method
+            serialized_name: ParentalWarningType
+            accessor:
+                getter: getParentalWarningType
+                setter: setParentalWarningType
+            xml_list:
+                inline: true
+                entry_name: ParentalWarningType
+            type: array<DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType>
+        relatedRelease:
+            expose: true
+            access_type: public_method
+            serialized_name: RelatedRelease
+            accessor:
+                getter: getRelatedRelease
+                setter: setRelatedRelease
+            xml_list:
+                inline: true
+                entry_name: RelatedRelease
+            type: array<DedexBundle\Entity\Ern42\RelatedReleaseType>
+        relatedResource:
+            expose: true
+            access_type: public_method
+            serialized_name: RelatedResource
+            accessor:
+                getter: getRelatedResource
+                setter: setRelatedResource
+            xml_list:
+                inline: true
+                entry_name: RelatedResource
+            type: array<DedexBundle\Entity\Ern42\RelatedResourceType>
+        compositeMusicalWorkType:
+            expose: true
+            access_type: public_method
+            serialized_name: CompositeMusicalWorkType
+            accessor:
+                getter: getCompositeMusicalWorkType
+                setter: setCompositeMusicalWorkType
+            type: string
+        isCover:
+            expose: true
+            access_type: public_method
+            serialized_name: IsCover
+            accessor:
+                getter: getIsCover
+                setter: setIsCover
+            type: bool
+        isInstrumental:
+            expose: true
+            access_type: public_method
+            serialized_name: IsInstrumental
+            accessor:
+                getter: getIsInstrumental
+                setter: setIsInstrumental
+            type: bool
+        containsHiddenContent:
+            expose: true
+            access_type: public_method
+            serialized_name: ContainsHiddenContent
+            accessor:
+                getter: getContainsHiddenContent
+                setter: setContainsHiddenContent
+            type: bool
+        isRemastered:
+            expose: true
+            access_type: public_method
+            serialized_name: IsRemastered
+            accessor:
+                getter: getIsRemastered
+                setter: setIsRemastered
+            type: bool
+        isHiResMusic:
+            expose: true
+            access_type: public_method
+            serialized_name: IsHiResMusic
+            accessor:
+                getter: getIsHiResMusic
+                setter: setIsHiResMusic
+            type: bool
+        disableCrossfade:
+            expose: true
+            access_type: public_method
+            serialized_name: DisableCrossfade
+            accessor:
+                getter: getDisableCrossfade
+                setter: setDisableCrossfade
+            type: bool
+        disableSearch:
+            expose: true
+            access_type: public_method
+            serialized_name: DisableSearch
+            accessor:
+                getter: getDisableSearch
+                setter: setDisableSearch
+            type: bool
+        displayCredits:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayCredits
+            accessor:
+                getter: getDisplayCredits
+                setter: setDisplayCredits
+            xml_list:
+                inline: true
+                entry_name: DisplayCredits
+            type: array<DedexBundle\Entity\Ern42\DisplayCreditsType>
+        languageOfPerformance:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageOfPerformance
+            accessor:
+                getter: getLanguageOfPerformance
+                setter: setLanguageOfPerformance
+            xml_list:
+                inline: true
+                entry_name: LanguageOfPerformance
+            type: array<string>
+        audioChannelConfiguration:
+            expose: true
+            access_type: public_method
+            serialized_name: AudioChannelConfiguration
+            accessor:
+                getter: getAudioChannelConfiguration
+                setter: setAudioChannelConfiguration
+            type: string
+        technicalDetails:
+            expose: true
+            access_type: public_method
+            serialized_name: TechnicalDetails
+            accessor:
+                getter: getTechnicalDetails
+                setter: setTechnicalDetails
+            xml_list:
+                inline: true
+                entry_name: TechnicalDetails
+            type: array<DedexBundle\Entity\Ern42\TechnicalSoundRecordingDetailsType>
+        raga:
+            expose: true
+            access_type: public_method
+            serialized_name: Raga
+            accessor:
+                getter: getRaga
+                setter: setRaga
+            xml_list:
+                inline: true
+                entry_name: Raga
+            type: array<DedexBundle\Entity\Ern42\RagaType>
+        tala:
+            expose: true
+            access_type: public_method
+            serialized_name: Tala
+            accessor:
+                getter: getTala
+                setter: setTala
+            xml_list:
+                inline: true
+                entry_name: Tala
+            type: array<DedexBundle\Entity\Ern42\TalaType>
+        deity:
+            expose: true
+            access_type: public_method
+            serialized_name: Deity
+            accessor:
+                getter: getDeity
+                setter: setDeity
+            xml_list:
+                inline: true
+                entry_name: Deity
+            type: array<DedexBundle\Entity\Ern42\DeityType>
+        audioChapterReference:
+            expose: true
+            access_type: public_method
+            serialized_name: AudioChapterReference
+            accessor:
+                getter: getAudioChapterReference
+                setter: setAudioChapterReference
+            xml_list:
+                inline: true
+                entry_name: AudioChapterReference
+            type: array<string>

--- a/src/Entity/Ern42/metadata/SoundRecordingTypeType.yml
+++ b/src/Entity/Ern42/metadata/SoundRecordingTypeType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\SoundRecordingTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/SubGenreCategoryType.yml
+++ b/src/Entity/Ern42/metadata/SubGenreCategoryType.yml
@@ -1,0 +1,13 @@
+DedexBundle\Entity\Ern42\SubGenreCategoryType:
+    properties:
+        value:
+            expose: true
+            access_type: public_method
+            serialized_name: Value
+            accessor:
+                getter: getValue
+                setter: setValue
+            xml_list:
+                inline: true
+                entry_name: Value
+            type: array<DedexBundle\Entity\Ern42\SubGenreCategoryValueType>

--- a/src/Entity/Ern42/metadata/SubGenreCategoryValueType.yml
+++ b/src/Entity/Ern42/metadata/SubGenreCategoryValueType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\SubGenreCategoryValueType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/SupplementalDocumentListType.yml
+++ b/src/Entity/Ern42/metadata/SupplementalDocumentListType.yml
@@ -1,0 +1,13 @@
+DedexBundle\Entity\Ern42\SupplementalDocumentListType:
+    properties:
+        supplementalDocument:
+            expose: true
+            access_type: public_method
+            serialized_name: SupplementalDocument
+            accessor:
+                getter: getSupplementalDocument
+                setter: setSupplementalDocument
+            xml_list:
+                inline: true
+                entry_name: SupplementalDocument
+            type: array<DedexBundle\Entity\Ern42\FileType>

--- a/src/Entity/Ern42/metadata/SynopsisWithTerritoryType.yml
+++ b/src/Entity/Ern42/metadata/SynopsisWithTerritoryType.yml
@@ -1,0 +1,46 @@
+DedexBundle\Entity\Ern42\SynopsisWithTerritoryType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool
+        isShortSynopsis:
+            expose: true
+            access_type: public_method
+            serialized_name: IsShortSynopsis
+            accessor:
+                getter: getIsShortSynopsis
+                setter: setIsShortSynopsis
+            xml_attribute: true
+            type: bool

--- a/src/Entity/Ern42/metadata/TalaType.yml
+++ b/src/Entity/Ern42/metadata/TalaType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\TalaType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool

--- a/src/Entity/Ern42/metadata/TechnicalImageDetailsType.yml
+++ b/src/Entity/Ern42/metadata/TechnicalImageDetailsType.yml
@@ -1,0 +1,136 @@
+DedexBundle\Entity\Ern42\TechnicalImageDetailsType:
+    properties:
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool
+        technicalResourceDetailsReference:
+            expose: true
+            access_type: public_method
+            serialized_name: TechnicalResourceDetailsReference
+            accessor:
+                getter: getTechnicalResourceDetailsReference
+                setter: setTechnicalResourceDetailsReference
+            type: string
+        imageCodecType:
+            expose: true
+            access_type: public_method
+            serialized_name: ImageCodecType
+            accessor:
+                getter: getImageCodecType
+                setter: setImageCodecType
+            type: DedexBundle\Entity\Ern42\ImageCodecTypeType
+        imageHeight:
+            expose: true
+            access_type: public_method
+            serialized_name: ImageHeight
+            accessor:
+                getter: getImageHeight
+                setter: setImageHeight
+            type: DedexBundle\Entity\Ern42\ExtentType
+        imageWidth:
+            expose: true
+            access_type: public_method
+            serialized_name: ImageWidth
+            accessor:
+                getter: getImageWidth
+                setter: setImageWidth
+            type: DedexBundle\Entity\Ern42\ExtentType
+        aspectRatio:
+            expose: true
+            access_type: public_method
+            serialized_name: AspectRatio
+            accessor:
+                getter: getAspectRatio
+                setter: setAspectRatio
+            type: DedexBundle\Entity\Ern42\AspectRatioType
+        colorDepth:
+            expose: true
+            access_type: public_method
+            serialized_name: ColorDepth
+            accessor:
+                getter: getColorDepth
+                setter: setColorDepth
+            type: int
+        imageResolution:
+            expose: true
+            access_type: public_method
+            serialized_name: ImageResolution
+            accessor:
+                getter: getImageResolution
+                setter: setImageResolution
+            type: int
+        bitDepth:
+            expose: true
+            access_type: public_method
+            serialized_name: BitDepth
+            accessor:
+                getter: getBitDepth
+                setter: setBitDepth
+            type: int
+        isPreview:
+            expose: true
+            access_type: public_method
+            serialized_name: IsPreview
+            accessor:
+                getter: getIsPreview
+                setter: setIsPreview
+            type: bool
+        previewDetails:
+            expose: true
+            access_type: public_method
+            serialized_name: PreviewDetails
+            accessor:
+                getter: getPreviewDetails
+                setter: setPreviewDetails
+            type: DedexBundle\Entity\Ern42\PreviewDetailsType
+        file:
+            expose: true
+            access_type: public_method
+            serialized_name: File
+            accessor:
+                getter: getFile
+                setter: setFile
+            type: DedexBundle\Entity\Ern42\FileType
+        isProvidedInDelivery:
+            expose: true
+            access_type: public_method
+            serialized_name: IsProvidedInDelivery
+            accessor:
+                getter: getIsProvidedInDelivery
+                setter: setIsProvidedInDelivery
+            type: bool
+        fingerprint:
+            expose: true
+            access_type: public_method
+            serialized_name: Fingerprint
+            accessor:
+                getter: getFingerprint
+                setter: setFingerprint
+            xml_list:
+                inline: true
+                entry_name: Fingerprint
+            type: array<DedexBundle\Entity\Ern42\FingerprintType>

--- a/src/Entity/Ern42/metadata/TechnicalSheetMusicDetailsType.yml
+++ b/src/Entity/Ern42/metadata/TechnicalSheetMusicDetailsType.yml
@@ -1,0 +1,96 @@
+DedexBundle\Entity\Ern42\TechnicalSheetMusicDetailsType:
+    properties:
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool
+        technicalResourceDetailsReference:
+            expose: true
+            access_type: public_method
+            serialized_name: TechnicalResourceDetailsReference
+            accessor:
+                getter: getTechnicalResourceDetailsReference
+                setter: setTechnicalResourceDetailsReference
+            type: string
+        sheetMusicCodecType:
+            expose: true
+            access_type: public_method
+            serialized_name: SheetMusicCodecType
+            accessor:
+                getter: getSheetMusicCodecType
+                setter: setSheetMusicCodecType
+            type: DedexBundle\Entity\Ern42\SheetMusicCodecTypeType
+        bitDepth:
+            expose: true
+            access_type: public_method
+            serialized_name: BitDepth
+            accessor:
+                getter: getBitDepth
+                setter: setBitDepth
+            type: int
+        isPreview:
+            expose: true
+            access_type: public_method
+            serialized_name: IsPreview
+            accessor:
+                getter: getIsPreview
+                setter: setIsPreview
+            type: bool
+        previewDetails:
+            expose: true
+            access_type: public_method
+            serialized_name: PreviewDetails
+            accessor:
+                getter: getPreviewDetails
+                setter: setPreviewDetails
+            type: DedexBundle\Entity\Ern42\PreviewDetailsType
+        file:
+            expose: true
+            access_type: public_method
+            serialized_name: File
+            accessor:
+                getter: getFile
+                setter: setFile
+            type: DedexBundle\Entity\Ern42\FileType
+        isProvidedInDelivery:
+            expose: true
+            access_type: public_method
+            serialized_name: IsProvidedInDelivery
+            accessor:
+                getter: getIsProvidedInDelivery
+                setter: setIsProvidedInDelivery
+            type: bool
+        fingerprint:
+            expose: true
+            access_type: public_method
+            serialized_name: Fingerprint
+            accessor:
+                getter: getFingerprint
+                setter: setFingerprint
+            xml_list:
+                inline: true
+                entry_name: Fingerprint
+            type: array<DedexBundle\Entity\Ern42\FingerprintType>

--- a/src/Entity/Ern42/metadata/TechnicalSoftwareDetailsType.yml
+++ b/src/Entity/Ern42/metadata/TechnicalSoftwareDetailsType.yml
@@ -1,0 +1,96 @@
+DedexBundle\Entity\Ern42\TechnicalSoftwareDetailsType:
+    properties:
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool
+        technicalResourceDetailsReference:
+            expose: true
+            access_type: public_method
+            serialized_name: TechnicalResourceDetailsReference
+            accessor:
+                getter: getTechnicalResourceDetailsReference
+                setter: setTechnicalResourceDetailsReference
+            type: string
+        operatingSystemType:
+            expose: true
+            access_type: public_method
+            serialized_name: OperatingSystemType
+            accessor:
+                getter: getOperatingSystemType
+                setter: setOperatingSystemType
+            type: DedexBundle\Entity\Ern42\OperatingSystemTypeType
+        bitDepth:
+            expose: true
+            access_type: public_method
+            serialized_name: BitDepth
+            accessor:
+                getter: getBitDepth
+                setter: setBitDepth
+            type: int
+        isPreview:
+            expose: true
+            access_type: public_method
+            serialized_name: IsPreview
+            accessor:
+                getter: getIsPreview
+                setter: setIsPreview
+            type: bool
+        previewDetails:
+            expose: true
+            access_type: public_method
+            serialized_name: PreviewDetails
+            accessor:
+                getter: getPreviewDetails
+                setter: setPreviewDetails
+            type: DedexBundle\Entity\Ern42\PreviewDetailsType
+        file:
+            expose: true
+            access_type: public_method
+            serialized_name: File
+            accessor:
+                getter: getFile
+                setter: setFile
+            type: DedexBundle\Entity\Ern42\FileType
+        isProvidedInDelivery:
+            expose: true
+            access_type: public_method
+            serialized_name: IsProvidedInDelivery
+            accessor:
+                getter: getIsProvidedInDelivery
+                setter: setIsProvidedInDelivery
+            type: bool
+        fingerprint:
+            expose: true
+            access_type: public_method
+            serialized_name: Fingerprint
+            accessor:
+                getter: getFingerprint
+                setter: setFingerprint
+            xml_list:
+                inline: true
+                entry_name: Fingerprint
+            type: array<DedexBundle\Entity\Ern42\FingerprintType>

--- a/src/Entity/Ern42/metadata/TechnicalSoundRecordingDetailsType.yml
+++ b/src/Entity/Ern42/metadata/TechnicalSoundRecordingDetailsType.yml
@@ -1,0 +1,168 @@
+DedexBundle\Entity\Ern42\TechnicalSoundRecordingDetailsType:
+    properties:
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool
+        technicalResourceDetailsReference:
+            expose: true
+            access_type: public_method
+            serialized_name: TechnicalResourceDetailsReference
+            accessor:
+                getter: getTechnicalResourceDetailsReference
+                setter: setTechnicalResourceDetailsReference
+            type: string
+        encodingId:
+            expose: true
+            access_type: public_method
+            serialized_name: EncodingId
+            accessor:
+                getter: getEncodingId
+                setter: setEncodingId
+            type: DedexBundle\Entity\Ern42\SoundRecordingIdType
+        audioCodecType:
+            expose: true
+            access_type: public_method
+            serialized_name: AudioCodecType
+            accessor:
+                getter: getAudioCodecType
+                setter: setAudioCodecType
+            type: DedexBundle\Entity\Ern42\AudioCodecTypeType
+        bitRate:
+            expose: true
+            access_type: public_method
+            serialized_name: BitRate
+            accessor:
+                getter: getBitRate
+                setter: setBitRate
+            type: DedexBundle\Entity\Ern42\BitRateType
+        originalBitRate:
+            expose: true
+            access_type: public_method
+            serialized_name: OriginalBitRate
+            accessor:
+                getter: getOriginalBitRate
+                setter: setOriginalBitRate
+            type: DedexBundle\Entity\Ern42\BitRateType
+        numberOfChannels:
+            expose: true
+            access_type: public_method
+            serialized_name: NumberOfChannels
+            accessor:
+                getter: getNumberOfChannels
+                setter: setNumberOfChannels
+            type: int
+        samplingRate:
+            expose: true
+            access_type: public_method
+            serialized_name: SamplingRate
+            accessor:
+                getter: getSamplingRate
+                setter: setSamplingRate
+            type: DedexBundle\Entity\Ern42\SamplingRateType
+        originalSamplingRate:
+            expose: true
+            access_type: public_method
+            serialized_name: OriginalSamplingRate
+            accessor:
+                getter: getOriginalSamplingRate
+                setter: setOriginalSamplingRate
+            type: DedexBundle\Entity\Ern42\SamplingRateType
+        bitsPerSample:
+            expose: true
+            access_type: public_method
+            serialized_name: BitsPerSample
+            accessor:
+                getter: getBitsPerSample
+                setter: setBitsPerSample
+            type: int
+        duration:
+            expose: true
+            access_type: public_method
+            serialized_name: Duration
+            accessor:
+                getter: getDuration
+                setter: setDuration
+            type: DateInterval
+        bitDepth:
+            expose: true
+            access_type: public_method
+            serialized_name: BitDepth
+            accessor:
+                getter: getBitDepth
+                setter: setBitDepth
+            type: int
+        isPreview:
+            expose: true
+            access_type: public_method
+            serialized_name: IsPreview
+            accessor:
+                getter: getIsPreview
+                setter: setIsPreview
+            type: bool
+        previewDetails:
+            expose: true
+            access_type: public_method
+            serialized_name: PreviewDetails
+            accessor:
+                getter: getPreviewDetails
+                setter: setPreviewDetails
+            type: DedexBundle\Entity\Ern42\SoundRecordingPreviewDetailsType
+        file:
+            expose: true
+            access_type: public_method
+            serialized_name: File
+            accessor:
+                getter: getFile
+                setter: setFile
+            type: DedexBundle\Entity\Ern42\FileType
+        isProvidedInDelivery:
+            expose: true
+            access_type: public_method
+            serialized_name: IsProvidedInDelivery
+            accessor:
+                getter: getIsProvidedInDelivery
+                setter: setIsProvidedInDelivery
+            type: bool
+        fingerprint:
+            expose: true
+            access_type: public_method
+            serialized_name: Fingerprint
+            accessor:
+                getter: getFingerprint
+                setter: setFingerprint
+            xml_list:
+                inline: true
+                entry_name: Fingerprint
+            type: array<DedexBundle\Entity\Ern42\FingerprintType>
+        encodingDescription:
+            expose: true
+            access_type: public_method
+            serialized_name: EncodingDescription
+            accessor:
+                getter: getEncodingDescription
+                setter: setEncodingDescription
+            type: string

--- a/src/Entity/Ern42/metadata/TechnicalTextDetailsType.yml
+++ b/src/Entity/Ern42/metadata/TechnicalTextDetailsType.yml
@@ -1,0 +1,96 @@
+DedexBundle\Entity\Ern42\TechnicalTextDetailsType:
+    properties:
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool
+        technicalResourceDetailsReference:
+            expose: true
+            access_type: public_method
+            serialized_name: TechnicalResourceDetailsReference
+            accessor:
+                getter: getTechnicalResourceDetailsReference
+                setter: setTechnicalResourceDetailsReference
+            type: string
+        textCodecType:
+            expose: true
+            access_type: public_method
+            serialized_name: TextCodecType
+            accessor:
+                getter: getTextCodecType
+                setter: setTextCodecType
+            type: DedexBundle\Entity\Ern42\TextCodecTypeType
+        bitDepth:
+            expose: true
+            access_type: public_method
+            serialized_name: BitDepth
+            accessor:
+                getter: getBitDepth
+                setter: setBitDepth
+            type: int
+        isPreview:
+            expose: true
+            access_type: public_method
+            serialized_name: IsPreview
+            accessor:
+                getter: getIsPreview
+                setter: setIsPreview
+            type: bool
+        previewDetails:
+            expose: true
+            access_type: public_method
+            serialized_name: PreviewDetails
+            accessor:
+                getter: getPreviewDetails
+                setter: setPreviewDetails
+            type: DedexBundle\Entity\Ern42\PreviewDetailsType
+        file:
+            expose: true
+            access_type: public_method
+            serialized_name: File
+            accessor:
+                getter: getFile
+                setter: setFile
+            type: DedexBundle\Entity\Ern42\FileType
+        isProvidedInDelivery:
+            expose: true
+            access_type: public_method
+            serialized_name: IsProvidedInDelivery
+            accessor:
+                getter: getIsProvidedInDelivery
+                setter: setIsProvidedInDelivery
+            type: bool
+        fingerprint:
+            expose: true
+            access_type: public_method
+            serialized_name: Fingerprint
+            accessor:
+                getter: getFingerprint
+                setter: setFingerprint
+            xml_list:
+                inline: true
+                entry_name: Fingerprint
+            type: array<DedexBundle\Entity\Ern42\FingerprintType>

--- a/src/Entity/Ern42/metadata/TechnicalVideoDetailsType.yml
+++ b/src/Entity/Ern42/metadata/TechnicalVideoDetailsType.yml
@@ -1,0 +1,240 @@
+DedexBundle\Entity\Ern42\TechnicalVideoDetailsType:
+    properties:
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool
+        technicalResourceDetailsReference:
+            expose: true
+            access_type: public_method
+            serialized_name: TechnicalResourceDetailsReference
+            accessor:
+                getter: getTechnicalResourceDetailsReference
+                setter: setTechnicalResourceDetailsReference
+            type: string
+        encodingId:
+            expose: true
+            access_type: public_method
+            serialized_name: EncodingId
+            accessor:
+                getter: getEncodingId
+                setter: setEncodingId
+            type: DedexBundle\Entity\Ern42\VideoIdType
+        overallBitRate:
+            expose: true
+            access_type: public_method
+            serialized_name: OverallBitRate
+            accessor:
+                getter: getOverallBitRate
+                setter: setOverallBitRate
+            type: DedexBundle\Entity\Ern42\BitRateType
+        containerFormat:
+            expose: true
+            access_type: public_method
+            serialized_name: ContainerFormat
+            accessor:
+                getter: getContainerFormat
+                setter: setContainerFormat
+            type: DedexBundle\Entity\Ern42\ContainerFormatType
+        videoCodecType:
+            expose: true
+            access_type: public_method
+            serialized_name: VideoCodecType
+            accessor:
+                getter: getVideoCodecType
+                setter: setVideoCodecType
+            type: DedexBundle\Entity\Ern42\VideoCodecTypeType
+        videoBitRate:
+            expose: true
+            access_type: public_method
+            serialized_name: VideoBitRate
+            accessor:
+                getter: getVideoBitRate
+                setter: setVideoBitRate
+            type: DedexBundle\Entity\Ern42\BitRateType
+        frameRate:
+            expose: true
+            access_type: public_method
+            serialized_name: FrameRate
+            accessor:
+                getter: getFrameRate
+                setter: setFrameRate
+            type: DedexBundle\Entity\Ern42\FrameRateType
+        imageHeight:
+            expose: true
+            access_type: public_method
+            serialized_name: ImageHeight
+            accessor:
+                getter: getImageHeight
+                setter: setImageHeight
+            type: DedexBundle\Entity\Ern42\ExtentType
+        imageWidth:
+            expose: true
+            access_type: public_method
+            serialized_name: ImageWidth
+            accessor:
+                getter: getImageWidth
+                setter: setImageWidth
+            type: DedexBundle\Entity\Ern42\ExtentType
+        aspectRatio:
+            expose: true
+            access_type: public_method
+            serialized_name: AspectRatio
+            accessor:
+                getter: getAspectRatio
+                setter: setAspectRatio
+            type: DedexBundle\Entity\Ern42\AspectRatioType
+        coreArea:
+            expose: true
+            access_type: public_method
+            serialized_name: CoreArea
+            accessor:
+                getter: getCoreArea
+                setter: setCoreArea
+            type: DedexBundle\Entity\Ern42\CoreAreaType
+        colorDepth:
+            expose: true
+            access_type: public_method
+            serialized_name: ColorDepth
+            accessor:
+                getter: getColorDepth
+                setter: setColorDepth
+            type: int
+        videoDefinitionType:
+            expose: true
+            access_type: public_method
+            serialized_name: VideoDefinitionType
+            accessor:
+                getter: getVideoDefinitionType
+                setter: setVideoDefinitionType
+            type: DedexBundle\Entity\Ern42\VideoDefinitionTypeType
+        audioCodecType:
+            expose: true
+            access_type: public_method
+            serialized_name: AudioCodecType
+            accessor:
+                getter: getAudioCodecType
+                setter: setAudioCodecType
+            type: DedexBundle\Entity\Ern42\AudioCodecTypeType
+        audioBitRate:
+            expose: true
+            access_type: public_method
+            serialized_name: AudioBitRate
+            accessor:
+                getter: getAudioBitRate
+                setter: setAudioBitRate
+            type: DedexBundle\Entity\Ern42\BitRateType
+        numberOfAudioChannels:
+            expose: true
+            access_type: public_method
+            serialized_name: NumberOfAudioChannels
+            accessor:
+                getter: getNumberOfAudioChannels
+                setter: setNumberOfAudioChannels
+            type: int
+        audioSamplingRate:
+            expose: true
+            access_type: public_method
+            serialized_name: AudioSamplingRate
+            accessor:
+                getter: getAudioSamplingRate
+                setter: setAudioSamplingRate
+            type: DedexBundle\Entity\Ern42\SamplingRateType
+        audioBitsPerSample:
+            expose: true
+            access_type: public_method
+            serialized_name: AudioBitsPerSample
+            accessor:
+                getter: getAudioBitsPerSample
+                setter: setAudioBitsPerSample
+            type: int
+        duration:
+            expose: true
+            access_type: public_method
+            serialized_name: Duration
+            accessor:
+                getter: getDuration
+                setter: setDuration
+            type: DateInterval
+        bitDepth:
+            expose: true
+            access_type: public_method
+            serialized_name: BitDepth
+            accessor:
+                getter: getBitDepth
+                setter: setBitDepth
+            type: int
+        isPreview:
+            expose: true
+            access_type: public_method
+            serialized_name: IsPreview
+            accessor:
+                getter: getIsPreview
+                setter: setIsPreview
+            type: bool
+        previewDetails:
+            expose: true
+            access_type: public_method
+            serialized_name: PreviewDetails
+            accessor:
+                getter: getPreviewDetails
+                setter: setPreviewDetails
+            type: DedexBundle\Entity\Ern42\SoundRecordingPreviewDetailsType
+        file:
+            expose: true
+            access_type: public_method
+            serialized_name: File
+            accessor:
+                getter: getFile
+                setter: setFile
+            type: DedexBundle\Entity\Ern42\FileType
+        isProvidedInDelivery:
+            expose: true
+            access_type: public_method
+            serialized_name: IsProvidedInDelivery
+            accessor:
+                getter: getIsProvidedInDelivery
+                setter: setIsProvidedInDelivery
+            type: bool
+        fingerprint:
+            expose: true
+            access_type: public_method
+            serialized_name: Fingerprint
+            accessor:
+                getter: getFingerprint
+                setter: setFingerprint
+            xml_list:
+                inline: true
+                entry_name: Fingerprint
+            type: array<DedexBundle\Entity\Ern42\FingerprintType>
+        encodingDescription:
+            expose: true
+            access_type: public_method
+            serialized_name: EncodingDescription
+            accessor:
+                getter: getEncodingDescription
+                setter: setEncodingDescription
+            type: string

--- a/src/Entity/Ern42/metadata/TextCodecTypeType.yml
+++ b/src/Entity/Ern42/metadata/TextCodecTypeType.yml
@@ -1,0 +1,37 @@
+DedexBundle\Entity\Ern42\TextCodecTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        version:
+            expose: true
+            access_type: public_method
+            serialized_name: Version
+            accessor:
+                getter: getVersion
+                setter: setVersion
+            xml_attribute: true
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/TextIdType.yml
+++ b/src/Entity/Ern42/metadata/TextIdType.yml
@@ -1,0 +1,46 @@
+DedexBundle\Entity\Ern42\TextIdType:
+    properties:
+        isReplaced:
+            expose: true
+            access_type: public_method
+            serialized_name: IsReplaced
+            accessor:
+                getter: getIsReplaced
+                setter: setIsReplaced
+            xml_attribute: true
+            type: bool
+        iSBN:
+            expose: true
+            access_type: public_method
+            serialized_name: ISBN
+            accessor:
+                getter: getISBN
+                setter: setISBN
+            type: string
+        iSSN:
+            expose: true
+            access_type: public_method
+            serialized_name: ISSN
+            accessor:
+                getter: getISSN
+                setter: setISSN
+            type: string
+        sICI:
+            expose: true
+            access_type: public_method
+            serialized_name: SICI
+            accessor:
+                getter: getSICI
+                setter: setSICI
+            type: string
+        proprietaryId:
+            expose: true
+            access_type: public_method
+            serialized_name: ProprietaryId
+            accessor:
+                getter: getProprietaryId
+                setter: setProprietaryId
+            xml_list:
+                inline: true
+                entry_name: ProprietaryId
+            type: array<DedexBundle\Entity\Ern42\ProprietaryIdType>

--- a/src/Entity/Ern42/metadata/TextType.yml
+++ b/src/Entity/Ern42/metadata/TextType.yml
@@ -1,0 +1,262 @@
+DedexBundle\Entity\Ern42\TextType:
+    properties:
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        isSupplemental:
+            expose: true
+            access_type: public_method
+            serialized_name: IsSupplemental
+            accessor:
+                getter: getIsSupplemental
+                setter: setIsSupplemental
+            xml_attribute: true
+            type: bool
+        resourceReference:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceReference
+            accessor:
+                getter: getResourceReference
+                setter: setResourceReference
+            type: string
+        type:
+            expose: true
+            access_type: public_method
+            serialized_name: Type
+            accessor:
+                getter: getType
+                setter: setType
+            type: DedexBundle\Entity\Ern42\TextTypeType
+        resourceId:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceId
+            accessor:
+                getter: getResourceId
+                setter: setResourceId
+            xml_list:
+                inline: true
+                entry_name: ResourceId
+            type: array<DedexBundle\Entity\Ern42\TextIdType>
+        workId:
+            expose: true
+            access_type: public_method
+            serialized_name: WorkId
+            accessor:
+                getter: getWorkId
+                setter: setWorkId
+            xml_list:
+                inline: true
+                entry_name: WorkId
+            type: array<DedexBundle\Entity\Ern42\MusicalWorkIdType>
+        displayTitleText:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayTitleText
+            accessor:
+                getter: getDisplayTitleText
+                setter: setDisplayTitleText
+            xml_list:
+                inline: true
+                entry_name: DisplayTitleText
+            type: array<DedexBundle\Entity\Ern42\DisplayTitleTextType>
+        displayTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayTitle
+            accessor:
+                getter: getDisplayTitle
+                setter: setDisplayTitle
+            xml_list:
+                inline: true
+                entry_name: DisplayTitle
+            type: array<DedexBundle\Entity\Ern42\DisplayTitleType>
+        additionalTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: AdditionalTitle
+            accessor:
+                getter: getAdditionalTitle
+                setter: setAdditionalTitle
+            xml_list:
+                inline: true
+                entry_name: AdditionalTitle
+            type: array<DedexBundle\Entity\Ern42\AdditionalTitleType>
+        versionType:
+            expose: true
+            access_type: public_method
+            serialized_name: VersionType
+            accessor:
+                getter: getVersionType
+                setter: setVersionType
+            xml_list:
+                inline: true
+                entry_name: VersionType
+            type: array<DedexBundle\Entity\Ern42\VersionTypeType>
+        displayArtistName:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayArtistName
+            accessor:
+                getter: getDisplayArtistName
+                setter: setDisplayArtistName
+            xml_list:
+                inline: true
+                entry_name: DisplayArtistName
+            type: array<DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType>
+        displayArtist:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayArtist
+            accessor:
+                getter: getDisplayArtist
+                setter: setDisplayArtist
+            xml_list:
+                inline: true
+                entry_name: DisplayArtist
+            type: array<DedexBundle\Entity\Ern42\DisplayArtistType>
+        contributor:
+            expose: true
+            access_type: public_method
+            serialized_name: Contributor
+            accessor:
+                getter: getContributor
+                setter: setContributor
+            xml_list:
+                inline: true
+                entry_name: Contributor
+            type: array<DedexBundle\Entity\Ern42\ContributorType>
+        resourceRightsController:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceRightsController
+            accessor:
+                getter: getResourceRightsController
+                setter: setResourceRightsController
+            xml_list:
+                inline: true
+                entry_name: ResourceRightsController
+            type: array<DedexBundle\Entity\Ern42\ResourceRightsControllerType>
+        workRightsController:
+            expose: true
+            access_type: public_method
+            serialized_name: WorkRightsController
+            accessor:
+                getter: getWorkRightsController
+                setter: setWorkRightsController
+            xml_list:
+                inline: true
+                entry_name: WorkRightsController
+            type: array<DedexBundle\Entity\Ern42\WorkRightsControllerType>
+        cLine:
+            expose: true
+            access_type: public_method
+            serialized_name: CLine
+            accessor:
+                getter: getCLine
+                setter: setCLine
+            xml_list:
+                inline: true
+                entry_name: CLine
+            type: array<DedexBundle\Entity\Ern42\CLineWithDefaultType>
+        courtesyLine:
+            expose: true
+            access_type: public_method
+            serialized_name: CourtesyLine
+            accessor:
+                getter: getCourtesyLine
+                setter: setCourtesyLine
+            xml_list:
+                inline: true
+                entry_name: CourtesyLine
+            type: array<DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType>
+        creationDate:
+            expose: true
+            access_type: public_method
+            serialized_name: CreationDate
+            accessor:
+                getter: getCreationDate
+                setter: setCreationDate
+            type: DedexBundle\Entity\Ern42\EventDateWithoutFlagsType
+        firstPublicationDate:
+            expose: true
+            access_type: public_method
+            serialized_name: FirstPublicationDate
+            accessor:
+                getter: getFirstPublicationDate
+                setter: setFirstPublicationDate
+            xml_list:
+                inline: true
+                entry_name: FirstPublicationDate
+            type: array<DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType>
+        parentalWarningType:
+            expose: true
+            access_type: public_method
+            serialized_name: ParentalWarningType
+            accessor:
+                getter: getParentalWarningType
+                setter: setParentalWarningType
+            xml_list:
+                inline: true
+                entry_name: ParentalWarningType
+            type: array<DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType>
+        relatedRelease:
+            expose: true
+            access_type: public_method
+            serialized_name: RelatedRelease
+            accessor:
+                getter: getRelatedRelease
+                setter: setRelatedRelease
+            xml_list:
+                inline: true
+                entry_name: RelatedRelease
+            type: array<DedexBundle\Entity\Ern42\RelatedReleaseType>
+        relatedResource:
+            expose: true
+            access_type: public_method
+            serialized_name: RelatedResource
+            accessor:
+                getter: getRelatedResource
+                setter: setRelatedResource
+            xml_list:
+                inline: true
+                entry_name: RelatedResource
+            type: array<DedexBundle\Entity\Ern42\RelatedResourceType>
+        containsHiddenContent:
+            expose: true
+            access_type: public_method
+            serialized_name: ContainsHiddenContent
+            accessor:
+                getter: getContainsHiddenContent
+                setter: setContainsHiddenContent
+            type: bool
+        resourceContainedResourceReferenceList:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceContainedResourceReferenceList
+            accessor:
+                getter: getResourceContainedResourceReferenceList
+                setter: setResourceContainedResourceReferenceList
+            type: array<DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType>
+            xml_list:
+                inline: false
+                entry_name: ResourceContainedResourceReference
+                skip_when_empty: true
+        technicalDetails:
+            expose: true
+            access_type: public_method
+            serialized_name: TechnicalDetails
+            accessor:
+                getter: getTechnicalDetails
+                setter: setTechnicalDetails
+            xml_list:
+                inline: true
+                entry_name: TechnicalDetails
+            type: array<DedexBundle\Entity\Ern42\TechnicalTextDetailsType>

--- a/src/Entity/Ern42/metadata/TextTypeType.yml
+++ b/src/Entity/Ern42/metadata/TextTypeType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\TextTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/TextWithFormatType.yml
+++ b/src/Entity/Ern42/metadata/TextWithFormatType.yml
@@ -1,0 +1,64 @@
+DedexBundle\Entity\Ern42\TextWithFormatType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool
+        format:
+            expose: true
+            access_type: public_method
+            serialized_name: Format
+            accessor:
+                getter: getFormat
+                setter: setFormat
+            xml_attribute: true
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/TextWithoutTerritoryType.yml
+++ b/src/Entity/Ern42/metadata/TextWithoutTerritoryType.yml
@@ -1,0 +1,64 @@
+DedexBundle\Entity\Ern42\TextWithoutTerritoryType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        applicableTerritoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: ApplicableTerritoryCode
+            accessor:
+                getter: getApplicableTerritoryCode
+                setter: setApplicableTerritoryCode
+            xml_attribute: true
+            type: string
+        isDefault:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDefault
+            accessor:
+                getter: getIsDefault
+                setter: setIsDefault
+            xml_attribute: true
+            type: bool
+        format:
+            expose: true
+            access_type: public_method
+            serialized_name: Format
+            accessor:
+                getter: getFormat
+                setter: setFormat
+            xml_attribute: true
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/TimingType.yml
+++ b/src/Entity/Ern42/metadata/TimingType.yml
@@ -1,0 +1,18 @@
+DedexBundle\Entity\Ern42\TimingType:
+    properties:
+        startPoint:
+            expose: true
+            access_type: public_method
+            serialized_name: StartPoint
+            accessor:
+                getter: getStartPoint
+                setter: setStartPoint
+            type: DateInterval
+        durationUsed:
+            expose: true
+            access_type: public_method
+            serialized_name: DurationUsed
+            accessor:
+                getter: getDurationUsed
+                setter: setDurationUsed
+            type: DateInterval

--- a/src/Entity/Ern42/metadata/TitleDisplayInformationType.yml
+++ b/src/Entity/Ern42/metadata/TitleDisplayInformationType.yml
@@ -1,0 +1,39 @@
+DedexBundle\Entity\Ern42\TitleDisplayInformationType:
+    properties:
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        sequenceNumber:
+            expose: true
+            access_type: public_method
+            serialized_name: SequenceNumber
+            accessor:
+                getter: getSequenceNumber
+                setter: setSequenceNumber
+            xml_attribute: true
+            type: int
+        isDisplayedInTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: IsDisplayedInTitle
+            accessor:
+                getter: getIsDisplayedInTitle
+                setter: setIsDisplayedInTitle
+            type: bool
+        prefix:
+            expose: true
+            access_type: public_method
+            serialized_name: Prefix
+            accessor:
+                getter: getPrefix
+                setter: setPrefix
+            xml_list:
+                inline: true
+                entry_name: Prefix
+            type: array<DedexBundle\Entity\Ern42\PrefixType>

--- a/src/Entity/Ern42/metadata/TitleType.yml
+++ b/src/Entity/Ern42/metadata/TitleType.yml
@@ -1,0 +1,36 @@
+DedexBundle\Entity\Ern42\TitleType:
+    properties:
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        titleType:
+            expose: true
+            access_type: public_method
+            serialized_name: TitleType
+            accessor:
+                getter: getTitleType
+                setter: setTitleType
+            xml_attribute: true
+            type: string
+        titleText:
+            expose: true
+            access_type: public_method
+            serialized_name: TitleText
+            accessor:
+                getter: getTitleText
+                setter: setTitleText
+            type: string
+        subTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: SubTitle
+            accessor:
+                getter: getSubTitle
+                setter: setSubTitle
+            type: string

--- a/src/Entity/Ern42/metadata/TrackReleaseType.yml
+++ b/src/Entity/Ern42/metadata/TrackReleaseType.yml
@@ -1,0 +1,172 @@
+DedexBundle\Entity\Ern42\TrackReleaseType:
+    properties:
+        isMainRelease:
+            expose: true
+            access_type: public_method
+            serialized_name: IsMainRelease
+            accessor:
+                getter: getIsMainRelease
+                setter: setIsMainRelease
+            xml_attribute: true
+            type: bool
+        releaseReference:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseReference
+            accessor:
+                getter: getReleaseReference
+                setter: setReleaseReference
+            type: string
+        releaseId:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseId
+            accessor:
+                getter: getReleaseId
+                setter: setReleaseId
+            type: DedexBundle\Entity\Ern42\ReleaseIdType
+        displayTitleText:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayTitleText
+            accessor:
+                getter: getDisplayTitleText
+                setter: setDisplayTitleText
+            xml_list:
+                inline: true
+                entry_name: DisplayTitleText
+            type: array<DedexBundle\Entity\Ern42\DisplayTitleTextType>
+        displayTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayTitle
+            accessor:
+                getter: getDisplayTitle
+                setter: setDisplayTitle
+            xml_list:
+                inline: true
+                entry_name: DisplayTitle
+            type: array<DedexBundle\Entity\Ern42\DisplayTitleType>
+        additionalTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: AdditionalTitle
+            accessor:
+                getter: getAdditionalTitle
+                setter: setAdditionalTitle
+            xml_list:
+                inline: true
+                entry_name: AdditionalTitle
+            type: array<DedexBundle\Entity\Ern42\AdditionalTitleType>
+        releaseResourceReference:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseResourceReference
+            accessor:
+                getter: getReleaseResourceReference
+                setter: setReleaseResourceReference
+            type: string
+        linkedReleaseResourceReference:
+            expose: true
+            access_type: public_method
+            serialized_name: LinkedReleaseResourceReference
+            accessor:
+                getter: getLinkedReleaseResourceReference
+                setter: setLinkedReleaseResourceReference
+            xml_list:
+                inline: true
+                entry_name: LinkedReleaseResourceReference
+            type: array<DedexBundle\Entity\Ern42\LinkedReleaseResourceReferenceType>
+        releaseLabelReference:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseLabelReference
+            accessor:
+                getter: getReleaseLabelReference
+                setter: setReleaseLabelReference
+            xml_list:
+                inline: true
+                entry_name: ReleaseLabelReference
+            type: array<DedexBundle\Entity\Ern42\ReleaseLabelReferenceWithPartyType>
+        genre:
+            expose: true
+            access_type: public_method
+            serialized_name: Genre
+            accessor:
+                getter: getGenre
+                setter: setGenre
+            xml_list:
+                inline: true
+                entry_name: Genre
+            type: array<DedexBundle\Entity\Ern42\GenreWithTerritoryType>
+        releaseVisibilityReference:
+            expose: true
+            access_type: public_method
+            serialized_name: ReleaseVisibilityReference
+            accessor:
+                getter: getReleaseVisibilityReference
+                setter: setReleaseVisibilityReference
+            type: string
+        relatedRelease:
+            expose: true
+            access_type: public_method
+            serialized_name: RelatedRelease
+            accessor:
+                getter: getRelatedRelease
+                setter: setRelatedRelease
+            xml_list:
+                inline: true
+                entry_name: RelatedRelease
+            type: array<DedexBundle\Entity\Ern42\RelatedReleaseType>
+        relatedResource:
+            expose: true
+            access_type: public_method
+            serialized_name: RelatedResource
+            accessor:
+                getter: getRelatedResource
+                setter: setRelatedResource
+            xml_list:
+                inline: true
+                entry_name: RelatedResource
+            type: array<DedexBundle\Entity\Ern42\RelatedResourceType>
+        targetURL:
+            expose: true
+            access_type: public_method
+            serialized_name: TargetURL
+            accessor:
+                getter: getTargetURL
+                setter: setTargetURL
+            type: string
+        keywords:
+            expose: true
+            access_type: public_method
+            serialized_name: Keywords
+            accessor:
+                getter: getKeywords
+                setter: setKeywords
+            xml_list:
+                inline: true
+                entry_name: Keywords
+            type: array<DedexBundle\Entity\Ern42\KeywordsWithTerritoryType>
+        synopsis:
+            expose: true
+            access_type: public_method
+            serialized_name: Synopsis
+            accessor:
+                getter: getSynopsis
+                setter: setSynopsis
+            xml_list:
+                inline: true
+                entry_name: Synopsis
+            type: array<DedexBundle\Entity\Ern42\SynopsisWithTerritoryType>
+        marketingComment:
+            expose: true
+            access_type: public_method
+            serialized_name: MarketingComment
+            accessor:
+                getter: getMarketingComment
+                setter: setMarketingComment
+            xml_list:
+                inline: true
+                entry_name: MarketingComment
+            type: array<DedexBundle\Entity\Ern42\MarketingCommentType>

--- a/src/Entity/Ern42/metadata/TrackReleaseVisibilityType.yml
+++ b/src/Entity/Ern42/metadata/TrackReleaseVisibilityType.yml
@@ -1,0 +1,26 @@
+DedexBundle\Entity\Ern42\TrackReleaseVisibilityType:
+    properties:
+        visibilityReference:
+            expose: true
+            access_type: public_method
+            serialized_name: VisibilityReference
+            accessor:
+                getter: getVisibilityReference
+                setter: setVisibilityReference
+            type: string
+        trackListingPreviewStartDateTime:
+            expose: true
+            access_type: public_method
+            serialized_name: TrackListingPreviewStartDateTime
+            accessor:
+                getter: getTrackListingPreviewStartDateTime
+                setter: setTrackListingPreviewStartDateTime
+            type: GoetasWebservices\Xsd\XsdToPhp\XMLSchema\DateTime
+        clipPreviewStartDateTime:
+            expose: true
+            access_type: public_method
+            serialized_name: ClipPreviewStartDateTime
+            accessor:
+                getter: getClipPreviewStartDateTime
+                setter: setClipPreviewStartDateTime
+            type: GoetasWebservices\Xsd\XsdToPhp\XMLSchema\DateTime

--- a/src/Entity/Ern42/metadata/UseTypeType.yml
+++ b/src/Entity/Ern42/metadata/UseTypeType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\UseTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/UserInterfaceTypeType.yml
+++ b/src/Entity/Ern42/metadata/UserInterfaceTypeType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\UserInterfaceTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/ValidityPeriodType.yml
+++ b/src/Entity/Ern42/metadata/ValidityPeriodType.yml
@@ -1,0 +1,18 @@
+DedexBundle\Entity\Ern42\ValidityPeriodType:
+    properties:
+        startDate:
+            expose: true
+            access_type: public_method
+            serialized_name: StartDate
+            accessor:
+                getter: getStartDate
+                setter: setStartDate
+            type: DedexBundle\Entity\Ern42\EventDateType
+        endDate:
+            expose: true
+            access_type: public_method
+            serialized_name: EndDate
+            accessor:
+                getter: getEndDate
+                setter: setEndDate
+            type: DedexBundle\Entity\Ern42\EventDateType

--- a/src/Entity/Ern42/metadata/VenueType.yml
+++ b/src/Entity/Ern42/metadata/VenueType.yml
@@ -1,0 +1,42 @@
+DedexBundle\Entity\Ern42\VenueType:
+    properties:
+        venueName:
+            expose: true
+            access_type: public_method
+            serialized_name: VenueName
+            accessor:
+                getter: getVenueName
+                setter: setVenueName
+            type: string
+        venueAddress:
+            expose: true
+            access_type: public_method
+            serialized_name: VenueAddress
+            accessor:
+                getter: getVenueAddress
+                setter: setVenueAddress
+            type: string
+        territoryCode:
+            expose: true
+            access_type: public_method
+            serialized_name: TerritoryCode
+            accessor:
+                getter: getTerritoryCode
+                setter: setTerritoryCode
+            type: DedexBundle\Entity\Ern42\AllTerritoryCodeType
+        locationCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LocationCode
+            accessor:
+                getter: getLocationCode
+                setter: setLocationCode
+            type: string
+        venueRoom:
+            expose: true
+            access_type: public_method
+            serialized_name: VenueRoom
+            accessor:
+                getter: getVenueRoom
+                setter: setVenueRoom
+            type: string

--- a/src/Entity/Ern42/metadata/VersionTypeType.yml
+++ b/src/Entity/Ern42/metadata/VersionTypeType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\VersionTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/VideoCodecTypeType.yml
+++ b/src/Entity/Ern42/metadata/VideoCodecTypeType.yml
@@ -1,0 +1,37 @@
+DedexBundle\Entity\Ern42\VideoCodecTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        version:
+            expose: true
+            access_type: public_method
+            serialized_name: Version
+            accessor:
+                getter: getVersion
+                setter: setVersion
+            xml_attribute: true
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/VideoDefinitionTypeType.yml
+++ b/src/Entity/Ern42/metadata/VideoDefinitionTypeType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\VideoDefinitionTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/VideoIdType.yml
+++ b/src/Entity/Ern42/metadata/VideoIdType.yml
@@ -1,0 +1,65 @@
+DedexBundle\Entity\Ern42\VideoIdType:
+    properties:
+        isReplaced:
+            expose: true
+            access_type: public_method
+            serialized_name: IsReplaced
+            accessor:
+                getter: getIsReplaced
+                setter: setIsReplaced
+            xml_attribute: true
+            type: bool
+        iSRC:
+            expose: true
+            access_type: public_method
+            serialized_name: ISRC
+            accessor:
+                getter: getISRC
+                setter: setISRC
+            type: string
+        iSAN:
+            expose: true
+            access_type: public_method
+            serialized_name: ISAN
+            accessor:
+                getter: getISAN
+                setter: setISAN
+            type: string
+        vISAN:
+            expose: true
+            access_type: public_method
+            serialized_name: VISAN
+            accessor:
+                getter: getVISAN
+                setter: setVISAN
+            type: string
+        catalogNumber:
+            expose: true
+            access_type: public_method
+            serialized_name: CatalogNumber
+            accessor:
+                getter: getCatalogNumber
+                setter: setCatalogNumber
+            type: DedexBundle\Entity\Ern42\CatalogNumberType
+        proprietaryId:
+            expose: true
+            access_type: public_method
+            serialized_name: ProprietaryId
+            accessor:
+                getter: getProprietaryId
+                setter: setProprietaryId
+            xml_list:
+                inline: true
+                entry_name: ProprietaryId
+            type: array<DedexBundle\Entity\Ern42\ProprietaryIdType>
+        eIDR:
+            expose: true
+            access_type: public_method
+            serialized_name: EIDR
+            accessor:
+                getter: getEIDR
+                setter: setEIDR
+            xml_list:
+                inline: true
+                entry_name: EIDR
+            type: array<string>

--- a/src/Entity/Ern42/metadata/VideoType.yml
+++ b/src/Entity/Ern42/metadata/VideoType.yml
@@ -1,0 +1,461 @@
+DedexBundle\Entity\Ern42\VideoType:
+    properties:
+        languageAndScriptCode:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageAndScriptCode
+            accessor:
+                getter: getLanguageAndScriptCode
+                setter: setLanguageAndScriptCode
+            xml_attribute: true
+            type: string
+        isSupplemental:
+            expose: true
+            access_type: public_method
+            serialized_name: IsSupplemental
+            accessor:
+                getter: getIsSupplemental
+                setter: setIsSupplemental
+            xml_attribute: true
+            type: bool
+        resourceReference:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceReference
+            accessor:
+                getter: getResourceReference
+                setter: setResourceReference
+            type: string
+        type:
+            expose: true
+            access_type: public_method
+            serialized_name: Type
+            accessor:
+                getter: getType
+                setter: setType
+            type: DedexBundle\Entity\Ern42\VideoTypeType
+        resourceId:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceId
+            accessor:
+                getter: getResourceId
+                setter: setResourceId
+            xml_list:
+                inline: true
+                entry_name: ResourceId
+            type: array<DedexBundle\Entity\Ern42\VideoIdType>
+        workId:
+            expose: true
+            access_type: public_method
+            serialized_name: WorkId
+            accessor:
+                getter: getWorkId
+                setter: setWorkId
+            xml_list:
+                inline: true
+                entry_name: WorkId
+            type: array<DedexBundle\Entity\Ern42\MusicalWorkIdType>
+        displayTitleText:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayTitleText
+            accessor:
+                getter: getDisplayTitleText
+                setter: setDisplayTitleText
+            xml_list:
+                inline: true
+                entry_name: DisplayTitleText
+            type: array<DedexBundle\Entity\Ern42\DisplayTitleTextType>
+        displayTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayTitle
+            accessor:
+                getter: getDisplayTitle
+                setter: setDisplayTitle
+            xml_list:
+                inline: true
+                entry_name: DisplayTitle
+            type: array<DedexBundle\Entity\Ern42\DisplayTitleType>
+        additionalTitle:
+            expose: true
+            access_type: public_method
+            serialized_name: AdditionalTitle
+            accessor:
+                getter: getAdditionalTitle
+                setter: setAdditionalTitle
+            xml_list:
+                inline: true
+                entry_name: AdditionalTitle
+            type: array<DedexBundle\Entity\Ern42\AdditionalTitleType>
+        versionType:
+            expose: true
+            access_type: public_method
+            serialized_name: VersionType
+            accessor:
+                getter: getVersionType
+                setter: setVersionType
+            xml_list:
+                inline: true
+                entry_name: VersionType
+            type: array<DedexBundle\Entity\Ern42\VersionTypeType>
+        displayArtistName:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayArtistName
+            accessor:
+                getter: getDisplayArtistName
+                setter: setDisplayArtistName
+            xml_list:
+                inline: true
+                entry_name: DisplayArtistName
+            type: array<DedexBundle\Entity\Ern42\DisplayArtistNameWithDefaultType>
+        displayArtist:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayArtist
+            accessor:
+                getter: getDisplayArtist
+                setter: setDisplayArtist
+            xml_list:
+                inline: true
+                entry_name: DisplayArtist
+            type: array<DedexBundle\Entity\Ern42\DisplayArtistType>
+        contributor:
+            expose: true
+            access_type: public_method
+            serialized_name: Contributor
+            accessor:
+                getter: getContributor
+                setter: setContributor
+            xml_list:
+                inline: true
+                entry_name: Contributor
+            type: array<DedexBundle\Entity\Ern42\ContributorType>
+        character:
+            expose: true
+            access_type: public_method
+            serialized_name: Character
+            accessor:
+                getter: getCharacter
+                setter: setCharacter
+            xml_list:
+                inline: true
+                entry_name: Character
+            type: array<DedexBundle\Entity\Ern42\CharacterType>
+        resourceRightsController:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceRightsController
+            accessor:
+                getter: getResourceRightsController
+                setter: setResourceRightsController
+            xml_list:
+                inline: true
+                entry_name: ResourceRightsController
+            type: array<DedexBundle\Entity\Ern42\ResourceRightsControllerType>
+        workRightsController:
+            expose: true
+            access_type: public_method
+            serialized_name: WorkRightsController
+            accessor:
+                getter: getWorkRightsController
+                setter: setWorkRightsController
+            xml_list:
+                inline: true
+                entry_name: WorkRightsController
+            type: array<DedexBundle\Entity\Ern42\WorkRightsControllerType>
+        pLine:
+            expose: true
+            access_type: public_method
+            serialized_name: PLine
+            accessor:
+                getter: getPLine
+                setter: setPLine
+            xml_list:
+                inline: true
+                entry_name: PLine
+            type: array<DedexBundle\Entity\Ern42\PLineWithDefaultType>
+        cLine:
+            expose: true
+            access_type: public_method
+            serialized_name: CLine
+            accessor:
+                getter: getCLine
+                setter: setCLine
+            xml_list:
+                inline: true
+                entry_name: CLine
+            type: array<DedexBundle\Entity\Ern42\CLineWithDefaultType>
+        courtesyLine:
+            expose: true
+            access_type: public_method
+            serialized_name: CourtesyLine
+            accessor:
+                getter: getCourtesyLine
+                setter: setCourtesyLine
+            xml_list:
+                inline: true
+                entry_name: CourtesyLine
+            type: array<DedexBundle\Entity\Ern42\CourtesyLineWithDefaultType>
+        duration:
+            expose: true
+            access_type: public_method
+            serialized_name: Duration
+            accessor:
+                getter: getDuration
+                setter: setDuration
+            type: DateInterval
+        creationDate:
+            expose: true
+            access_type: public_method
+            serialized_name: CreationDate
+            accessor:
+                getter: getCreationDate
+                setter: setCreationDate
+            type: DedexBundle\Entity\Ern42\EventDateWithoutFlagsType
+        masteredDate:
+            expose: true
+            access_type: public_method
+            serialized_name: MasteredDate
+            accessor:
+                getter: getMasteredDate
+                setter: setMasteredDate
+            type: DedexBundle\Entity\Ern42\EventDateWithoutFlagsType
+        remasteredDate:
+            expose: true
+            access_type: public_method
+            serialized_name: RemasteredDate
+            accessor:
+                getter: getRemasteredDate
+                setter: setRemasteredDate
+            xml_list:
+                inline: true
+                entry_name: RemasteredDate
+            type: array<DedexBundle\Entity\Ern42\EventDateWithoutFlagsType>
+        firstPublicationDate:
+            expose: true
+            access_type: public_method
+            serialized_name: FirstPublicationDate
+            accessor:
+                getter: getFirstPublicationDate
+                setter: setFirstPublicationDate
+            xml_list:
+                inline: true
+                entry_name: FirstPublicationDate
+            type: array<DedexBundle\Entity\Ern42\FulfillmentDateWithTerritoryType>
+        parentalWarningType:
+            expose: true
+            access_type: public_method
+            serialized_name: ParentalWarningType
+            accessor:
+                getter: getParentalWarningType
+                setter: setParentalWarningType
+            xml_list:
+                inline: true
+                entry_name: ParentalWarningType
+            type: array<DedexBundle\Entity\Ern42\ParentalWarningTypeWithTerritoryType>
+        avRating:
+            expose: true
+            access_type: public_method
+            serialized_name: AvRating
+            accessor:
+                getter: getAvRating
+                setter: setAvRating
+            xml_list:
+                inline: true
+                entry_name: AvRating
+            type: array<DedexBundle\Entity\Ern42\AvRatingType>
+        relatedRelease:
+            expose: true
+            access_type: public_method
+            serialized_name: RelatedRelease
+            accessor:
+                getter: getRelatedRelease
+                setter: setRelatedRelease
+            xml_list:
+                inline: true
+                entry_name: RelatedRelease
+            type: array<DedexBundle\Entity\Ern42\RelatedReleaseType>
+        relatedResource:
+            expose: true
+            access_type: public_method
+            serialized_name: RelatedResource
+            accessor:
+                getter: getRelatedResource
+                setter: setRelatedResource
+            xml_list:
+                inline: true
+                entry_name: RelatedResource
+            type: array<DedexBundle\Entity\Ern42\RelatedResourceType>
+        compositeMusicalWorkType:
+            expose: true
+            access_type: public_method
+            serialized_name: CompositeMusicalWorkType
+            accessor:
+                getter: getCompositeMusicalWorkType
+                setter: setCompositeMusicalWorkType
+            type: string
+        videoCueSheetReference:
+            expose: true
+            access_type: public_method
+            serialized_name: VideoCueSheetReference
+            accessor:
+                getter: getVideoCueSheetReference
+                setter: setVideoCueSheetReference
+            xml_list:
+                inline: true
+                entry_name: VideoCueSheetReference
+            type: array<string>
+        reasonForCueSheetAbsence:
+            expose: true
+            access_type: public_method
+            serialized_name: ReasonForCueSheetAbsence
+            accessor:
+                getter: getReasonForCueSheetAbsence
+                setter: setReasonForCueSheetAbsence
+            type: DedexBundle\Entity\Ern42\ReasonType
+        isCover:
+            expose: true
+            access_type: public_method
+            serialized_name: IsCover
+            accessor:
+                getter: getIsCover
+                setter: setIsCover
+            type: bool
+        isInstrumental:
+            expose: true
+            access_type: public_method
+            serialized_name: IsInstrumental
+            accessor:
+                getter: getIsInstrumental
+                setter: setIsInstrumental
+            type: bool
+        containsHiddenContent:
+            expose: true
+            access_type: public_method
+            serialized_name: ContainsHiddenContent
+            accessor:
+                getter: getContainsHiddenContent
+                setter: setContainsHiddenContent
+            type: bool
+        isRemastered:
+            expose: true
+            access_type: public_method
+            serialized_name: IsRemastered
+            accessor:
+                getter: getIsRemastered
+                setter: setIsRemastered
+            type: bool
+        displayCredits:
+            expose: true
+            access_type: public_method
+            serialized_name: DisplayCredits
+            accessor:
+                getter: getDisplayCredits
+                setter: setDisplayCredits
+            xml_list:
+                inline: true
+                entry_name: DisplayCredits
+            type: array<DedexBundle\Entity\Ern42\DisplayCreditsType>
+        languageOfPerformance:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageOfPerformance
+            accessor:
+                getter: getLanguageOfPerformance
+                setter: setLanguageOfPerformance
+            xml_list:
+                inline: true
+                entry_name: LanguageOfPerformance
+            type: array<string>
+        languageOfDubbing:
+            expose: true
+            access_type: public_method
+            serialized_name: LanguageOfDubbing
+            accessor:
+                getter: getLanguageOfDubbing
+                setter: setLanguageOfDubbing
+            xml_list:
+                inline: true
+                entry_name: LanguageOfDubbing
+            type: array<string>
+        subTitleLanguage:
+            expose: true
+            access_type: public_method
+            serialized_name: SubTitleLanguage
+            accessor:
+                getter: getSubTitleLanguage
+                setter: setSubTitleLanguage
+            xml_list:
+                inline: true
+                entry_name: SubTitleLanguage
+            type: array<string>
+        resourceContainedResourceReferenceList:
+            expose: true
+            access_type: public_method
+            serialized_name: ResourceContainedResourceReferenceList
+            accessor:
+                getter: getResourceContainedResourceReferenceList
+                setter: setResourceContainedResourceReferenceList
+            type: array<DedexBundle\Entity\Ern42\ResourceContainedResourceReferenceType>
+            xml_list:
+                inline: false
+                entry_name: ResourceContainedResourceReference
+                skip_when_empty: true
+        technicalDetails:
+            expose: true
+            access_type: public_method
+            serialized_name: TechnicalDetails
+            accessor:
+                getter: getTechnicalDetails
+                setter: setTechnicalDetails
+            xml_list:
+                inline: true
+                entry_name: TechnicalDetails
+            type: array<DedexBundle\Entity\Ern42\TechnicalVideoDetailsType>
+        raga:
+            expose: true
+            access_type: public_method
+            serialized_name: Raga
+            accessor:
+                getter: getRaga
+                setter: setRaga
+            xml_list:
+                inline: true
+                entry_name: Raga
+            type: array<string>
+        tala:
+            expose: true
+            access_type: public_method
+            serialized_name: Tala
+            accessor:
+                getter: getTala
+                setter: setTala
+            xml_list:
+                inline: true
+                entry_name: Tala
+            type: array<string>
+        deity:
+            expose: true
+            access_type: public_method
+            serialized_name: Deity
+            accessor:
+                getter: getDeity
+                setter: setDeity
+            xml_list:
+                inline: true
+                entry_name: Deity
+            type: array<string>
+        videoChapterReference:
+            expose: true
+            access_type: public_method
+            serialized_name: VideoChapterReference
+            accessor:
+                getter: getVideoChapterReference
+                setter: setVideoChapterReference
+            xml_list:
+                inline: true
+                entry_name: VideoChapterReference
+            type: array<string>

--- a/src/Entity/Ern42/metadata/VideoTypeType.yml
+++ b/src/Entity/Ern42/metadata/VideoTypeType.yml
@@ -1,0 +1,28 @@
+DedexBundle\Entity\Ern42\VideoTypeType:
+    properties:
+        __value:
+            expose: true
+            xml_value: true
+            access_type: public_method
+            accessor:
+                getter: value
+                setter: value
+            type: string
+        namespace:
+            expose: true
+            access_type: public_method
+            serialized_name: Namespace
+            accessor:
+                getter: getNamespace
+                setter: setNamespace
+            xml_attribute: true
+            type: string
+        userDefinedValue:
+            expose: true
+            access_type: public_method
+            serialized_name: UserDefinedValue
+            accessor:
+                getter: getUserDefinedValue
+                setter: setUserDefinedValue
+            xml_attribute: true
+            type: string

--- a/src/Entity/Ern42/metadata/WorkRightsControllerType.yml
+++ b/src/Entity/Ern42/metadata/WorkRightsControllerType.yml
@@ -1,0 +1,72 @@
+DedexBundle\Entity\Ern42\WorkRightsControllerType:
+    properties:
+        rightsControllerPartyReference:
+            expose: true
+            access_type: public_method
+            serialized_name: RightsControllerPartyReference
+            accessor:
+                getter: getRightsControllerPartyReference
+                setter: setRightsControllerPartyReference
+            type: string
+        rightsControlType:
+            expose: true
+            access_type: public_method
+            serialized_name: RightsControlType
+            accessor:
+                getter: getRightsControlType
+                setter: setRightsControlType
+            xml_list:
+                inline: true
+                entry_name: RightsControlType
+            type: array<string>
+        rightsControllerType:
+            expose: true
+            access_type: public_method
+            serialized_name: RightsControllerType
+            accessor:
+                getter: getRightsControllerType
+                setter: setRightsControllerType
+            type: string
+        rightShareUnknown:
+            expose: true
+            access_type: public_method
+            serialized_name: RightShareUnknown
+            accessor:
+                getter: getRightShareUnknown
+                setter: setRightShareUnknown
+            type: bool
+        rightSharePercentage:
+            expose: true
+            access_type: public_method
+            serialized_name: RightSharePercentage
+            accessor:
+                getter: getRightSharePercentage
+                setter: setRightSharePercentage
+            type: float
+        territory:
+            expose: true
+            access_type: public_method
+            serialized_name: Territory
+            accessor:
+                getter: getTerritory
+                setter: setTerritory
+            xml_list:
+                inline: true
+                entry_name: Territory
+            type: array<DedexBundle\Entity\Ern42\AllTerritoryCodeType>
+        startDate:
+            expose: true
+            access_type: public_method
+            serialized_name: StartDate
+            accessor:
+                getter: getStartDate
+                setter: setStartDate
+            type: string
+        endDate:
+            expose: true
+            access_type: public_method
+            serialized_name: EndDate
+            accessor:
+                getter: getEndDate
+                setter: setEndDate
+            type: string

--- a/src/Simplifiers/SimpleDeal.php
+++ b/src/Simplifiers/SimpleDeal.php
@@ -83,23 +83,33 @@ class SimpleDeal extends SimpleEntity {
 		/* @var $deal DealType */
 		$deal = $ddexDeal->getDeal()[0];
 		$this->ddexDeal = $deal;
-		
+
 		// Get all commercial model types
 		foreach ($deal->getDealTerms()->getCommercialModelType() as $cmt) {
 			$this->commercialModelTypes[] = $this->getUserDefinedValue($cmt);
 		}
 
-		foreach ($deal->getDealTerms()->getUsage() as $usage) {
-			// Get all use types
-			foreach ($usage->getUseType() as $usetype) {
-				$this->useTypes[] = $this->getUserDefinedValue($usetype);	
+		try {
+			// ERN 3.x: UseType and DistributionChannelType are nested under Usage
+			foreach ($deal->getDealTerms()->getUsage() as $usage) {
+				foreach ($usage->getUseType() as $usetype) {
+					$this->useTypes[] = $this->getUserDefinedValue($usetype);
+				}
+				foreach ($usage->getDistributionChannelType() as $distribchanneltype) {
+					$this->distributionChannelTypes[] = $this->getUserDefinedValue($distribchanneltype);
+				}
 			}
-			// Get all distribution channel type
-			foreach ($usage->getDistributionChannelType() as $distribchanneltype) {
-				$this->distributionChannelTypes[] = $this->getUserDefinedValue($distribchanneltype);	
+		} catch (Throwable $ex) {
+			// ERN 4.x: UseType is directly on DealTerms, no Usage wrapper
+			try {
+				foreach ($deal->getDealTerms()->getUseType() as $usetype) {
+					$this->useTypes[] = $this->getUserDefinedValue($usetype);
+				}
+			} catch (Throwable $ex2) {
+				// no use types
 			}
 		}
-		
+
 		// Territory codes
 		foreach ($deal->getDealTerms()->getTerritoryCode() as $territory) {
 			$this->territories[] = $territory;

--- a/src/Simplifiers/SimpleImage.php
+++ b/src/Simplifiers/SimpleImage.php
@@ -51,11 +51,17 @@ class SimpleImage extends SimpleEntity {
 	
 	/**
 	 * @param ImageType $image
+	 * @param string $version version string as detected by ErnParserController
 	 */
-	public function __construct($image) {
+	public function __construct($image, string $version = "382") {
 		$this->ddexImage = $image;
-		
-		$this->details = $this->getDetailsByTerritory($image, "image", "worldwide");
+
+		if ($this->isVersion4x($version)) {
+			// ERN 4.x: no DetailsByTerritory, the Image itself holds the details
+			$this->details = $image;
+		} else {
+			$this->details = $this->getDetailsByTerritory($image, "image", "worldwide");
+		}
 	}
 	
 	/**
@@ -74,9 +80,11 @@ class SimpleImage extends SimpleEntity {
 	 */
 	public function getFileName() {
 		try {
+            // ERN 3.x: FilePath and FileName are in the File element, which is in the TechnicalImageDetails element
 			return $this->details->getTechnicalImageDetails()[0]->getFile()[0]->getFileName();
 		} catch (Throwable $ex) {
-			return "";
+            // ERN 4.x: FilePath and FileName are in the TechnicalDetails/File
+            return $this->details->getTechnicalDetails()[0]->getFile()->getURI();
 		}
 	}
 	

--- a/tests/Controller/ParserControllerTest.php
+++ b/tests/Controller/ParserControllerTest.php
@@ -219,20 +219,36 @@ class ParserControllerTest extends TestCase {
     $this->assertEquals("Šumadijsko lagano kolo", $resource_three->getReferenceTitle()->getTitleText());
   }
 
-  /**
-   * Test ERN 411 is parsed correctly
-   */
-  public function testSample015Ern411() {
-    $xml_path = "tests/samples/015_ern411.xml";
-    $parser_controller = new ErnParserController();
-    // Set this to true to see logs from the parser
-    $parser_controller->setDisplayLog(false);
-    /* @var $ddex NewReleaseMessage */
-    $ddex = $parser_controller->parse($xml_path);
+    /**
+     * Test ERN 411 is parsed correctly
+     */
+    public function testSample015Ern411() {
+        $xml_path = "tests/samples/015_ern411.xml";
+        $parser_controller = new ErnParserController();
+        // Set this to true to see logs from the parser
+        $parser_controller->setDisplayLog(false);
+        /* @var $ddex NewReleaseMessage */
+        $ddex = $parser_controller->parse($xml_path);
 
-    // ERN version is now 411. It is using classes with namespace 411.
-    // ERN 411 does not have a getMessageSchemaVersionId() function
-    $this->assertEquals('DedexBundle\Entity\Ern411\NewReleaseMessage', get_class($ddex));
-  }
+        // ERN version is now 411. It is using classes with namespace 411.
+        // ERN 411 does not have a getMessageSchemaVersionId() function
+        $this->assertEquals('DedexBundle\Entity\Ern411\NewReleaseMessage', get_class($ddex));
+    }
+
+    /**
+     * Test ERN 42 is parsed correctly
+     */
+    public function testSample015Ern42() {
+        $xml_path = "tests/samples/018_ern42.xml";
+        $parser_controller = new ErnParserController();
+        // Set this to true to see logs from the parser
+        $parser_controller->setDisplayLog(false);
+        /* @var $ddex NewReleaseMessage */
+        $ddex = $parser_controller->parse($xml_path);
+
+        // ERN version is now 411. It is using classes with namespace 411.
+        // ERN 411 does not have a getMessageSchemaVersionId() function
+        $this->assertEquals('DedexBundle\Entity\Ern42\NewReleaseMessage', get_class($ddex));
+    }
 
 }

--- a/tests/Controller/ParserControllerTest.php
+++ b/tests/Controller/ParserControllerTest.php
@@ -246,8 +246,8 @@ class ParserControllerTest extends TestCase {
         /* @var $ddex NewReleaseMessage */
         $ddex = $parser_controller->parse($xml_path);
 
-        // ERN version is now 411. It is using classes with namespace 411.
-        // ERN 411 does not have a getMessageSchemaVersionId() function
+        // ERN version is now 42. It is using classes with namespace 42.
+        // ERN 42 does not have a getMessageSchemaVersionId() function
         $this->assertEquals('DedexBundle\Entity\Ern42\NewReleaseMessage', get_class($ddex));
     }
 

--- a/tests/samples/018_ern42.xml
+++ b/tests/samples/018_ern42.xml
@@ -1,0 +1,1387 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ern:NewReleaseMessage xmlns:avs="http://ddex.net/xml/avs/avs"
+   xmlns:ern="http://ddex.net/xml/ern/42"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://ddex.net/xml/ern/42 http://ddex.net/xml/ern/42/release-notification.xsd"
+   ReleaseProfileVersionId="Audio" LanguageAndScriptCode="en">
+   <MessageHeader>
+      <MessageThreadId>Test1</MessageThreadId>
+      <MessageId>Test1.1</MessageId>
+      <MessageSender>
+         <PartyId>PADPIDA2013042401U</PartyId>
+         <PartyName>
+            <FullName>UniversalMusicGroup</FullName>
+         </PartyName>
+      </MessageSender>
+      <MessageRecipient>
+         <PartyId>PADPIDA2009101501Y</PartyId>
+         <PartyName>
+            <FullName>Sony DADC</FullName>
+         </PartyName>
+      </MessageRecipient>
+      <MessageCreatedDateTime>2014-09-24T14:57:25+01:00</MessageCreatedDateTime>
+   </MessageHeader>
+   <PartyList>
+      <Party>
+         <PartyReference>PSaekoShu</PartyReference>
+         <PartyName>
+            <FullName>Saeko Shu</FullName>
+            <FullNameIndexed>Shu, Saeko</FullNameIndexed>
+         </PartyName>
+         <PartyName LanguageAndScriptCode="ja-Jpan">
+            <FullName>しゅうさえこ</FullName>
+         </PartyName>
+      </Party>
+      <Party>
+         <PartyReference>PEMI</PartyReference>
+         <PartyName>
+            <FullName>EMI MUSIC JAPAN INC.</FullName>
+         </PartyName>
+      </Party>
+   </PartyList>
+   <ResourceList>
+      <SoundRecording>
+         <ResourceReference>A1</ResourceReference>
+         <Type>MusicalWorkSoundRecording</Type>
+         <ResourceId>
+            <ISRC>JPTO09404900</ISRC>
+         </ResourceId>
+         <DisplayTitleText>Yume no Lullaby</DisplayTitleText>
+         <DisplayTitle ApplicableTerritoryCode="Worldwide" IsDefault="true">
+            <TitleText>Yume no Lullaby</TitleText>
+         </DisplayTitle>
+         <DisplayTitle LanguageAndScriptCode="ja-Jpan" ApplicableTerritoryCode="Worldwide">
+            <TitleText>夢のララバイ</TitleText>
+         </DisplayTitle>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Latn" IsDefault="true">Saeko Shu</DisplayArtistName>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Jpan">しゅうさえこ</DisplayArtistName>
+         <DisplayArtist SequenceNumber="1">
+            <ArtistPartyReference>PSaekoShu</ArtistPartyReference>
+            <DisplayArtistRole>MainArtist</DisplayArtistRole>
+         </DisplayArtist>
+         <Contributor SequenceNumber="1">
+            <ContributorPartyReference>PSaekoShu</ContributorPartyReference>
+            <Role>Artist</Role>
+         </Contributor>
+         <PLine>
+            <Year>1994</Year>
+            <PLineText>(P) 1994 EMI Music Japan Inc.</PLineText>
+         </PLine>
+         <Duration>PT2M28S</Duration>
+         <CreationDate IsApproximate="true">1993-12-01</CreationDate>
+         <ParentalWarningType>NoAdviceAvailable</ParentalWarningType>
+         <IsInstrumental>false</IsInstrumental>
+         <LanguageOfPerformance>ja</LanguageOfPerformance>
+         <TechnicalDetails>
+            <TechnicalResourceDetailsReference>T1</TechnicalResourceDetailsReference>
+            <PreviewDetails>
+               <StartPoint>45</StartPoint>
+               <ExpressionType>Instructive</ExpressionType>
+            </PreviewDetails>
+            <File>
+               <URI>0094631432057_01_001.wav</URI>
+            </File>
+         </TechnicalDetails>
+      </SoundRecording>
+      <SoundRecording>
+         <ResourceReference>A2</ResourceReference>
+         <Type>MusicalWorkSoundRecording</Type>
+         <ResourceId>
+            <ISRC>JPTO09404910</ISRC>
+         </ResourceId>
+         <DisplayTitleText>Yume no Hajimari - Kaze no Okuri Mono (Introduction)</DisplayTitleText>
+         <DisplayTitle ApplicableTerritoryCode="Worldwide" IsDefault="true">
+            <TitleText>Yume no Hajimari - Kaze no Okuri Mono (Introduction)</TitleText>
+         </DisplayTitle>
+         <DisplayTitle LanguageAndScriptCode="ja-Jpan" ApplicableTerritoryCode="Worldwide">
+            <TitleText>夢のはじまり－風のおくりもの（イントロダクション）</TitleText>
+         </DisplayTitle>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Latn" IsDefault="true">Saeko Shu</DisplayArtistName>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Jpan">しゅうさえこ</DisplayArtistName>
+         <DisplayArtist SequenceNumber="1">
+            <ArtistPartyReference>PSaekoShu</ArtistPartyReference>
+            <DisplayArtistRole>MainArtist</DisplayArtistRole>
+         </DisplayArtist>
+         <PLine>
+            <Year>1994</Year>
+            <PLineText>(P) 1994 EMI Music Japan Inc.</PLineText>
+         </PLine>
+         <Duration>PT1M42S</Duration>
+         <CreationDate IsApproximate="true">1993-12-01</CreationDate>
+         <ParentalWarningType>NoAdviceAvailable</ParentalWarningType>
+         <IsInstrumental>false</IsInstrumental>
+         <LanguageOfPerformance>ja</LanguageOfPerformance>
+         <TechnicalDetails>
+            <TechnicalResourceDetailsReference>T2</TechnicalResourceDetailsReference>
+            <PreviewDetails>
+               <StartPoint>45</StartPoint>
+               <ExpressionType>Instructive</ExpressionType>
+            </PreviewDetails>
+            <File>
+               <URI>0094631432057_01_002.wav</URI>
+            </File>
+         </TechnicalDetails>
+      </SoundRecording>
+      <SoundRecording>
+         <ResourceReference>A3</ResourceReference>
+         <Type>MusicalWorkSoundRecording</Type>
+         <ResourceId>
+            <ISRC>JPTO09404920</ISRC>
+         </ResourceId>
+         <DisplayTitleText>-Haru- Soushunfu</DisplayTitleText>
+         <DisplayTitle ApplicableTerritoryCode="Worldwide" IsDefault="true">
+            <TitleText>-Haru- Soushunfu</TitleText>
+         </DisplayTitle>
+         <DisplayTitle LanguageAndScriptCode="ja-Jpan" ApplicableTerritoryCode="Worldwide">
+            <TitleText>-春-　早春賦</TitleText>
+         </DisplayTitle>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Latn" IsDefault="true">Saeko Shu</DisplayArtistName>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Jpan">しゅうさえこ</DisplayArtistName>
+         <DisplayArtist SequenceNumber="1">
+            <ArtistPartyReference>PSaekoShu</ArtistPartyReference>
+            <DisplayArtistRole>MainArtist</DisplayArtistRole>
+         </DisplayArtist>
+         <Contributor SequenceNumber="1">
+            <ContributorPartyReference>PSaekoShu</ContributorPartyReference>
+            <Role>Artist</Role>
+         </Contributor>
+         <PLine>
+            <Year>1994</Year>
+            <PLineText>(P) 1994 EMI Music Japan Inc.</PLineText>
+         </PLine>
+         <Duration>PT1M12S</Duration>
+         <CreationDate IsApproximate="true">1993-12-01</CreationDate>
+         <ParentalWarningType>NoAdviceAvailable</ParentalWarningType>
+         <IsInstrumental>false</IsInstrumental>
+         <LanguageOfPerformance>ja</LanguageOfPerformance>
+         <TechnicalDetails>
+            <TechnicalResourceDetailsReference>T3</TechnicalResourceDetailsReference>
+            <PreviewDetails>
+               <StartPoint>0</StartPoint>
+               <ExpressionType>Instructive</ExpressionType>
+            </PreviewDetails>
+            <File>
+               <URI>0094631432057_01_003.wav</URI>
+            </File>
+         </TechnicalDetails>
+      </SoundRecording>
+      <SoundRecording>
+         <ResourceReference>A4</ResourceReference>
+         <Type>MusicalWorkSoundRecording</Type>
+         <ResourceId>
+            <ISRC>JPTO09404930</ISRC>
+         </ResourceId>
+         <DisplayTitleText>Dokoka de Haru ga</DisplayTitleText>
+         <DisplayTitle ApplicableTerritoryCode="Worldwide" IsDefault="true">
+            <TitleText>Dokoka de Haru ga</TitleText>
+         </DisplayTitle>
+         <DisplayTitle LanguageAndScriptCode="ja-Jpan" ApplicableTerritoryCode="Worldwide">
+            <TitleText>～どこかで春が</TitleText>
+         </DisplayTitle>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Latn" IsDefault="true">Saeko Shu</DisplayArtistName>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Jpan">しゅうさえこ</DisplayArtistName>
+         <DisplayArtist SequenceNumber="1">
+            <ArtistPartyReference>PSaekoShu</ArtistPartyReference>
+            <DisplayArtistRole>MainArtist</DisplayArtistRole>
+         </DisplayArtist>
+         <Contributor SequenceNumber="1">
+            <ContributorPartyReference>PSaekoShu</ContributorPartyReference>
+            <Role>Artist</Role>
+         </Contributor>
+         <PLine>
+            <Year>1994</Year>
+            <PLineText>(P) 1994 EMI Music Japan Inc.</PLineText>
+         </PLine>
+         <Duration>PT1M22S</Duration>
+         <CreationDate IsApproximate="true">1993-12-01</CreationDate>
+         <ParentalWarningType>NoAdviceAvailable</ParentalWarningType>
+         <IsInstrumental>false</IsInstrumental>
+         <LanguageOfPerformance>ja</LanguageOfPerformance>
+         <TechnicalDetails>
+            <TechnicalResourceDetailsReference>T4</TechnicalResourceDetailsReference>
+            <PreviewDetails>
+               <StartPoint>45</StartPoint>
+               <ExpressionType>Instructive</ExpressionType>
+            </PreviewDetails>
+            <File>
+               <URI>0094631432057_01_004.wav</URI>
+            </File>
+         </TechnicalDetails>
+      </SoundRecording>
+      <SoundRecording>
+         <ResourceReference>A5</ResourceReference>
+         <Type>MusicalWorkSoundRecording</Type>
+         <ResourceId>
+            <ISRC>JPTO09404940</ISRC>
+         </ResourceId>
+         <DisplayTitleText>Haru ga Kita</DisplayTitleText>
+         <DisplayTitle ApplicableTerritoryCode="Worldwide" IsDefault="true">
+            <TitleText>Haru ga Kita</TitleText>
+         </DisplayTitle>
+         <DisplayTitle LanguageAndScriptCode="ja-Jpan" ApplicableTerritoryCode="Worldwide">
+            <TitleText>～春が来た</TitleText>
+         </DisplayTitle>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Latn" IsDefault="true">Saeko Shu</DisplayArtistName>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Jpan">しゅうさえこ</DisplayArtistName>
+         <DisplayArtist SequenceNumber="1">
+            <ArtistPartyReference>PSaekoShu</ArtistPartyReference>
+            <DisplayArtistRole>MainArtist</DisplayArtistRole>
+         </DisplayArtist>
+         <Contributor SequenceNumber="1">
+            <ContributorPartyReference>PSaekoShu</ContributorPartyReference>
+            <Role>Artist</Role>
+         </Contributor>
+         <PLine>
+            <Year>1994</Year>
+            <PLineText>(P) 1994 EMI Music Japan Inc.</PLineText>
+         </PLine>
+         <Duration>PT1M32S</Duration>
+         <CreationDate IsApproximate="true">1993-12-01</CreationDate>
+         <ParentalWarningType>NoAdviceAvailable</ParentalWarningType>
+         <IsInstrumental>false</IsInstrumental>
+         <LanguageOfPerformance>ja</LanguageOfPerformance>
+         <TechnicalDetails>
+            <TechnicalResourceDetailsReference>T5</TechnicalResourceDetailsReference>
+            <PreviewDetails>
+               <StartPoint>45</StartPoint>
+               <ExpressionType>Instructive</ExpressionType>
+            </PreviewDetails>
+            <File>
+               <URI>0094631432057_01_005.wav</URI>
+            </File>
+         </TechnicalDetails>
+      </SoundRecording>
+      <SoundRecording>
+         <ResourceReference>A6</ResourceReference>
+         <Type>MusicalWorkSoundRecording</Type>
+         <ResourceId>
+            <ISRC>JPTO09404950</ISRC>
+         </ResourceId>
+         <DisplayTitleText>Haru no Ogawa (Monbushou Shouka)</DisplayTitleText>
+         <DisplayTitle ApplicableTerritoryCode="Worldwide" IsDefault="true">
+            <TitleText>Haru no Ogawa (Monbushou Shouka)</TitleText>
+         </DisplayTitle>
+         <DisplayTitle LanguageAndScriptCode="ja-Jpan" ApplicableTerritoryCode="Worldwide">
+            <TitleText>～春の小川（文部省唱歌）</TitleText>
+         </DisplayTitle>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Latn" IsDefault="true">Saeko Shu</DisplayArtistName>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Jpan">しゅうさえこ</DisplayArtistName>
+         <DisplayArtist SequenceNumber="1">
+            <ArtistPartyReference>PSaekoShu</ArtistPartyReference>
+            <DisplayArtistRole>MainArtist</DisplayArtistRole>
+         </DisplayArtist>
+         <Contributor SequenceNumber="1">
+            <ContributorPartyReference>PSaekoShu</ContributorPartyReference>
+            <Role>Artist</Role>
+         </Contributor>
+         <PLine>
+            <Year>1994</Year>
+            <PLineText>(P) 1994 EMI Music Japan Inc.</PLineText>
+         </PLine>
+         <Duration>PT1M14S</Duration>
+         <CreationDate IsApproximate="true">1993-12-01</CreationDate>
+         <ParentalWarningType>NoAdviceAvailable</ParentalWarningType>
+         <IsInstrumental>false</IsInstrumental>
+         <LanguageOfPerformance>ja</LanguageOfPerformance>
+         <TechnicalDetails>
+            <TechnicalResourceDetailsReference>T6</TechnicalResourceDetailsReference>
+            <PreviewDetails>
+               <StartPoint>0</StartPoint>
+               <ExpressionType>Instructive</ExpressionType>
+            </PreviewDetails>
+            <File>
+               <URI>0094631432057_01_006.wav</URI>
+            </File>
+         </TechnicalDetails>
+      </SoundRecording>
+      <SoundRecording>
+         <ResourceReference>A7</ResourceReference>
+         <Type>MusicalWorkSoundRecording</Type>
+         <ResourceId>
+            <ISRC>JPTO09404960</ISRC>
+         </ResourceId>
+         <DisplayTitleText>-Natsu- Umi (Monbushou Shouka)</DisplayTitleText>
+         <DisplayTitle ApplicableTerritoryCode="Worldwide" IsDefault="true">
+            <TitleText>-Natsu- Umi (Monbushou Shouka)</TitleText>
+         </DisplayTitle>
+         <DisplayTitle LanguageAndScriptCode="ja-Jpan" ApplicableTerritoryCode="Worldwide">
+            <TitleText>-夏-　海（文部省唱歌）</TitleText>
+         </DisplayTitle>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Latn" IsDefault="true">Saeko Shu</DisplayArtistName>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Jpan">しゅうさえこ</DisplayArtistName>
+         <DisplayArtist SequenceNumber="1">
+            <ArtistPartyReference>PSaekoShu</ArtistPartyReference>
+            <DisplayArtistRole>MainArtist</DisplayArtistRole>
+         </DisplayArtist>
+         <Contributor SequenceNumber="1">
+            <ContributorPartyReference>PSaekoShu</ContributorPartyReference>
+            <Role>Artist</Role>
+         </Contributor>
+         <PLine>
+            <Year>1994</Year>
+            <PLineText>(P) 1994 EMI Music Japan Inc.</PLineText>
+         </PLine>
+         <Duration>PT1M9S</Duration>
+         <CreationDate IsApproximate="true">1993-12-01</CreationDate>
+         <ParentalWarningType>NoAdviceAvailable</ParentalWarningType>
+         <IsInstrumental>false</IsInstrumental>
+         <LanguageOfPerformance>ja</LanguageOfPerformance>
+         <TechnicalDetails>
+            <TechnicalResourceDetailsReference>T7</TechnicalResourceDetailsReference>
+            <PreviewDetails>
+               <StartPoint>0</StartPoint>
+               <ExpressionType>Instructive</ExpressionType>
+            </PreviewDetails>
+            <File>
+               <URI>0094631432057_01_007.wav</URI>
+            </File>
+         </TechnicalDetails>
+      </SoundRecording>
+      <SoundRecording>
+         <ResourceReference>A8</ResourceReference>
+         <Type>MusicalWorkSoundRecording</Type>
+         <ResourceId>
+            <ISRC>JPTO09404970</ISRC>
+         </ResourceId>
+         <DisplayTitleText>Ware wa Umi no Ko</DisplayTitleText>
+         <DisplayTitle ApplicableTerritoryCode="Worldwide" IsDefault="true">
+            <TitleText>Ware wa Umi no Ko</TitleText>
+         </DisplayTitle>
+         <DisplayTitle LanguageAndScriptCode="ja-Jpan" ApplicableTerritoryCode="Worldwide">
+            <TitleText>～我は海の子</TitleText>
+         </DisplayTitle>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Latn" IsDefault="true">Saeko Shu</DisplayArtistName>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Jpan">しゅうさえこ</DisplayArtistName>
+         <DisplayArtist SequenceNumber="1">
+            <ArtistPartyReference>PSaekoShu</ArtistPartyReference>
+            <DisplayArtistRole>MainArtist</DisplayArtistRole>
+         </DisplayArtist>
+         <Contributor SequenceNumber="1">
+            <ContributorPartyReference>PSaekoShu</ContributorPartyReference>
+            <Role>Artist</Role>
+         </Contributor>
+         <PLine>
+            <Year>1994</Year>
+            <PLineText>(P) 1994 EMI Music Japan Inc.</PLineText>
+         </PLine>
+         <Duration>PT1M12S</Duration>
+         <CreationDate IsApproximate="true">1993-12-01</CreationDate>
+         <ParentalWarningType>NoAdviceAvailable</ParentalWarningType>
+         <IsInstrumental>false</IsInstrumental>
+         <LanguageOfPerformance>ja</LanguageOfPerformance>
+         <TechnicalDetails>
+            <TechnicalResourceDetailsReference>T8</TechnicalResourceDetailsReference>
+            <PreviewDetails>
+               <StartPoint>0</StartPoint>
+               <ExpressionType>Instructive</ExpressionType>
+            </PreviewDetails>
+            <File>
+               <URI>0094631432057_01_008.wav</URI>
+            </File>
+         </TechnicalDetails>
+      </SoundRecording>
+      <SoundRecording>
+         <ResourceReference>A9</ResourceReference>
+         <Type>MusicalWorkSoundRecording</Type>
+         <ResourceId>
+            <ISRC>JPTO09404980</ISRC>
+         </ResourceId>
+         <DisplayTitleText>Natsu no Omoide (Instrumental)</DisplayTitleText>
+         <DisplayTitle ApplicableTerritoryCode="Worldwide" IsDefault="true">
+            <TitleText>Natsu no Omoide</TitleText>
+            <SubTitle>Instrumental</SubTitle>
+         </DisplayTitle>
+         <DisplayTitle LanguageAndScriptCode="ja-Jpan" ApplicableTerritoryCode="Worldwide">
+            <TitleText>～夏の思い出 (インストゥルメンタル)</TitleText>
+         </DisplayTitle>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Latn" IsDefault="true">Saeko Shu</DisplayArtistName>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Jpan">しゅうさえこ</DisplayArtistName>
+         <DisplayArtist SequenceNumber="1">
+            <ArtistPartyReference>PSaekoShu</ArtistPartyReference>
+            <DisplayArtistRole>MainArtist</DisplayArtistRole>
+         </DisplayArtist>
+         <Contributor SequenceNumber="1">
+            <ContributorPartyReference>PSaekoShu</ContributorPartyReference>
+            <Role>Artist</Role>
+         </Contributor>
+         <PLine>
+            <Year>1994</Year>
+            <PLineText>(P) 1994 EMI Music Japan Inc.</PLineText>
+         </PLine>
+         <Duration>PT1M14S</Duration>
+         <CreationDate IsApproximate="true">1993-12-01</CreationDate>
+         <ParentalWarningType>NoAdviceAvailable</ParentalWarningType>
+         <IsInstrumental>false</IsInstrumental>
+         <LanguageOfPerformance>ja</LanguageOfPerformance>
+         <TechnicalDetails>
+            <TechnicalResourceDetailsReference>T9</TechnicalResourceDetailsReference>
+            <PreviewDetails>
+               <StartPoint>0</StartPoint>
+               <ExpressionType>Instructive</ExpressionType>
+            </PreviewDetails>
+            <File>
+               <URI>0094631432057_01_009.wav</URI>
+            </File>
+         </TechnicalDetails>
+      </SoundRecording>
+      <SoundRecording>
+         <ResourceReference>A10</ResourceReference>
+         <Type>MusicalWorkSoundRecording</Type>
+         <ResourceId>
+            <ISRC>JPTO09404990</ISRC>
+         </ResourceId>
+         <DisplayTitleText>Natsu wa Konu</DisplayTitleText>
+         <DisplayTitle ApplicableTerritoryCode="Worldwide" IsDefault="true">
+            <TitleText>Natsu wa Konu</TitleText>
+         </DisplayTitle>
+         <DisplayTitle LanguageAndScriptCode="ja-Jpan" ApplicableTerritoryCode="Worldwide">
+            <TitleText>～夏は来ぬ</TitleText>
+         </DisplayTitle>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Latn" IsDefault="true">Saeko Shu</DisplayArtistName>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Jpan">しゅうさえこ</DisplayArtistName>
+         <DisplayArtist SequenceNumber="1">
+            <ArtistPartyReference>PSaekoShu</ArtistPartyReference>
+            <DisplayArtistRole>MainArtist</DisplayArtistRole>
+         </DisplayArtist>
+         <Contributor SequenceNumber="1">
+            <ContributorPartyReference>PSaekoShu</ContributorPartyReference>
+            <Role>Artist</Role>
+         </Contributor>
+         <PLine>
+            <Year>1994</Year>
+            <PLineText>(P) 1994 EMI Music Japan Inc.</PLineText>
+         </PLine>
+         <Duration>PT1M30S</Duration>
+         <CreationDate IsApproximate="true">1993-12-01</CreationDate>
+         <ParentalWarningType>NoAdviceAvailable</ParentalWarningType>
+         <IsInstrumental>false</IsInstrumental>
+         <LanguageOfPerformance>ja</LanguageOfPerformance>
+         <TechnicalDetails>
+            <TechnicalResourceDetailsReference>T10</TechnicalResourceDetailsReference>
+            <PreviewDetails>
+               <StartPoint>45</StartPoint>
+               <ExpressionType>Instructive</ExpressionType>
+            </PreviewDetails>
+            <File>
+               <URI>0094631432057_01_010.wav</URI>
+            </File>
+         </TechnicalDetails>
+      </SoundRecording>
+      <SoundRecording>
+         <ResourceReference>A11</ResourceReference>
+         <Type>MusicalWorkSoundRecording</Type>
+         <ResourceId>
+            <ISRC>JPTO09405000</ISRC>
+         </ResourceId>
+         <DisplayTitleText>-Aki- Chiisai Aki Mitsuketa</DisplayTitleText>
+         <DisplayTitle ApplicableTerritoryCode="Worldwide" IsDefault="true">
+            <TitleText>-Aki- Chiisai Aki Mitsuketa</TitleText>
+         </DisplayTitle>
+         <DisplayTitle LanguageAndScriptCode="ja-Jpan" ApplicableTerritoryCode="Worldwide">
+            <TitleText>-秋-　ちいさい秋みつけた</TitleText>
+         </DisplayTitle>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Latn" IsDefault="true">Saeko Shu</DisplayArtistName>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Jpan">しゅうさえこ</DisplayArtistName>
+         <DisplayArtist SequenceNumber="1">
+            <ArtistPartyReference>PSaekoShu</ArtistPartyReference>
+            <DisplayArtistRole>MainArtist</DisplayArtistRole>
+         </DisplayArtist>
+         <Contributor SequenceNumber="1">
+            <ContributorPartyReference>PSaekoShu</ContributorPartyReference>
+            <Role>Artist</Role>
+         </Contributor>
+         <PLine>
+            <Year>1994</Year>
+            <PLineText>(P) 1994 EMI Music Japan Inc.</PLineText>
+         </PLine>
+         <Duration>PT1M5S</Duration>
+         <CreationDate IsApproximate="true">1993-12-01</CreationDate>
+         <ParentalWarningType>NoAdviceAvailable</ParentalWarningType>
+         <IsInstrumental>false</IsInstrumental>
+         <LanguageOfPerformance>ja</LanguageOfPerformance>
+         <TechnicalDetails>
+            <TechnicalResourceDetailsReference>T11</TechnicalResourceDetailsReference>
+            <PreviewDetails>
+               <StartPoint>0</StartPoint>
+               <ExpressionType>Instructive</ExpressionType>
+            </PreviewDetails>
+            <File>
+               <URI>0094631432057_01_011.wav</URI>
+            </File>
+         </TechnicalDetails>
+      </SoundRecording>
+      <SoundRecording>
+         <ResourceReference>A12</ResourceReference>
+         <Type>MusicalWorkSoundRecording</Type>
+         <ResourceId>
+            <ISRC>JPTO09405010</ISRC>
+         </ResourceId>
+         <DisplayTitleText>Sato no Aki</DisplayTitleText>
+         <DisplayTitle ApplicableTerritoryCode="Worldwide" IsDefault="true">
+            <TitleText>Sato no Aki</TitleText>
+         </DisplayTitle>
+         <DisplayTitle LanguageAndScriptCode="ja-Jpan" ApplicableTerritoryCode="Worldwide">
+            <TitleText>～里の秋</TitleText>
+         </DisplayTitle>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Latn" IsDefault="true">Saeko Shu</DisplayArtistName>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Jpan">しゅうさえこ</DisplayArtistName>
+         <DisplayArtist SequenceNumber="1">
+            <ArtistPartyReference>PSaekoShu</ArtistPartyReference>
+            <DisplayArtistRole>MainArtist</DisplayArtistRole>
+         </DisplayArtist>
+         <Contributor SequenceNumber="1">
+            <ContributorPartyReference>PSaekoShu</ContributorPartyReference>
+            <Role>Artist</Role>
+         </Contributor>
+         <PLine>
+            <Year>1994</Year>
+            <PLineText>(P) 1994 EMI Music Japan Inc.</PLineText>
+         </PLine>
+         <Duration>PT58S</Duration>
+         <CreationDate IsApproximate="true">1993-12-01</CreationDate>
+         <ParentalWarningType>NoAdviceAvailable</ParentalWarningType>
+         <IsInstrumental>false</IsInstrumental>
+         <LanguageOfPerformance>ja</LanguageOfPerformance>
+         <TechnicalDetails>
+            <TechnicalResourceDetailsReference>T12</TechnicalResourceDetailsReference>
+            <PreviewDetails>
+               <StartPoint>0</StartPoint>
+               <ExpressionType>Instructive</ExpressionType>
+            </PreviewDetails>
+            <File>
+               <URI>0094631432057_01_012.wav</URI>
+            </File>
+         </TechnicalDetails>
+      </SoundRecording>
+      <SoundRecording>
+         <ResourceReference>A13</ResourceReference>
+         <Type>MusicalWorkSoundRecording</Type>
+         <ResourceId>
+            <ISRC>JPTO09405020</ISRC>
+         </ResourceId>
+         <DisplayTitleText>Ryoshuu</DisplayTitleText>
+         <DisplayTitle ApplicableTerritoryCode="Worldwide" IsDefault="true">
+            <TitleText>Ryoshuu</TitleText>
+         </DisplayTitle>
+         <DisplayTitle LanguageAndScriptCode="ja-Jpan" ApplicableTerritoryCode="Worldwide">
+            <TitleText>～旅愁</TitleText>
+         </DisplayTitle>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Latn" IsDefault="true">Saeko Shu</DisplayArtistName>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Jpan">しゅうさえこ</DisplayArtistName>
+         <DisplayArtist SequenceNumber="1">
+            <ArtistPartyReference>PSaekoShu</ArtistPartyReference>
+            <DisplayArtistRole>MainArtist</DisplayArtistRole>
+         </DisplayArtist>
+         <Contributor SequenceNumber="1">
+            <ContributorPartyReference>PSaekoShu</ContributorPartyReference>
+            <Role>Artist</Role>
+         </Contributor>
+         <PLine>
+            <Year>1994</Year>
+            <PLineText>(P) 1994 EMI Music Japan Inc.</PLineText>
+         </PLine>
+         <Duration>PT1M21S</Duration>
+         <CreationDate IsApproximate="true">1993-12-01</CreationDate>
+         <ParentalWarningType>NoAdviceAvailable</ParentalWarningType>
+         <IsInstrumental>false</IsInstrumental>
+         <LanguageOfPerformance>ja</LanguageOfPerformance>
+         <TechnicalDetails>
+            <TechnicalResourceDetailsReference>T13</TechnicalResourceDetailsReference>
+            <PreviewDetails>
+               <StartPoint>45</StartPoint>
+               <ExpressionType>Instructive</ExpressionType>
+            </PreviewDetails>
+            <File>
+               <URI>0094631432057_01_013.wav</URI>
+            </File>
+         </TechnicalDetails>
+      </SoundRecording>
+      <SoundRecording>
+         <ResourceReference>A14</ResourceReference>
+         <Type>MusicalWorkSoundRecording</Type>
+         <ResourceId>
+            <ISRC>JPTO09405030</ISRC>
+         </ResourceId>
+         <DisplayTitleText>Aka Tonbo</DisplayTitleText>
+         <DisplayTitle ApplicableTerritoryCode="Worldwide" IsDefault="true">
+            <TitleText>Aka Tonbo</TitleText>
+         </DisplayTitle>
+         <DisplayTitle LanguageAndScriptCode="ja-Jpan" ApplicableTerritoryCode="Worldwide">
+            <TitleText>～赤とんぼ</TitleText>
+         </DisplayTitle>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Latn" IsDefault="true">Saeko Shu</DisplayArtistName>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Jpan">しゅうさえこ</DisplayArtistName>
+         <DisplayArtist SequenceNumber="1">
+            <ArtistPartyReference>PSaekoShu</ArtistPartyReference>
+            <DisplayArtistRole>MainArtist</DisplayArtistRole>
+         </DisplayArtist>
+         <Contributor SequenceNumber="1">
+            <ContributorPartyReference>PSaekoShu</ContributorPartyReference>
+            <Role>Artist</Role>
+         </Contributor>
+         <PLine>
+            <Year>1994</Year>
+            <PLineText>(P) 1994 EMI Music Japan Inc.</PLineText>
+         </PLine>
+         <Duration>PT1M45S</Duration>
+         <CreationDate IsApproximate="true">1993-12-01</CreationDate>
+         <ParentalWarningType>NoAdviceAvailable</ParentalWarningType>
+         <IsInstrumental>false</IsInstrumental>
+         <LanguageOfPerformance>ja</LanguageOfPerformance>
+         <TechnicalDetails>
+            <TechnicalResourceDetailsReference>T14</TechnicalResourceDetailsReference>
+            <PreviewDetails>
+               <StartPoint>45</StartPoint>
+               <ExpressionType>Instructive</ExpressionType>
+            </PreviewDetails>
+            <File>
+               <URI>0094631432057_01_014.wav</URI>
+            </File>
+         </TechnicalDetails>
+      </SoundRecording>
+      <SoundRecording>
+         <ResourceReference>A15</ResourceReference>
+         <Type>MusicalWorkSoundRecording</Type>
+         <ResourceId>
+            <ISRC>JPTO09405040</ISRC>
+         </ResourceId>
+         <DisplayTitleText>-Fuyu- Fuyu no Yoru (Monbushou Shouka)</DisplayTitleText>
+         <DisplayTitle ApplicableTerritoryCode="Worldwide" IsDefault="true">
+            <TitleText>-Fuyu- Fuyu no Yoru (Monbushou Shouka)</TitleText>
+         </DisplayTitle>
+         <DisplayTitle LanguageAndScriptCode="ja-Jpan" ApplicableTerritoryCode="Worldwide">
+            <TitleText>-冬-　冬の夜（文部省唱歌）</TitleText>
+         </DisplayTitle>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Latn" IsDefault="true">Saeko Shu</DisplayArtistName>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Jpan">しゅうさえこ</DisplayArtistName>
+         <DisplayArtist SequenceNumber="1">
+            <ArtistPartyReference>PSaekoShu</ArtistPartyReference>
+            <DisplayArtistRole>MainArtist</DisplayArtistRole>
+         </DisplayArtist>
+         <Contributor SequenceNumber="1">
+            <ContributorPartyReference>PSaekoShu</ContributorPartyReference>
+            <Role>Artist</Role>
+         </Contributor>
+         <PLine>
+            <Year>1994</Year>
+            <PLineText>(P) 1994 EMI Music Japan Inc.</PLineText>
+         </PLine>
+         <Duration>PT1M26S</Duration>
+         <CreationDate IsApproximate="true">1993-12-01</CreationDate>
+         <ParentalWarningType>NoAdviceAvailable</ParentalWarningType>
+         <IsInstrumental>false</IsInstrumental>
+         <LanguageOfPerformance>ja</LanguageOfPerformance>
+         <TechnicalDetails>
+            <TechnicalResourceDetailsReference>T15</TechnicalResourceDetailsReference>
+            <PreviewDetails>
+               <StartPoint>45</StartPoint>
+               <ExpressionType>Instructive</ExpressionType>
+            </PreviewDetails>
+            <File>
+               <URI>0094631432057_01_015.wav</URI>
+            </File>
+         </TechnicalDetails>
+      </SoundRecording>
+      <SoundRecording>
+         <ResourceReference>A16</ResourceReference>
+         <Type>MusicalWorkSoundRecording</Type>
+         <ResourceId>
+            <ISRC>JPTO09405050</ISRC>
+         </ResourceId>
+         <DisplayTitleText>Pechka</DisplayTitleText>
+         <DisplayTitle ApplicableTerritoryCode="Worldwide" IsDefault="true">
+            <TitleText>Pechka</TitleText>
+         </DisplayTitle>
+         <DisplayTitle LanguageAndScriptCode="ja-Jpan" ApplicableTerritoryCode="Worldwide">
+            <TitleText>～ペチカ</TitleText>
+         </DisplayTitle>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Latn" IsDefault="true">Saeko Shu</DisplayArtistName>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Jpan">しゅうさえこ</DisplayArtistName>
+         <DisplayArtist SequenceNumber="1">
+            <ArtistPartyReference>PSaekoShu</ArtistPartyReference>
+            <DisplayArtistRole>MainArtist</DisplayArtistRole>
+         </DisplayArtist>
+         <Contributor SequenceNumber="1">
+            <ContributorPartyReference>PSaekoShu</ContributorPartyReference>
+            <Role>Artist</Role>
+         </Contributor>
+         <PLine>
+            <Year>1994</Year>
+            <PLineText>(P) 1994 EMI Music Japan Inc.</PLineText>
+         </PLine>
+         <Duration>PT1M5S</Duration>
+         <CreationDate IsApproximate="true">1993-12-01</CreationDate>
+         <ParentalWarningType>NoAdviceAvailable</ParentalWarningType>
+         <IsInstrumental>false</IsInstrumental>
+         <LanguageOfPerformance>ja</LanguageOfPerformance>
+         <TechnicalDetails>
+            <TechnicalResourceDetailsReference>T16</TechnicalResourceDetailsReference>
+            <PreviewDetails>
+               <StartPoint>0</StartPoint>
+               <ExpressionType>Instructive</ExpressionType>
+            </PreviewDetails>
+            <File>
+               <URI>0094631432057_01_016.wav</URI>
+            </File>
+         </TechnicalDetails>
+      </SoundRecording>
+      <SoundRecording>
+         <ResourceReference>A17</ResourceReference>
+         <Type>MusicalWorkSoundRecording</Type>
+         <ResourceId>
+            <ISRC>JPTO09405060</ISRC>
+         </ResourceId>
+         <DisplayTitleText>Yuki no Furu Machi wo</DisplayTitleText>
+         <DisplayTitle ApplicableTerritoryCode="Worldwide" IsDefault="true">
+            <TitleText>Yuki no Furu Machi wo</TitleText>
+         </DisplayTitle>
+         <DisplayTitle LanguageAndScriptCode="ja-Jpan" ApplicableTerritoryCode="Worldwide">
+            <TitleText>～雪の降る街を</TitleText>
+         </DisplayTitle>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Latn" IsDefault="true">Saeko Shu</DisplayArtistName>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Jpan">しゅうさえこ</DisplayArtistName>
+         <DisplayArtist SequenceNumber="1">
+            <ArtistPartyReference>PSaekoShu</ArtistPartyReference>
+            <DisplayArtistRole>MainArtist</DisplayArtistRole>
+         </DisplayArtist>
+         <Contributor SequenceNumber="1">
+            <ContributorPartyReference>PSaekoShu</ContributorPartyReference>
+            <Role>Artist</Role>
+         </Contributor>
+         <PLine>
+            <Year>1994</Year>
+            <PLineText>(P) 1994 EMI Music Japan Inc.</PLineText>
+         </PLine>
+         <Duration>PT1M11S</Duration>
+         <CreationDate IsApproximate="true">1993-12-01</CreationDate>
+         <ParentalWarningType>NoAdviceAvailable</ParentalWarningType>
+         <IsInstrumental>false</IsInstrumental>
+         <LanguageOfPerformance>ja</LanguageOfPerformance>
+         <TechnicalDetails>
+            <TechnicalResourceDetailsReference>T17</TechnicalResourceDetailsReference>
+            <PreviewDetails>
+               <StartPoint>0</StartPoint>
+               <ExpressionType>Instructive</ExpressionType>
+            </PreviewDetails>
+            <File>
+               <URI>0094631432057_01_017.wav</URI>
+            </File>
+         </TechnicalDetails>
+      </SoundRecording>
+      <SoundRecording>
+         <ResourceReference>A18</ResourceReference>
+         <Type>MusicalWorkSoundRecording</Type>
+         <ResourceId>
+            <ISRC>JPTO09405070</ISRC>
+         </ResourceId>
+         <DisplayTitleText>Komoriuta</DisplayTitleText>
+         <DisplayTitle ApplicableTerritoryCode="Worldwide" IsDefault="true">
+            <TitleText>Komoriuta</TitleText>
+         </DisplayTitle>
+         <DisplayTitle LanguageAndScriptCode="ja-Jpan" ApplicableTerritoryCode="Worldwide">
+            <TitleText>～こもりうた</TitleText>
+         </DisplayTitle>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Latn" IsDefault="true">Saeko Shu</DisplayArtistName>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Jpan">しゅうさえこ</DisplayArtistName>
+         <DisplayArtist SequenceNumber="1">
+            <ArtistPartyReference>PSaekoShu</ArtistPartyReference>
+            <DisplayArtistRole>MainArtist</DisplayArtistRole>
+         </DisplayArtist>
+         <Contributor SequenceNumber="1">
+            <ContributorPartyReference>PSaekoShu</ContributorPartyReference>
+            <Role>Artist</Role>
+         </Contributor>
+         <PLine>
+            <Year>1994</Year>
+            <PLineText>(P) 1994 EMI Music Japan Inc.</PLineText>
+         </PLine>
+         <Duration>PT2M12S</Duration>
+         <CreationDate IsApproximate="true">1993-12-01</CreationDate>
+         <ParentalWarningType>NoAdviceAvailable</ParentalWarningType>
+         <IsInstrumental>false</IsInstrumental>
+         <LanguageOfPerformance>ja</LanguageOfPerformance>
+         <TechnicalDetails>
+            <TechnicalResourceDetailsReference>T18</TechnicalResourceDetailsReference>
+            <PreviewDetails>
+               <StartPoint>45</StartPoint>
+               <ExpressionType>Instructive</ExpressionType>
+            </PreviewDetails>
+            <File>
+               <URI>0094631432057_01_018.wav</URI>
+            </File>
+         </TechnicalDetails>
+      </SoundRecording>
+      <SoundRecording>
+         <ResourceReference>A19</ResourceReference>
+         <Type>MusicalWorkSoundRecording</Type>
+         <ResourceId>
+            <ISRC>JPTO09332840</ISRC>
+         </ResourceId>
+         <DisplayTitleText>Aerobics Mama</DisplayTitleText>
+         <DisplayTitle ApplicableTerritoryCode="Worldwide" IsDefault="true">
+            <TitleText>Aerobics Mama</TitleText>
+         </DisplayTitle>
+         <DisplayTitle LanguageAndScriptCode="ja-Jpan" ApplicableTerritoryCode="Worldwide">
+            <TitleText>エアロビ　ママ</TitleText>
+         </DisplayTitle>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Latn" IsDefault="true">Saeko Shu</DisplayArtistName>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Jpan">しゅうさえこ</DisplayArtistName>
+         <DisplayArtist SequenceNumber="1">
+            <ArtistPartyReference>PSaekoShu</ArtistPartyReference>
+            <DisplayArtistRole>MainArtist</DisplayArtistRole>
+         </DisplayArtist>
+         <Contributor SequenceNumber="1">
+            <ContributorPartyReference>PSaekoShu</ContributorPartyReference>
+            <Role>Artist</Role>
+         </Contributor>
+         <PLine>
+            <Year>1994</Year>
+            <PLineText>(P) 1994 EMI Music Japan Inc.</PLineText>
+         </PLine>
+         <Duration>PT3M24S</Duration>
+         <CreationDate IsApproximate="true">1993-12-01</CreationDate>
+         <ParentalWarningType>NoAdviceAvailable</ParentalWarningType>
+         <IsInstrumental>false</IsInstrumental>
+         <LanguageOfPerformance>ja</LanguageOfPerformance>
+         <TechnicalDetails>
+            <TechnicalResourceDetailsReference>T19</TechnicalResourceDetailsReference>
+            <PreviewDetails>
+               <StartPoint>45</StartPoint>
+               <ExpressionType>Instructive</ExpressionType>
+            </PreviewDetails>
+            <File>
+               <URI>0094631432057_01_019.wav</URI>
+            </File>
+         </TechnicalDetails>
+      </SoundRecording>
+      <SoundRecording>
+         <ResourceReference>A20</ResourceReference>
+         <Type>MusicalWorkSoundRecording</Type>
+         <ResourceId>
+            <ISRC>JPTO09405080</ISRC>
+         </ResourceId>
+         <DisplayTitleText>Mother's Song -Kodomotachi e-</DisplayTitleText>
+         <DisplayTitle ApplicableTerritoryCode="Worldwide" IsDefault="true">
+            <TitleText>Mother's Song -Kodomotachi e-</TitleText>
+         </DisplayTitle>
+         <DisplayTitle LanguageAndScriptCode="ja-Jpan" ApplicableTerritoryCode="Worldwide">
+            <TitleText>Ｍｏｔｈｅｒ’ｓ　Ｓｏｎｇ－こどもたちへ－</TitleText>
+         </DisplayTitle>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Latn" IsDefault="true">Saeko Shu</DisplayArtistName>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Jpan">しゅうさえこ</DisplayArtistName>
+         <DisplayArtist SequenceNumber="1">
+            <ArtistPartyReference>PSaekoShu</ArtistPartyReference>
+            <DisplayArtistRole>MainArtist</DisplayArtistRole>
+         </DisplayArtist>
+         <Contributor SequenceNumber="1">
+            <ContributorPartyReference>PSaekoShu</ContributorPartyReference>
+            <Role>Artist</Role>
+         </Contributor>
+         <PLine>
+            <Year>1994</Year>
+            <PLineText>(P) 1994 EMI Music Japan Inc.</PLineText>
+         </PLine>
+         <Duration>PT3M42S</Duration>
+         <CreationDate IsApproximate="true">1993-12-01</CreationDate>
+         <ParentalWarningType>NoAdviceAvailable</ParentalWarningType>
+         <IsInstrumental>false</IsInstrumental>
+         <LanguageOfPerformance>ja</LanguageOfPerformance>
+         <TechnicalDetails>
+            <TechnicalResourceDetailsReference>T20</TechnicalResourceDetailsReference>
+            <PreviewDetails>
+               <StartPoint>45</StartPoint>
+               <ExpressionType>Instructive</ExpressionType>
+            </PreviewDetails>
+            <File>
+               <URI>0094631432057_01_020.wav</URI>
+            </File>
+         </TechnicalDetails>
+      </SoundRecording>
+      <SoundRecording>
+         <ResourceReference>A21</ResourceReference>
+         <Type>MusicalWorkSoundRecording</Type>
+         <ResourceId>
+            <ISRC>JPTO09332830</ISRC>
+         </ResourceId>
+         <DisplayTitleText>Kitto Shiawase (NHK Minna no Uta)</DisplayTitleText>
+         <DisplayTitle ApplicableTerritoryCode="Worldwide" IsDefault="true">
+            <TitleText>Kitto Shiawase (NHK Minna no Uta)</TitleText>
+         </DisplayTitle>
+         <DisplayTitle LanguageAndScriptCode="ja-Jpan" ApplicableTerritoryCode="Worldwide">
+            <TitleText>きっと　しあわせ（ＮＨＫみんなのうた）</TitleText>
+         </DisplayTitle>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Latn" IsDefault="true">Saeko Shu</DisplayArtistName>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Jpan">しゅうさえこ</DisplayArtistName>
+         <DisplayArtist SequenceNumber="1">
+            <ArtistPartyReference>PSaekoShu</ArtistPartyReference>
+            <DisplayArtistRole>MainArtist</DisplayArtistRole>
+         </DisplayArtist>
+         <Contributor SequenceNumber="1">
+            <ContributorPartyReference>PSaekoShu</ContributorPartyReference>
+            <Role>Artist</Role>
+         </Contributor>
+         <PLine>
+            <Year>1994</Year>
+            <PLineText>(P) 1994 EMI Music Japan Inc.</PLineText>
+         </PLine>
+         <Duration>PT3M46S</Duration>
+         <CreationDate IsApproximate="true">1993-12-01</CreationDate>
+         <ParentalWarningType>NoAdviceAvailable</ParentalWarningType>
+         <IsInstrumental>false</IsInstrumental>
+         <LanguageOfPerformance>ja</LanguageOfPerformance>
+         <TechnicalDetails>
+            <TechnicalResourceDetailsReference>T21</TechnicalResourceDetailsReference>
+            <PreviewDetails>
+               <StartPoint>45</StartPoint>
+               <ExpressionType>Instructive</ExpressionType>
+            </PreviewDetails>
+            <File>
+               <URI>0094631432057_01_021.wav</URI>
+            </File>
+         </TechnicalDetails>
+      </SoundRecording>
+      <Image>
+         <ResourceReference>A22</ResourceReference>
+         <Type>FrontCoverImage</Type>
+         <ResourceId>
+            <ProprietaryId Namespace="PADPIDA2013042401U">PACKSHOT:0094631432057</ProprietaryId>
+         </ResourceId>
+         <ParentalWarningType>NotExplicit</ParentalWarningType>
+         <TechnicalDetails>
+            <TechnicalResourceDetailsReference>T22</TechnicalResourceDetailsReference>
+            <File>
+               <URI>0094631432057.jpg</URI>
+            </File>
+         </TechnicalDetails>
+      </Image>
+   </ResourceList>
+   <ReleaseList>
+      <Release>
+         <ReleaseReference>R0</ReleaseReference>
+         <ReleaseType>Album</ReleaseType>
+         <ReleaseId>
+            <ICPN>00094631432057</ICPN>
+         </ReleaseId>
+         <DisplayTitleText>Yume no Hajmari</DisplayTitleText>
+         <DisplayTitle ApplicableTerritoryCode="Worldwide" IsDefault="true">
+            <TitleText>Yume no Hajmari</TitleText>
+         </DisplayTitle>
+         <DisplayTitle LanguageAndScriptCode="ja-Jpan" ApplicableTerritoryCode="Worldwide">
+            <TitleText>夢のはじまり</TitleText>
+         </DisplayTitle>
+         <DisplayTitle LanguageAndScriptCode="ja-Kana" ApplicableTerritoryCode="Worldwide">
+            <TitleText>ﾕﾒﾉﾊｼﾞﾏﾘ</TitleText>
+         </DisplayTitle>
+         <DisplayArtistName ApplicableTerritoryCode="Worldwide" LanguageAndScriptCode="ja-Latn" IsDefault="true">Saeko Shu</DisplayArtistName>
+         <DisplayArtistName LanguageAndScriptCode="ja-Jpan" ApplicableTerritoryCode="Worldwide">しゅうさえこ</DisplayArtistName>
+         <DisplayArtistName LanguageAndScriptCode="ja-Kana" ApplicableTerritoryCode="Worldwide">ｼｭｳｻｴｺ</DisplayArtistName>
+         <DisplayArtist SequenceNumber="1">
+            <ArtistPartyReference>PSaekoShu</ArtistPartyReference>
+            <DisplayArtistRole>MainArtist</DisplayArtistRole>
+         </DisplayArtist>
+         <ReleaseLabelReference ApplicableTerritoryCode="Worldwide">PEMI</ReleaseLabelReference>
+         <Duration>PT36M30S</Duration>
+         <Genre ApplicableTerritoryCode="Worldwide">
+            <GenreText>J-Pop</GenreText>
+         </Genre>
+         <ParentalWarningType>NoAdviceAvailable</ParentalWarningType>
+         <RelatedRelease>
+            <ReleaseRelationshipType>IsDigitalEquivalentToPhysical</ReleaseRelationshipType>
+            <ReleaseId>
+               <ICPN>04988006110809</ICPN>
+            </ReleaseId>
+         </RelatedRelease>
+         <IsMultiArtistCompilation>false</IsMultiArtistCompilation>
+         <ResourceGroup >
+		   <AdditionalTitle>
+			  <TitleText>Component 1</TitleText>
+		   </AdditionalTitle>
+		   <SequenceNumber>1</SequenceNumber>
+		   <ResourceGroupContentItem>
+			  <SequenceNumber>1</SequenceNumber>
+			  <ReleaseResourceReference>A1</ReleaseResourceReference>
+		   </ResourceGroupContentItem>
+		   <ResourceGroupContentItem>
+			  <SequenceNumber>2</SequenceNumber>
+			  <ReleaseResourceReference>A2</ReleaseResourceReference>
+		   </ResourceGroupContentItem>
+		   <ResourceGroupContentItem>
+			  <SequenceNumber>3</SequenceNumber>
+			  <ReleaseResourceReference>A3</ReleaseResourceReference>
+		   </ResourceGroupContentItem>
+		   <ResourceGroupContentItem>
+			  <SequenceNumber>4</SequenceNumber>
+			  <ReleaseResourceReference>A4</ReleaseResourceReference>
+		   </ResourceGroupContentItem>
+		   <ResourceGroupContentItem>
+			  <SequenceNumber>5</SequenceNumber>
+			  <ReleaseResourceReference>A5</ReleaseResourceReference>
+		   </ResourceGroupContentItem>
+		   <ResourceGroupContentItem>
+			  <SequenceNumber>6</SequenceNumber>
+			  <ReleaseResourceReference>A6</ReleaseResourceReference>
+		   </ResourceGroupContentItem>
+		   <ResourceGroupContentItem>
+			  <SequenceNumber>7</SequenceNumber>
+			  <ReleaseResourceReference>A7</ReleaseResourceReference>
+		   </ResourceGroupContentItem>
+		   <ResourceGroupContentItem>
+			  <SequenceNumber>8</SequenceNumber>
+			  <ReleaseResourceReference>A8</ReleaseResourceReference>
+		   </ResourceGroupContentItem>
+		   <ResourceGroupContentItem>
+			  <SequenceNumber>9</SequenceNumber>
+			  <ReleaseResourceReference>A9</ReleaseResourceReference>
+		   </ResourceGroupContentItem>
+		   <ResourceGroupContentItem>
+			  <SequenceNumber>10</SequenceNumber>
+			  <ReleaseResourceReference>A10</ReleaseResourceReference>
+		   </ResourceGroupContentItem>
+		   <ResourceGroupContentItem>
+			  <SequenceNumber>11</SequenceNumber>
+			  <ReleaseResourceReference>A11</ReleaseResourceReference>
+		   </ResourceGroupContentItem>
+		   <ResourceGroupContentItem>
+			  <SequenceNumber>12</SequenceNumber>
+			  <ReleaseResourceReference>A12</ReleaseResourceReference>
+		   </ResourceGroupContentItem>
+		   <ResourceGroupContentItem>
+			  <SequenceNumber>13</SequenceNumber>
+			  <ReleaseResourceReference>A13</ReleaseResourceReference>
+		   </ResourceGroupContentItem>
+		   <ResourceGroupContentItem>
+			  <SequenceNumber>14</SequenceNumber>
+			  <ReleaseResourceReference>A14</ReleaseResourceReference>
+		   </ResourceGroupContentItem>
+		   <ResourceGroupContentItem>
+			  <SequenceNumber>15</SequenceNumber>
+			  <ReleaseResourceReference>A15</ReleaseResourceReference>
+		   </ResourceGroupContentItem>
+		   <ResourceGroupContentItem>
+			  <SequenceNumber>16</SequenceNumber>
+			  <ReleaseResourceReference>A16</ReleaseResourceReference>
+		   </ResourceGroupContentItem>
+		   <ResourceGroupContentItem>
+			  <SequenceNumber>17</SequenceNumber>
+			  <ReleaseResourceReference>A17</ReleaseResourceReference>
+		   </ResourceGroupContentItem>
+		   <ResourceGroupContentItem>
+			  <SequenceNumber>18</SequenceNumber>
+			  <ReleaseResourceReference>A18</ReleaseResourceReference>
+		   </ResourceGroupContentItem>
+		   <ResourceGroupContentItem>
+			  <SequenceNumber>19</SequenceNumber>
+			  <ReleaseResourceReference>A19</ReleaseResourceReference>
+		   </ResourceGroupContentItem>
+		   <ResourceGroupContentItem>
+			  <SequenceNumber>20</SequenceNumber>
+			  <ReleaseResourceReference>A20</ReleaseResourceReference>
+		   </ResourceGroupContentItem>
+		   <ResourceGroupContentItem>
+			  <SequenceNumber>21</SequenceNumber>
+			  <ReleaseResourceReference>A21</ReleaseResourceReference>
+		   </ResourceGroupContentItem>
+            <LinkedReleaseResourceReference>A22</LinkedReleaseResourceReference>
+         </ResourceGroup>
+      </Release>
+      <TrackRelease>
+         <ReleaseReference>R1</ReleaseReference>
+         <ReleaseId>
+            <ProprietaryId Namespace="PADPIDA2013042401U">00094631432057_JPTO09404900_R1</ProprietaryId>
+         </ReleaseId>
+         <ReleaseResourceReference>A1</ReleaseResourceReference>
+         <ReleaseLabelReference ApplicableTerritoryCode="Worldwide">PEMI</ReleaseLabelReference>
+         <Genre ApplicableTerritoryCode="Worldwide">
+            <GenreText>J-Pop</GenreText>
+         </Genre>
+      </TrackRelease>
+      <TrackRelease>
+         <ReleaseReference>R2</ReleaseReference>
+         <ReleaseId>
+            <ProprietaryId Namespace="PADPIDA2013042401U">00094631432057_JPTO09404910_R2</ProprietaryId>
+         </ReleaseId>
+         <ReleaseResourceReference>A2</ReleaseResourceReference>
+         <ReleaseLabelReference ApplicableTerritoryCode="Worldwide">PEMI</ReleaseLabelReference>
+         <Genre ApplicableTerritoryCode="Worldwide">
+            <GenreText>J-Pop</GenreText>
+         </Genre>
+      </TrackRelease>
+      <TrackRelease>
+         <ReleaseReference>R3</ReleaseReference>
+         <ReleaseId>
+            <ProprietaryId Namespace="PADPIDA2013042401U">00094631432057_JPTO09404920_R3</ProprietaryId>
+         </ReleaseId>
+         <ReleaseResourceReference>A3</ReleaseResourceReference>
+         <ReleaseLabelReference ApplicableTerritoryCode="Worldwide">PEMI</ReleaseLabelReference>
+         <Genre ApplicableTerritoryCode="Worldwide">
+            <GenreText>J-Pop</GenreText>
+         </Genre>
+      </TrackRelease>
+      <TrackRelease>
+         <ReleaseReference>R4</ReleaseReference>
+         <ReleaseId>
+            <ProprietaryId Namespace="PADPIDA2013042401U">00094631432057_JPTO09404930_R4</ProprietaryId>
+         </ReleaseId>
+         <ReleaseResourceReference>A4</ReleaseResourceReference>
+         <ReleaseLabelReference ApplicableTerritoryCode="Worldwide">PEMI</ReleaseLabelReference>
+         <Genre ApplicableTerritoryCode="Worldwide">
+            <GenreText>J-Pop</GenreText>
+         </Genre>
+      </TrackRelease>
+      <TrackRelease>
+         <ReleaseReference>R5</ReleaseReference>
+         <ReleaseId>
+            <ProprietaryId Namespace="PADPIDA2013042401U">00094631432057_JPTO09404940_R5</ProprietaryId>
+         </ReleaseId>
+         <ReleaseResourceReference>A5</ReleaseResourceReference>
+         <ReleaseLabelReference ApplicableTerritoryCode="Worldwide">PEMI</ReleaseLabelReference>
+         <Genre ApplicableTerritoryCode="Worldwide">
+            <GenreText>J-Pop</GenreText>
+         </Genre>
+      </TrackRelease>
+      <TrackRelease>
+         <ReleaseReference>R6</ReleaseReference>
+         <ReleaseId>
+            <ProprietaryId Namespace="PADPIDA2013042401U">00094631432057_JPTO09404950_R6</ProprietaryId>
+         </ReleaseId>
+         <ReleaseResourceReference>A6</ReleaseResourceReference>
+         <ReleaseLabelReference ApplicableTerritoryCode="Worldwide">PEMI</ReleaseLabelReference>
+         <Genre ApplicableTerritoryCode="Worldwide">
+            <GenreText>J-Pop</GenreText>
+         </Genre>
+      </TrackRelease>
+      <TrackRelease>
+         <ReleaseReference>R7</ReleaseReference>
+         <ReleaseId>
+            <ProprietaryId Namespace="PADPIDA2013042401U">00094631432057_JPTO09404960_R7</ProprietaryId>
+         </ReleaseId>
+         <ReleaseResourceReference>A7</ReleaseResourceReference>
+         <ReleaseLabelReference ApplicableTerritoryCode="Worldwide">PEMI</ReleaseLabelReference>
+         <Genre ApplicableTerritoryCode="Worldwide">
+            <GenreText>J-Pop</GenreText>
+         </Genre>
+      </TrackRelease>
+      <TrackRelease>
+         <ReleaseReference>R8</ReleaseReference>
+         <ReleaseId>
+            <ProprietaryId Namespace="PADPIDA2013042401U">00094631432057_JPTO09404970_R8</ProprietaryId>
+         </ReleaseId>
+         <ReleaseResourceReference>A8</ReleaseResourceReference>
+         <ReleaseLabelReference ApplicableTerritoryCode="Worldwide">PEMI</ReleaseLabelReference>
+         <Genre ApplicableTerritoryCode="Worldwide">
+            <GenreText>J-Pop</GenreText>
+         </Genre>
+      </TrackRelease>
+      <TrackRelease>
+         <ReleaseReference>R9</ReleaseReference>
+         <ReleaseId>
+            <ProprietaryId Namespace="PADPIDA2013042401U">00094631432057_JPTO09404980_R9</ProprietaryId>
+         </ReleaseId>
+         <ReleaseResourceReference>A9</ReleaseResourceReference>
+         <ReleaseLabelReference ApplicableTerritoryCode="Worldwide">PEMI</ReleaseLabelReference>
+         <Genre ApplicableTerritoryCode="Worldwide">
+            <GenreText>J-Pop</GenreText>
+         </Genre>
+      </TrackRelease>
+      <TrackRelease>
+         <ReleaseReference>R10</ReleaseReference>
+         <ReleaseId>
+            <ProprietaryId Namespace="PADPIDA2013042401U">00094631432057_JPTO09404990_R10</ProprietaryId>
+         </ReleaseId>
+         <ReleaseResourceReference>A10</ReleaseResourceReference>
+         <ReleaseLabelReference ApplicableTerritoryCode="Worldwide">PEMI</ReleaseLabelReference>
+         <Genre ApplicableTerritoryCode="Worldwide">
+            <GenreText>J-Pop</GenreText>
+         </Genre>
+      </TrackRelease>
+      <TrackRelease>
+         <ReleaseReference>R11</ReleaseReference>
+         <ReleaseId>
+            <ProprietaryId Namespace="PADPIDA2013042401U">00094631432057_JPTO09405000_R11</ProprietaryId>
+         </ReleaseId>
+         <ReleaseResourceReference>A11</ReleaseResourceReference>
+         <ReleaseLabelReference ApplicableTerritoryCode="Worldwide">PEMI</ReleaseLabelReference>
+         <Genre ApplicableTerritoryCode="Worldwide">
+            <GenreText>J-Pop</GenreText>
+         </Genre>
+      </TrackRelease>
+      <TrackRelease>
+         <ReleaseReference>R12</ReleaseReference>
+         <ReleaseId>
+            <ProprietaryId Namespace="PADPIDA2013042401U">00094631432057_JPTO09405010_R12</ProprietaryId>
+         </ReleaseId>
+         <ReleaseResourceReference>A12</ReleaseResourceReference>
+         <ReleaseLabelReference ApplicableTerritoryCode="Worldwide">PEMI</ReleaseLabelReference>
+         <Genre ApplicableTerritoryCode="Worldwide">
+            <GenreText>J-Pop</GenreText>
+         </Genre>
+      </TrackRelease>
+      <TrackRelease>
+         <ReleaseReference>R13</ReleaseReference>
+         <ReleaseId>
+            <ProprietaryId Namespace="PADPIDA2013042401U">00094631432057_JPTO09405020_R13</ProprietaryId>
+         </ReleaseId>
+         <ReleaseResourceReference>A13</ReleaseResourceReference>
+         <ReleaseLabelReference ApplicableTerritoryCode="Worldwide">PEMI</ReleaseLabelReference>
+         <Genre ApplicableTerritoryCode="Worldwide">
+            <GenreText>J-Pop</GenreText>
+         </Genre>
+      </TrackRelease>
+      <TrackRelease>
+         <ReleaseReference>R14</ReleaseReference>
+         <ReleaseId>
+            <ProprietaryId Namespace="PADPIDA2013042401U">00094631432057_JPTO09405030_R14</ProprietaryId>
+         </ReleaseId>
+         <ReleaseResourceReference>A14</ReleaseResourceReference>
+         <ReleaseLabelReference ApplicableTerritoryCode="Worldwide">PEMI</ReleaseLabelReference>
+         <Genre ApplicableTerritoryCode="Worldwide">
+            <GenreText>J-Pop</GenreText>
+         </Genre>
+      </TrackRelease>
+      <TrackRelease>
+         <ReleaseReference>R15</ReleaseReference>
+         <ReleaseId>
+            <ProprietaryId Namespace="PADPIDA2013042401U">00094631432057_JPTO09405040_R15</ProprietaryId>
+         </ReleaseId>
+         <ReleaseResourceReference>A15</ReleaseResourceReference>
+         <ReleaseLabelReference ApplicableTerritoryCode="Worldwide">PEMI</ReleaseLabelReference>
+         <Genre ApplicableTerritoryCode="Worldwide">
+            <GenreText>J-Pop</GenreText>
+         </Genre>
+      </TrackRelease>
+      <TrackRelease>
+         <ReleaseReference>R16</ReleaseReference>
+         <ReleaseId>
+            <ProprietaryId Namespace="PADPIDA2013042401U">00094631432057_JPTO09405050_R16</ProprietaryId>
+         </ReleaseId>
+         <ReleaseResourceReference>A16</ReleaseResourceReference>
+         <ReleaseLabelReference ApplicableTerritoryCode="Worldwide">PEMI</ReleaseLabelReference>
+         <Genre ApplicableTerritoryCode="Worldwide">
+            <GenreText>J-Pop</GenreText>
+         </Genre>
+      </TrackRelease>
+      <TrackRelease>
+         <ReleaseReference>R17</ReleaseReference>
+         <ReleaseId>
+            <ProprietaryId Namespace="PADPIDA2013042401U">00094631432057_JPTO09405060_R17</ProprietaryId>
+         </ReleaseId>
+         <ReleaseResourceReference>A17</ReleaseResourceReference>
+         <ReleaseLabelReference ApplicableTerritoryCode="Worldwide">PEMI</ReleaseLabelReference>
+         <Genre ApplicableTerritoryCode="Worldwide">
+            <GenreText>J-Pop</GenreText>
+         </Genre>
+      </TrackRelease>
+      <TrackRelease>
+         <ReleaseReference>R18</ReleaseReference>
+         <ReleaseId>
+            <ProprietaryId Namespace="PADPIDA2013042401U">00094631432057_JPTO09405070_R18</ProprietaryId>
+         </ReleaseId>
+         <ReleaseResourceReference>A18</ReleaseResourceReference>
+         <ReleaseLabelReference ApplicableTerritoryCode="Worldwide">PEMI</ReleaseLabelReference>
+         <Genre ApplicableTerritoryCode="Worldwide">
+            <GenreText>J-Pop</GenreText>
+         </Genre>
+      </TrackRelease>
+      <TrackRelease>
+         <ReleaseReference>R19</ReleaseReference>
+         <ReleaseId>
+            <ProprietaryId Namespace="PADPIDA2013042401U">00094631432057_JPTO09332840_R19</ProprietaryId>
+         </ReleaseId>
+         <ReleaseResourceReference>A19</ReleaseResourceReference>
+         <ReleaseLabelReference ApplicableTerritoryCode="Worldwide">PEMI</ReleaseLabelReference>
+         <Genre ApplicableTerritoryCode="Worldwide">
+            <GenreText>J-Pop</GenreText>
+         </Genre>
+      </TrackRelease>
+      <TrackRelease>
+         <ReleaseReference>R20</ReleaseReference>
+         <ReleaseId>
+            <ProprietaryId Namespace="PADPIDA2013042401U">00094631432057_JPTO09405080_R20</ProprietaryId>
+         </ReleaseId>
+         <ReleaseResourceReference>A20</ReleaseResourceReference>
+         <ReleaseLabelReference ApplicableTerritoryCode="Worldwide">PEMI</ReleaseLabelReference>
+         <Genre ApplicableTerritoryCode="Worldwide">
+            <GenreText>J-Pop</GenreText>
+         </Genre>
+      </TrackRelease>
+      <TrackRelease>
+         <ReleaseReference>R21</ReleaseReference>
+         <ReleaseId>
+            <ProprietaryId Namespace="PADPIDA2013042401U">00094631432057_JPTO09332830_R21</ProprietaryId>
+         </ReleaseId>
+         <ReleaseResourceReference>A21</ReleaseResourceReference>
+         <ReleaseLabelReference ApplicableTerritoryCode="Worldwide">PEMI</ReleaseLabelReference>
+         <Genre ApplicableTerritoryCode="Worldwide">
+            <GenreText>J-Pop</GenreText>
+         </Genre>
+      </TrackRelease>
+   </ReleaseList>
+   <DealList>
+      <ReleaseDeal>
+         <DealReleaseReference>R1</DealReleaseReference>
+         <DealReleaseReference>R2</DealReleaseReference>
+         <DealReleaseReference>R3</DealReleaseReference>
+         <DealReleaseReference>R4</DealReleaseReference>
+         <DealReleaseReference>R5</DealReleaseReference>
+         <DealReleaseReference>R6</DealReleaseReference>
+         <DealReleaseReference>R7</DealReleaseReference>
+         <DealReleaseReference>R8</DealReleaseReference>
+         <DealReleaseReference>R9</DealReleaseReference>
+         <DealReleaseReference>R10</DealReleaseReference>
+         <DealReleaseReference>R11</DealReleaseReference>
+         <DealReleaseReference>R12</DealReleaseReference>
+         <DealReleaseReference>R13</DealReleaseReference>
+         <DealReleaseReference>R14</DealReleaseReference>
+         <DealReleaseReference>R15</DealReleaseReference>
+         <DealReleaseReference>R16</DealReleaseReference>
+         <DealReleaseReference>R17</DealReleaseReference>
+         <DealReleaseReference>R18</DealReleaseReference>
+         <DealReleaseReference>R19</DealReleaseReference>
+         <DealReleaseReference>R20</DealReleaseReference>
+         <DealReleaseReference>R21</DealReleaseReference>
+         <Deal>
+            <DealTerms>
+               <TerritoryCode>JP</TerritoryCode>
+               <ValidityPeriod>
+                  <StartDate>2004-04-01</StartDate>
+               </ValidityPeriod>
+               <CommercialModelType>SubscriptionModel</CommercialModelType>
+               <CommercialModelType>AdvertisementSupportedModel</CommercialModelType>
+               <UseType>ConditionalDownload</UseType>
+               <UseType>Stream</UseType>
+            </DealTerms>
+         </Deal>
+         <Deal>
+            <DealTerms>
+               <TerritoryCode>JP</TerritoryCode>
+               <ValidityPeriod>
+                  <StartDate>2004-04-01</StartDate>
+               </ValidityPeriod>
+               <CommercialModelType>PayAsYouGoModel</CommercialModelType>
+               <UseType>PermanentDownload</UseType>
+               <UseType>ConditionalDownload</UseType>
+               <PriceInformation>
+                  <PriceCode Namespace="PADPIDA2013042401U">AAAA</PriceCode>
+               </PriceInformation>
+            </DealTerms>
+         </Deal>
+      </ReleaseDeal>
+      <ReleaseDeal>
+         <DealReleaseReference>R0</DealReleaseReference>
+         <Deal>
+            <DealTerms>
+               <TerritoryCode>JP</TerritoryCode>
+               <ValidityPeriod>
+                  <StartDate>2004-04-01</StartDate>
+               </ValidityPeriod>
+               <CommercialModelType>PayAsYouGoModel</CommercialModelType>
+               <UseType>PermanentDownload</UseType>
+               <UseType>ConditionalDownload</UseType>
+               <PriceInformation>
+                  <PriceCode Namespace="PADPIDA2013042401U">AAAA</PriceCode>
+               </PriceInformation>
+            </DealTerms>
+         </Deal>
+      </ReleaseDeal>
+   </DealList>
+</ern:NewReleaseMessage>

--- a/xsd/release_notification/42/release_notification.xsd
+++ b/xsd/release_notification/42/release_notification.xsd
@@ -1,0 +1,7282 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SCOW Version v0.8.50 -->
+<xs:schema xmlns:ern="http://ddex.net/xml/ern/42" xmlns:avs="http://ddex.net/xml/avs/avs" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://ddex.net/xml/ern/42" elementFormDefault="unqualified" attributeFormDefault="unqualified">
+   <xs:import namespace="http://ddex.net/xml/avs/avs" schemaLocation="http://ddex.net/xml/avs/avs20200518.xsd"/>
+   <xs:annotation>
+      <xs:documentation>© 2006-2020 Digital Data Exchange, LLC (DDEX)</xs:documentation>
+      <xs:documentation>This XML Schema Definition file is, together with all DDEX standards, subject to two licences: If you wish to evaluate whether the standard meets your needs please have a look at the Evaluation Licence at https://kb.ddex.net/general-implementation-guidance/licensing-the-standards/. If you want to implement and use this DDEX standard, please take out an Implementation Licence. For details please go to http://ddex.net/apply-ddex-implementation-licence.</xs:documentation>
+   </xs:annotation>
+   <xs:element name="NewReleaseMessage">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Message in the Release Notification Message Suite Standard, containing details of a new Release.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-message-exchange-protocols-and-choreographies</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element name="MessageHeader" type="ern:MessageHeader">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The MessageHeader for the NewReleaseMessage.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="ReleaseAdmin" minOccurs="0" maxOccurs="unbounded" type="ern:ReleaseAdmin">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of Release administration.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="PartyList" type="ern:PartyList">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of one or more Parties relating to the reported MusicalWorks.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="CueSheetList" minOccurs="0" type="ern:DetailedCueSheetList">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of one or more CueSheets contained in Releases for which data is provided in the NewReleaseMessage.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="ResourceList" type="ern:ResourceList">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of one or more Resources.</xs:documentation>
+                  <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/sequencing-resources</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="ChapterList" minOccurs="0" type="ern:ChapterList">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of one or more Chapters contained in Releases for which data is provided in the NewReleaseMessage.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="ReleaseList" type="ern:ReleaseList">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of one or more DDEX Releases contained in the NewReleaseMessage.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="DealList" minOccurs="0" type="ern:DealList">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of one or more Deals governing the Usage of the Releases in the Message.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="SupplementalDocumentList" minOccurs="0" type="ern:SupplementalDocumentList">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of one or more XML documents communicated with the Message.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:sequence>
+         <xs:attribute name="ReleaseProfileVersionId" type="avs:ReleaseProfileVersionId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier of the Version of the release profile used for the Message. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+         <xs:attribute name="ReleaseProfileVariantVersionId" type="avs:ReleaseProfileVariantVersionId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier of the Version of the release profile variant used for the Message. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+         <xs:attribute name="LanguageAndScriptCode" use="required">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Language and script for the Elements of this Message as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="PurgeReleaseMessage">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Message in the Release Notification Message Suite Standard, allowing a ReleaseCreator to 'purge' a Release that a DSP has on its books but that cannot be retracted or be taken down in the normal way (e.g. because its metadata is corrupt).</xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element name="MessageHeader" type="ern:MessageHeader">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The MessageHeader for the PurgeReleaseMessage.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="PurgedRelease" type="ern:PurgedRelease">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of a DDEX Release to be purged.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:sequence>
+         <xs:attribute name="LanguageAndScriptCode" use="required">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Language and script for the Elements of this Message as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   <xs:complexType name="AdditionalTitle">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of an AdditionalTitle.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="TitleText" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The text of the Title.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SubTitle" minOccurs="0" maxOccurs="unbounded" type="ern:DisplaySubTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a SubTitle of the Title, including Titles of Versions used to differentiate different versions of the same Title, as required by the GRid and ISRC ReferenceDescriptiveMetadataSets.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the Title as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:string">
+               <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A Territory to which the Title applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="TitleType" type="avs:AdditionalTitleType">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A Type of the Title which defines its origin or the function it fulfils in relation to a Creation. Note: A Title may fulfil more than one role. Example: 'Help' may be both the OriginalTitle and the DisplayTitle for the well-known Beatles song. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Namespace" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Namespace of the AdditionalTitleType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="UserDefinedValue" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A UserDefined value of the AdditionalTitleType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IsDefault" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="AdministratingRecordCompanyWithReference">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of an AdministratingRecordCompany.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named AdministratingRecordCompanyWithReference to disambiguate it from the basic AdministratingRecordCompany Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="RecordCompanyPartyReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Reference for a Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:IDREF">
+                  <xs:pattern value="P[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="Role" type="ern:AdministratingRecordCompanyRole">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The role played by the Party responsible for administering Rights in a Resource or a Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="AvRating">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a rating for an audio-visual Creation.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="Rating" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The text of the AvRating.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Agency" type="ern:RatingAgency">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an Organization that issues the AvRating.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Reason" minOccurs="0" type="ern:RatingReason">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Reason for a rating being applied.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A Territory to which the AvRating applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IsDefault" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="CLineWithDefault">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a CLine.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named CLineWithDefault to disambiguate it from the basic CLine Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="Year" minOccurs="0" type="xs:gYear">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Year of the CLine.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CLineCompany" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Name of the company releasing the Creation. This may be an owner or a Licensee of the Creation.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CLineText" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The text of the CLine.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A Territory to which the CLine applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IsDefault" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script of the CLineText as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="Chapter">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Chapter. Chapters referenced from Video Resources are of ChapterType VideoChapter. Chapters referenced from a Release composite are of ChapterType Series, Season or Episode.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ChapterReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier (specific to the Message) of the Chapter within the Release which contains it. This is a LocalCollectionAnchor starting with the letter X.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:ID">
+                  <xs:pattern value="X[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="ChapterId" minOccurs="0" maxOccurs="unbounded" type="ern:ProprietaryId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an Identifier of the Chapter.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayTitleText" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayTitleText">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the Chapter as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayTitle" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the Chapter as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AdditionalTitle" minOccurs="0" maxOccurs="unbounded" type="ern:AdditionalTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an AdditionalTitle of the Chapter. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SequenceNumber" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The number indicating the order of the Chapter within all Chapters at this level. The default value is 1, and the value must be incremented by 1 for each Chapter occurring at a particular level.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Contributor" minOccurs="0" maxOccurs="unbounded" type="ern:Contributor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Contributor to the Chapter. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Character" minOccurs="0" maxOccurs="unbounded" type="ern:Character">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Character in the Chapter. A Character may be described through Name, Identifier and Roles. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RepresentativeImageReference" minOccurs="0">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Reference for an Image (specific to this Message). This is a LocalResourceAnchorReference starting with the letter A.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:IDREF">
+                  <xs:pattern value="A[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="StartTime" minOccurs="0" type="xs:duration">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The start time of the Chapter, measured from the start of the Resource that contains it (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Duration" minOccurs="0" type="xs:duration">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Duration of the use of the Chapter (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="EndTime" minOccurs="0" type="xs:duration">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The end time of the Chapter, measured from the start of the Resource that contains it (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the Collection as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:string">
+               <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="ChapterList">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of one or more Chapters.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="Chapter" maxOccurs="unbounded" type="ern:Chapter">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Chapter contained in a Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the ChapterList as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:string">
+               <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="Character">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Character. A Character may be described through Name, Identifier and Roles.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="CharacterPartyReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Reference for a Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:IDREF">
+                  <xs:pattern value="P[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="Performer" minOccurs="0" type="ern:Contributor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Name, Identifier and Role(s) of a Performer.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="SequenceNumber" type="xs:integer">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The number indicating the order of the Character in a group of Characters. This is represented in an XML schema as an XML Attribute. </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="CommercialModelType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a CommercialModelType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:CommercialModelType_ERN">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the CommercialModelType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the CommercialModelType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="ConditionForRightsClaimPolicy">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Condition.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named ConditionForRightsClaimPolicy to disambiguate it from the basic mwnl:Condition Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="Value" type="xs:decimal">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The numeric value of the Condition.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Unit" type="avs:UnitOfConditionValue">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A UnitOfMeasure for the condition value.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ReferenceCreation" minOccurs="0" type="avs:ReferenceCreation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Creation that is used as a reference when the unit is Percent, so it can be expressed whether the value is a percentage of the reference Resource for which rights are claimed or of a consumer's UserGeneratedContent.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RelationalRelator" type="avs:RelationalRelator">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Relator expressing the accuracy of the condition value.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MeasurementType" minOccurs="0" type="avs:MeasurementType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type to signal whether the Measurement should be made on the audio, the video, either or both. The absence of this element means that the terms of the contract between MessageSender and MessageRecipient rule.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="Contributor">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of the Name, Identifier and Role(s) of a Contributor to a Resource.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ContributorPartyReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Reference for a Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:IDREF">
+                  <xs:pattern value="P[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="Role" minOccurs="0" maxOccurs="unbounded" type="ern:ContributorRole">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Role played by the Contributor.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="InstrumentType" minOccurs="0" maxOccurs="unbounded" type="ern:InstrumentType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of musical Instrument played by the Contributor.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="HasMadeFeaturedContribution" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating whether the Party is a featured Artist (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="HasMadeContractedContribution" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating whether the Party is an Artist that has a contract for its part in creating the Resource (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsCredited" minOccurs="0" type="ern:IsCredited">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating whether the Contributor is credited as having played a role in creating the Recording (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayCredits" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayCredits">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Role for which the Party is credited.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="SequenceNumber" type="xs:integer">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The number indicating the order of the ResourceContributor in a group of ResourceContributors that have contributed to a Resource. This is represented in an XML schema as an XML Attribute. </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="CoreArea">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of the core part of a Video.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="TopLeftCorner">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The position of the top left corner of the core area measured in Pixels. The position is given as two coordinate values separated by a comma, the top left pixel being 0,0.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:pattern value="[0-9]+,[0-9]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="BottomRightCorner">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The position of the bottom right corner of the core area measured in Pixels. The position is given as two coordinate values separated by a comma, the top left pixel being 0,0.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:pattern value="[0-9]+,[0-9]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="CourtesyLineWithDefault">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a CourtesyLine.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named CourtesyLineWithDefault to disambiguate it from the basic CourtesyLine Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script of the CourtesyLine as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Territory to which the CourtesyLine applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsDefault" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="Deal">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details (in full or in summary) of a Deal made between a DSP (as Licensee) and a Licensor of Works or Releases. When any new DealTerms are added or removed from an existing Deal (different UseTypes, Prices, Territories, DistributionChannels) then a new Deal is created, and (if appropriate) the ValidityPeriod of the existing Deal should be terminated. The only changes which should be made to the DealTerms of an existing Deal are corrections required because of an earlier error or omission, or the addition of an EndDate to the Deal's ValidityPeriod.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="DealReference" minOccurs="0" maxOccurs="unbounded" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Reference to a TextDocument containing details of the Deal (in the form of an Identifier, Name or Description).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsCommunicatedOutOfBand" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating whether the Deal is communicated outside the usual ERN delivery and identified by an Identifier in the DealReference element (=true) or not (=false). It would be up to the MessageSender and MessageRecipient to ensure that this Deal Identifier is unique.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DealTerms" minOccurs="0" type="ern:DealTerms">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the terms of the Deal.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/cancelling-a-deal-before-street-date</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DealTechnicalResourceDetailsReferenceList" minOccurs="0" type="ern:DealTechnicalResourceDetailsReferenceList">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing a list of DealTechnicalResourceDetailsReferences for the Deal.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DistributionChannelPage" minOccurs="0" maxOccurs="unbounded" type="ern:DistributionChannelPage">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a WebPage for the DistributionChannel.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="DealList">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of one or more Deals.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ReleaseDeal" maxOccurs="unbounded" type="ern:ReleaseDeal">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of one or more Deals pertaining to one or more Releases.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/multiple-deals-for-one-release</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/newreleasemessage-with-no-deal</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/complex-deals-can-be-dangerous</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ReleaseVisibility" minOccurs="0" maxOccurs="unbounded" type="ern:ReleaseVisibility">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a set of Dates specifying when a Release can be shown to Consumers.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="TrackReleaseVisibility" minOccurs="0" maxOccurs="unbounded" type="ern:TrackReleaseVisibility">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a set of Dates specifying when a TrackRelease can be shown to Consumers.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="DealResourceReferenceList">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of one or more Resources relating to a Deal.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="DealResourceReference" maxOccurs="unbounded">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Reference for a Resource (specific to this Message). This is a LocalResourceAnchorReference starting with the letter A.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:IDREF">
+                  <xs:pattern value="A[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="DealTechnicalResourceDetailsReferenceList">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing a list of DealTechnicalResourceDetailsReferences.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="DealTechnicalResourceDetailsReference" maxOccurs="unbounded">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Reference for a Composite specifying technical details of a Resource (specific to this Message). This is a LocalTechnicalResourceDetailsAnchorReference starting with the letter T.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:IDREF">
+                  <xs:pattern value="T[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="DealTerms">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of the terms of a Deal.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:choice minOccurs="0">
+            <xs:element name="TerritoryCode" maxOccurs="unbounded" type="ern:CurrentTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Territory in which the Deal applies. Either this Element or ExcludedTerritory must be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="ExcludedTerritoryCode" maxOccurs="unbounded" type="ern:CurrentTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Territory in which the Deal does not apply. Either this Element or Territory must be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:choice>
+         <xs:element name="ValidityPeriod" maxOccurs="unbounded" type="ern:PeriodWithStartDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details about a Period of Time during which the Deal is valid. To indicate a Deal that is valid at the time of sending of a NewReleaseMessage, the MessageSender should use a StartDate or StartDateTime set in the past. No EndDate in this Composite means that the Deal is valid until further notice. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/general-implementation-guidance/licensing-the-standards/ddex-party-identifier-(dpid)</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/start-dates%2C-end-dates%2C-start-datetimes-and-end-datetimes</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CommercialModelType" minOccurs="0" maxOccurs="unbounded" type="ern:CommercialModelType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the fundamental business model which applies to the Deal (e.g. SubscriptionModel and PayAsYouGoModel). The CommercialModelType indicates how the Consumer pays for the Service or Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="UseType" minOccurs="0" maxOccurs="unbounded" type="ern:DiscoverableUseType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a nature of a Service, or a Release, as used by a Consumer. The UseType is mandatory unless the terms of the Deal were communicated beforehand (possibly out of band) and then referenced using a DealReference.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="UserInterfaceType" minOccurs="0" maxOccurs="unbounded" type="ern:UserInterfaceType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a physical interface by which a Consumer uses a Service or Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CarrierType" minOccurs="0" maxOccurs="unbounded" type="ern:CarrierType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Carrier.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="TechnicalInstantiation" minOccurs="0" type="ern:DealTermsTechnicalInstantiation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing technical details of the Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NumberOfUsages" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The number of times a Release can be used under the terms of the Deal.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:choice minOccurs="0">
+            <xs:element name="DistributionChannel" maxOccurs="unbounded" type="ern:DSP">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the DSP through whose DistributionChannel the sales are permitted. If none are provided no limitations on the DistributionChannels are given.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="ExcludedDistributionChannel" maxOccurs="unbounded" type="ern:DSP">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of excluded DSP. This is used in an aggregator model where all agreed partners of the aggregators may use a ReleaseDeal, except those that are listed herein.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:choice>
+         <xs:element name="RightsClaimPolicy" minOccurs="0" maxOccurs="unbounded" type="ern:RightsClaimPolicy">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a rights claim policy.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PriceInformation" minOccurs="0" maxOccurs="unbounded" type="ern:PriceInformationWithType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Price. Note that this Price applies to all UseTypes referenced in this Composite.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/price-information</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:choice minOccurs="0">
+            <xs:element name="IsPromotional" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether a special Deal is made between the Licensor and the Licensee (=true) or not (=false) regarding the royalties or payments due to be paid for Releases distributed under this Deal.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="PromotionalCode" type="ern:PromotionalCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of a PromotionalCode.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:choice>
+         <xs:element name="IsPreOrderDeal" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating whether the Deal is covering only the period where the Release can be purchased by a consumer but not yet fulfilled (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="InstantGratificationResourceList" minOccurs="0" type="ern:DealResourceReferenceList">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of one or more Resources that are only available for download as soon as the Release is purchased (i.e. before the ReleaseDate).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PhysicalReturns" minOccurs="0" type="ern:PhysicalReturns">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of physical returns.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NumberOfProductsPerCarton" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A number of Products per carton. This is the smallest number of Products that can be ordered.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="DealTermsTechnicalInstantiation">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing technical details of a Release.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="VideoDefinitionType" minOccurs="0" type="ern:VideoDefinitionType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of resolution (or definition) in which a Video is provided.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CodingType" minOccurs="0" type="avs:CodingType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of coding used to encode a Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="BitRate" minOccurs="0" type="ern:BitRate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the BitRate for the audio data and a UnitOfMeasure (the default is kbps).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="Deity">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Deity.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Territory to which the Deity applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsDefault" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="DelegatedUsageRights">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of the kinds of usage for which Rights have been delegated.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="UseType" maxOccurs="unbounded" type="ern:UseType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the use for which Rights are delegated.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PeriodOfRightsDelegation" minOccurs="0" type="ern:Period">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details about a Period of Time for which the delegation of usage Rights applies. Periods are typically described by at least a StartDate or EndDate.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="TerritoryOfRightsDelegation" minOccurs="0" maxOccurs="unbounded" type="ern:AllTerritoryCode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Territory for which the delegation of usage rights applies.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="DescriptionWithTerritory">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Description.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named DescriptionWithTerritory to disambiguate it from the basic Description Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script of the Description as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Territory to which the Description applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsDefault" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="DetailedCue">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Cue.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named DetailedCue to disambiguate it from the basic Cue Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="CueUseType" minOccurs="0" type="ern:CueUseType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a UseType of the Cue. It can be expected that this element will be contractually mandatory in many communications of cue sheets to music rights societies.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CueThemeType" minOccurs="0" type="ern:CueThemeType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ThemeType for the Creation referenced in the Cue.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CueVocalType" minOccurs="0" type="ern:CueVocalType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a VocalType for the Creation referenced in the Cue.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CueVisualPerceptionType" minOccurs="0" type="ern:CueVisualPerceptionType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a VisualPerceptionType for the Creation referenced in the Cue.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CueOrigin" minOccurs="0" type="ern:CueOrigin">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a CueOrigin for the Cue. It can be expected that this element will be contractually mandatory in many communications of cue sheets to music rights societies.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:choice minOccurs="0">
+            <xs:element name="ResourceId" type="ern:ResourceId">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of a ResourceId.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="WorkId" type="ern:MusicalWorkId">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of a WorkId.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:choice>
+         <xs:element name="DisplayTitleText" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayTitleText">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the Work referenced in the Cue, as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayTitle" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the Work referenced in the Cue, as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AdditionalTitle" minOccurs="0" maxOccurs="unbounded" type="ern:AdditionalTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an AdditionalTitle of the Work referenced in the Cue. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Contributor" minOccurs="0" maxOccurs="unbounded" type="ern:Contributor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Contributor of the Work referenced in the Cue.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsDance" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating whether a Creation contains dancing (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="HasMusicalContent" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating whether whether the Creation referenced in the Cue contains musical content such as a SoundRecording or a MusicalWork (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PLine" minOccurs="0" maxOccurs="unbounded" type="ern:PLine">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the PLine for the Cue.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CLine" minOccurs="0" maxOccurs="unbounded" type="ern:CLine">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the CLine for the Cue.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="StartTime" minOccurs="0" type="xs:duration">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The start time of the Creation, measured from the start of the Resource from which the CueSheet is referenced (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Duration" minOccurs="0" type="xs:duration">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Duration of the use of the Creation that is referenced in the CueCreationReference (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="EndTime" minOccurs="0" type="xs:duration">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The end time of the Creation, measured from the start of the Resource from which the CueSheet is referenced (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="DetailedCueSheet">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a CueSheet.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="CueSheetId" minOccurs="0" maxOccurs="unbounded" type="ern:ProprietaryId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a CueSheetId of the CueSheet.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CueSheetReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier (specific to the Message) of the CueSheet within the Release which contains it. This is a LocalCueSheetAnchor starting with the letter Q.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:ID">
+                  <xs:pattern value="Q[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="CueSheetType" type="ern:CueSheetType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Type of the CueSheet.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Cue" maxOccurs="unbounded" type="ern:DetailedCue">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Cue.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="DetailedCueSheetList">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of one or more CueSheets.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="CueSheet" maxOccurs="unbounded" type="ern:DetailedCueSheet">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a CueSheet contained in a Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="DetailedResourceContributor">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of the Name, Identifier and Role(s) of a Contributor to a Resource.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named DetailedResourceContributor to disambiguate it from the basic ResourceContributor Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:choice>
+            <xs:element name="PartyId" maxOccurs="unbounded" type="ern:DetailedPartyId">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:sequence>
+               <xs:element name="PartyName" maxOccurs="unbounded" type="ern:PartyName">
+                  <xs:annotation>
+                     <xs:documentation source="ddex:Definition">A Composite containing details of the PartyName(s).</xs:documentation>
+                     <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision</xs:documentation>
+                     <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers</xs:documentation>
+                  </xs:annotation>
+               </xs:element>
+               <xs:element name="PartyId" minOccurs="0" maxOccurs="unbounded" type="ern:DetailedPartyId">
+                  <xs:annotation>
+                     <xs:documentation source="ddex:Definition">A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.</xs:documentation>
+                  </xs:annotation>
+               </xs:element>
+            </xs:sequence>
+         </xs:choice>
+         <xs:element name="Role" minOccurs="0" maxOccurs="unbounded" type="ern:ContributorRole">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Role played by the Contributor.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="InstrumentType" minOccurs="0" maxOccurs="unbounded" type="ern:InstrumentType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of musical Instrument played by the Artist.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="HasMadeFeaturedContribution" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating whether the Contributor is a featured Artist (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="HasMadeContractedContribution" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating whether the Contributor is an Artist that has a contract for its part in creating the Resource (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayCredits" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayCredits">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Role for which the Party is credited.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="SequenceNumber" type="xs:integer">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The number indicating the order of the ResourceContributor in a group of ResourceContributors that have contributed to a Resource. This is represented in an XML schema as an XML Attribute. </xs:documentation>
+            <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/sequencing-recording-artists-and-writers</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="DiscoverableUseType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a UseType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:UseType_ERN">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the UseType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsDiscoverable" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Flag indicating whether the Deal allows the ReleaseDistributor to include the release(s) referenced in the Deal to be indexed and searchable by Consumers on the ReleaseDistributor’s platform (=true) or not (=false). If this Attribute is not provided, it is assumed that this is True.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the UseType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="DisplayArtist">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of the Name, Identifier and Role(s) of a DisplayArtist of a Resource.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ArtistPartyReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Reference for a Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:IDREF">
+                  <xs:pattern value="P[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="DisplayArtistRole" type="ern:DisplayArtistRole">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Role played by the DisplayArtist.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ArtisticRole" minOccurs="0" maxOccurs="unbounded" type="ern:ContributorRole">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ContributorRole played by the DisplayArtist.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="TitleDisplayInformation" minOccurs="0" maxOccurs="unbounded" type="ern:TitleDisplayInformation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing information on how a RecordCompany wishes Artist information to be presented to Consumers as part of the Title (and in addition to displaying the DisplayArtist information).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="SequenceNumber" type="xs:integer">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The number indicating the order of the Resource DisplayArtist in a group of Artists that have contributed to a Resource. This is represented in an XML schema as an XML Attribute. </xs:documentation>
+            <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/sequencing-recording-artists-and-writers</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="DisplaySubTitle">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a SubTitle.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named DisplaySubTitle to disambiguate it from the basic SubTitle Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="SequenceNumber" type="xs:integer">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The number indicating the order of the SubTitle in a group of SubTitles. This is represented in an XML schema as an XML Attribute. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsDisplayedInTitle" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Flag indicating whether the SubTitle is displayed in the Title (=true) or not (=false). This is represented in an XML schema as an XML Attribute. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="SubTitleType" type="avs:SubTitleType">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Type of the SubTitle which defines its origin or the function it fulfils. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="DisplayTitle">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Title as the MessageSender suggests it should be shown to the Consumer.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="TitleText" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The text of the Title.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SubTitle" minOccurs="0" maxOccurs="unbounded" type="ern:DisplaySubTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a SubTitle of the Title, including Titles of Versions used to differentiate different versions of the same Title, as required by the GRid and ISRC ReferenceDescriptiveMetadataSets.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the Title as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:string">
+               <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A Territory to which the Title applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IsDefault" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="DisplayTitleText">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Title as the MessageSender suggests it should be shown to the Consumer.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="LanguageAndScriptCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script for the Elements of the Title as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+               <xs:simpleType>
+                  <xs:restriction base="xs:string">
+                     <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Territory to which the Title applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsDefault" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="DistributionChannelPage">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a WebPage for a DistributionChannel.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="PartyId" minOccurs="0" maxOccurs="unbounded" type="ern:DetailedPartyId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the PartyId for a Party owning the WebPage. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PageName" minOccurs="0" type="ern:Name">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the Name of the WebPage.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="URL" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A URL of the WebPage.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="UserName" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Identifier of a computer user who is granted maintenance access to the WebPage.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="EventDateTimeWithoutFlags">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of the DateTime and Place of an Event.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named EventDateTimeWithoutFlags to disambiguate it from the basic EventDateTime Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:dateTime">
+            <xs:attribute name="IsApproximate" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether the reported DateTime is approximate (=true) or exact (=false). This is represented in an XML schema as an XML Attribute. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Territory in which the Event occurred. This is represented in an XML schema as an XML Attribute. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="LocationDescription" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Description of the location in which the Event occurred. It offers the opportunity to describe a place more precisely than using the TerritoryCode. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="LanguageAndScriptCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script for the LocationDescription as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+               <xs:simpleType>
+                  <xs:restriction base="xs:string">
+                     <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="EventDateWithCurrentTerritory">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of an Event.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named EventDateWithCurrentTerritory to disambiguate it from the basic EventDate Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="ern:ddex_IsoDate">
+            <xs:attribute name="IsApproximate" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether the reported Date is approximate (=true) or exact (=false). This is represented in an XML schema as an XML Attribute. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The main Territory in which the Event occurred. This is represented in an XML schema as an XML Attribute. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="LocationDescription" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Description of the location in which the Event occurred. It offers the opportunity to describe a place more precisely than using the TerritoryCode. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="LanguageAndScriptCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script for the LocationDescription as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+               <xs:simpleType>
+                  <xs:restriction base="xs:string">
+                     <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="EventDateWithDefault">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of an Event.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named EventDateWithDefault to disambiguate it from the basic EventDate Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="ern:ddex_IsoDate">
+            <xs:attribute name="IsApproximate" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether the reported Date is approximate (=true) or exact (=false). This is represented in an XML schema as an XML Attribute. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="ApplicableTerritoryCode" type="avs:AllTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Territory in which the Event occurred. This is represented in an XML schema as an XML Attribute. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsDefault" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="EventDateWithoutFlags">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of an Event.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named EventDateWithoutFlags to disambiguate it from the basic EventDate Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="ern:ddex_IsoDate">
+            <xs:attribute name="IsApproximate" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether the reported Date is approximate (=true) or exact (=false). This is represented in an XML schema as an XML Attribute. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="ApplicableTerritoryCode" type="avs:AllTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The main Territory in which the Event occurred. This is represented in an XML schema as an XML Attribute. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="LocationDescription" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Description of the location in which the Event occurred. It offers the opportunity to describe a place more precisely than using the TerritoryCode. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="LanguageAndScriptCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script for the LocationDescription as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+               <xs:simpleType>
+                  <xs:restriction base="xs:string">
+                     <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="ExternalResourceLink">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of promotional or other material in digital form related to a Release.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="URL" maxOccurs="unbounded" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A URL of the linked external Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ValidityPeriod" minOccurs="0" type="ern:PeriodWithoutFlags">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details about the Period of Time during which the ExternalResourceLink is active. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/general-implementation-guidance/licensing-the-standards/ddex-party-identifier-(dpid)</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ExternalLink" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier which provides a communication link to the related external Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ExternallyLinkedResourceType" minOccurs="0" maxOccurs="unbounded" type="ern:ExternallyLinkedResourceType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Type of a Resource pointed to by the ExternalResourceLink.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="FileFormat" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The FileFormat of the external Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="Fingerprint">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Fingerprint and its governing algorithm.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="Algorithm" type="ern:FingerprintAlgorithmType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Type of Algorithm governing the Fingerprint.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Version" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier of the Version of the FingerprintAlgorithm.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Parameter" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A parameter of the FingerprintAlgorithm.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:choice minOccurs="0">
+            <xs:element name="File" type="ern:File">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of a File containing the Fingerprint.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:sequence>
+               <xs:element name="DataType" type="avs:BinaryDataType">
+                  <xs:annotation>
+                     <xs:documentation source="ddex:Definition">The datatype of the Fingerprint.</xs:documentation>
+                  </xs:annotation>
+               </xs:element>
+               <xs:element name="FingerprintValue" type="xs:string">
+                  <xs:annotation>
+                     <xs:documentation source="ddex:Definition">The value of the Fingerprint.</xs:documentation>
+                  </xs:annotation>
+               </xs:element>
+            </xs:sequence>
+         </xs:choice>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="Image">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of an Image. </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ResourceReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier (specific to the Message) of the Image within the Release which contains it. This is a LocalResourceAnchor starting with the letter A.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:ID">
+                  <xs:pattern value="A[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="Type" type="ern:ImageType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Type of the Image.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceId" maxOccurs="unbounded" type="ern:ResourceProprietaryId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of Identifiers of the Image.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayTitleText" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayTitleText">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the Image as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayTitle" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the Image as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AdditionalTitle" minOccurs="0" maxOccurs="unbounded" type="ern:AdditionalTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an AdditionalTitle of the Image. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="VersionType" minOccurs="0" maxOccurs="unbounded" type="ern:VersionType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Type of Version of the Image.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayArtistName" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayArtistNameWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayArtist" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the DisplayArtist for the Image. The DisplayArtist may be described through Name, Identifier and Roles.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Contributor" minOccurs="0" maxOccurs="unbounded" type="ern:Contributor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Contributor to the Image.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceRightsController" minOccurs="0" maxOccurs="unbounded" type="ern:ResourceRightsController">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of RightsController of Rights in the Image.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="WorkRightsController" minOccurs="0" maxOccurs="unbounded" type="ern:WorkRightsController">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of RightsController of Rights in the Work.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CLine" minOccurs="0" maxOccurs="unbounded" type="ern:CLineWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the CLine for the Image.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CourtesyLine" minOccurs="0" maxOccurs="unbounded" type="ern:CourtesyLineWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured on the Image.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CreationDate" minOccurs="0" type="ern:EventDateWithoutFlags">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the Image was created. This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="FirstPublicationDate" minOccurs="0" maxOccurs="unbounded" type="ern:FulfillmentDateWithTerritory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the Image was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ParentalWarningType" minOccurs="0" maxOccurs="unbounded" type="ern:ParentalWarningTypeWithTerritory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the classification of the Image according to advice which it carries about the level of explicitness or offensiveness of its content.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RelatedRelease" minOccurs="0" maxOccurs="unbounded" type="ern:RelatedRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Image.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RelatedResource" minOccurs="0" maxOccurs="unbounded" type="ern:RelatedResource">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Image.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ContainsHiddenContent" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the Image contains content that is hidden in some way from the Consumer (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Description" minOccurs="0" maxOccurs="unbounded" type="ern:DescriptionWithTerritory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing a Description of the subject of the Image.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="TechnicalDetails" minOccurs="0" maxOccurs="unbounded" type="ern:TechnicalImageDetails">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing technical details of the Image.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the Image as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:string">
+               <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="IsSupplemental" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether the Image is provided in a addition to the Resources that form part of the Release (=true) or not (=false). If the flag is set to false (or absent) the Image is part of at least one Release in the message. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="IsCredited">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Flag indicating whether the Contributor is credited as having played a role in creating the Recording.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:boolean">
+            <xs:attribute name="MayBeShared" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Flag indicating whether this information may be shared (=true) or not (=false). If the Flag is not present, the Contributor may be credited.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="LinkedReleaseResourceReference">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a LinkedReleaseResourceReference for a Resource which is linked to a ContentItem.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="ern:ddex_LocalResourceAnchorReference">
+            <xs:attribute name="LinkDescription" type="avs:LinkDescription">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A description of the link for the ReleaseResourceReference.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="LanguageAndScriptCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script for the LinkDescription as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+               <xs:simpleType>
+                  <xs:restriction base="xs:string">
+                     <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the LinkDescription. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the LinkDescription. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="LocationAndDateOfSession">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Session.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="SessionType" minOccurs="0" maxOccurs="unbounded" type="ern:SessionType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Type of Session.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Period" minOccurs="0" type="ern:Period">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details about a Period of the Session. Periods are typically described by at least a StartDate or EndDate.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Venue" minOccurs="0" maxOccurs="unbounded" type="ern:Venue">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the venue where the Session took place.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Comment" minOccurs="0" type="ern:TextWithFormat">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing a human-readable Comment about the Session.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Contributor" minOccurs="0" maxOccurs="unbounded" type="ern:PartyWithRole">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Contributor.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="Party">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Party.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="PartyReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier (specific to the Message) of the Party. This is a LocalPartyAnchor starting with the letter P.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:ID">
+                  <xs:pattern value="P[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:choice>
+            <xs:element name="PartyId" maxOccurs="unbounded" type="ern:DetailedPartyId">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:sequence>
+               <xs:element name="PartyName" maxOccurs="unbounded" type="ern:PartyNameWithTerritory">
+                  <xs:annotation>
+                     <xs:documentation source="ddex:Definition">A Composite containing details of the PartyName(s).</xs:documentation>
+                  </xs:annotation>
+               </xs:element>
+               <xs:element name="PartyId" minOccurs="0" maxOccurs="unbounded" type="ern:DetailedPartyId">
+                  <xs:annotation>
+                     <xs:documentation source="ddex:Definition">A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.</xs:documentation>
+                  </xs:annotation>
+               </xs:element>
+            </xs:sequence>
+         </xs:choice>
+         <xs:element name="Affiliation" minOccurs="0" maxOccurs="unbounded" type="ern:Affiliation">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an affiliation for the Party.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RelatedParty" minOccurs="0" maxOccurs="unbounded" type="ern:RelatedParty">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a PartyRelatedPartyReference referring to a Party that is related to the current Party. This can be used to express, for instance, relationships between a band and its members or between a label and its parent company.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ArtistProfilePage" minOccurs="0" maxOccurs="unbounded" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A URL of a WebPage for the Artist.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="PartyList">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of one or more Parties.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="Party" maxOccurs="unbounded" type="ern:Party">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Party.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="PartyNameWithTerritory">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a PartyName. Name details for a Party typically either contain a FullName or a KeyName.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named PartyNameWithTerritory to disambiguate it from the basic PartyName Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="FullName" type="ern:Name">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the complete Name of the Party, in its normal form of presentation (e.g. John H. Smith, Acme Music Inc, the Beatles).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="FullNameAsciiTranscribed" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The FullName transcribed using 7-bit ASCII code.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="FullNameIndexed" minOccurs="0" type="ern:Name">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the complete Name of the Party in the form in which it normally appears in an alphabetic index, with the KeyName first (e.g. Smith, John H.; Beatles, The).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NamesBeforeKeyName" minOccurs="0" type="ern:Name">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the Name(s) preceding the KeyName in the FullName (and that is placed after it in a FullNameIndexed). Examples: 'George' in 'George Michael'; 'John Fitzgerald' in 'John Fitzgerald Kennedy'. Not all PartyNames have a NamesBeforeKeyName (e.g. Madonna, EMI Music Inc).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="KeyName" minOccurs="0" type="ern:Name">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the Part of a Name of the Party normally used to index an entry in an alphabetical list, such as 'Smith' (in John Smith) or 'Garcia Marquez' or 'Madonna' or 'Francis de Sales' (in Saint Francis de Sales). For persons, this normally corresponds to the 'family name' or names, which in Western name forms usually comes as a surname at the end of a FullName, and in Asian name forms often at the beginning of a FullName. </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NamesAfterKeyName" minOccurs="0" type="ern:Name">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the Name(s) following the KeyName. Example:'Ibrahim' (in Anwar Ibrahim). This is common, e.g., in many Asian personal name forms where a FullName begins with the KeyName, which is followed by other names.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AbbreviatedName" minOccurs="0" type="ern:Name">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing a short version of the PartyName (e.g. for use on devices with a small display).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the PartyName as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IsNickname" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Name is a nickname (=true) or not (=false). A nickname is a substitute for the proper name (e.g. an affective or diminutive name) and not to be confused with a pseudonym or a stage name.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IsStageName" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Name is a stage name (=true) or not (=false).</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IsLegalName" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Name is a legal name (=true) or not (=false).</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A Territory to which the PartyName applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IsDefault" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="PartyWithRole">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Party.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named PartyWithRole to disambiguate it from the basic mead:Party Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ISNI" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An International Standard Name Identifier, the ISO 27729 Standard Identifier for names, of the Party for which information is provided. DDEX will enforce the syntax [0-9]{15}[X0-9] using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DPID" minOccurs="0">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Identifier of the Party for which information is provided according to the DdexPartyId standard DDEX-DPID.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:pattern value="PADPIDA[a-zA-Z0-9]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="IpiNameNumber" minOccurs="0">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Interested Party Identifier, a CISAC standard Identifier, of the Party for which information is provided. An IpiNameNumber comprises 11 digits.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:pattern value="[0-9]{11}"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="IPN" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An International Performer Number, an IPDA Identifier, of the Party for which information is provided.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ProprietaryId" minOccurs="0" maxOccurs="unbounded" type="ern:ProprietaryId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ProprietaryIdentifier of the Party for which information is provided.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PartyName" minOccurs="0" type="ern:PartyNameWithTerritory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Name of the Contributor.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Role" minOccurs="0" type="ern:ResourceContributorRole">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Role played by the Contributor.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="PeriodWithStartDate">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details about a Period of Time with a mandatory StartDate or StartDateTime.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named PeriodWithStartDate to disambiguate it from the basic Period Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:choice>
+         <xs:sequence>
+            <xs:element name="StartDate" type="ern:EventDateWithCurrentTerritory">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DD). The StartDate must be no later than the EndDate if both are provided. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="EndDate" minOccurs="0" type="ern:EventDateWithCurrentTerritory">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DD). The EndDate must not be earlier than the StartDate if both are provided. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:sequence>
+         <xs:sequence>
+            <xs:element name="StartDateTime" type="ern:EventDateTimeWithoutFlags">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the DateTime and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DDThh:mm:ss). The StartDateTime must be no later than the EndDateTime if both are provided.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="EndDateTime" minOccurs="0" type="ern:EventDateTimeWithoutFlags">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the DateTime and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DDThh:mm:ss). The EndDateTime must not be earlier than the StartDateTime if both are provided.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:sequence>
+      </xs:choice>
+   </xs:complexType>
+   <xs:complexType name="PeriodWithoutFlags">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details about a Period of Time. Periods are typically describedby at least a StartDate or EndDate (or StartDateTime or EndDateTime) where the StartDate(Time) and EndDate(Time) are included in the Period. Thus a one-day period can be described by using the same date in the StartDate and EndDate. If two subsequent Periods form a continuum (i.e. with no break in-between) there are two ways to express this: (a) if using dates, the EndDate of the first Period must be one day before the StartDate of the second Period; (b) if using date times, the EndDateTime of the first Period must be the same as the StartDateTime of the second Period.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named PeriodWithoutFlags to disambiguate it from the basic Period Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:choice>
+         <xs:sequence>
+            <xs:element name="StartDate" minOccurs="0" type="ern:EventDateWithCurrentTerritory">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DD). The StartDate must be no later than the EndDate if both are provided. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="EndDate" minOccurs="0" type="ern:EventDateWithCurrentTerritory">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DD). The EndDate must not be earlier than the StartDate if both are provided. StartDate and EndDate are deprecated and StartDateTime/EndDateTime should be used instead. DDEX advises that StartDate and EndDate may be removed at a future date and therefore recommends against using them.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:sequence>
+         <xs:sequence>
+            <xs:element name="StartDateTime" minOccurs="0" type="ern:EventDateTimeWithoutFlags">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the DateTime and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DDThh:mm:ss). The StartDateTime must be no later than the EndDateTime if both are provided.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="EndDateTime" minOccurs="0" type="ern:EventDateTimeWithoutFlags">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the DateTime and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DDThh:mm:ss). The EndDateTime must not be earlier than the StartDateTime if both are provided.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:sequence>
+      </xs:choice>
+   </xs:complexType>
+   <xs:complexType name="PhysicalReturns">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of physical returns.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="PhysicalReturnsAllowed" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether physical returns are allowed (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="LatestDateForPhysicalReturns" minOccurs="0" type="ern:ddex_IsoDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Date which is the latest one for physical returns (in ISO 8601 format: YYYY-MM-DD).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="PreviewDetails">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a preview.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="TopLeftCorner" minOccurs="0">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The position of the top left corner of the preview measured in Pixels from the top left corner of the Resource. The position is given as two coordinate values separated by a comma, the top left pixel being 0,0.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:pattern value="[0-9]+,[0-9]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="BottomRightCorner" minOccurs="0">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The position of the bottom right corner of the preview measured in Pixels from the top left corner of the Resource. The position is given as two coordinate values separated by a comma, the top left pixel being 0,0.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:pattern value="[0-9]+,[0-9]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="ExpressionType" type="avs:ExpressionType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of expression indicating how this should be perceived, e.g. as instruction (meaning that this has to be done to create the preview) or as information (meaning that this has been done to craete the preview).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="PriceInformationWithType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Price.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named PriceInformationWithType to disambiguate it from the basic PriceInformation Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="PriceCode" minOccurs="0" type="ern:PriceType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing further details of the Price, including a Price code that informs the DSP of the Price the Release should be offered at, often in combination with a rate card. This element should not be combined with WholesalePricePerUnit or BulkOrderWholesalePricePerUnit.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/price-information</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="WholesalePricePerUnit" minOccurs="0" type="ern:Price">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a wholesale Price for a single unit of Usage, which informs the informs the DSP of the Price the Release should be offered at. Note that this Price applies to all UseTypes referenced in a DealTerm Composite. This element should not be combined with PriceType.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="BulkOrderWholesalePricePerUnit" minOccurs="0" type="ern:Price">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a wholesale Price for a single unit, which informs the informs the DSP of the Price the Release should be offered at. Note that the size of a bulk order is defined in the contract between MessageSender and the MessageRecipient. This element should not be combined with PriceType.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SuggestedRetailPrice" minOccurs="0" type="ern:Price">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a suggested retail Price.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="PriceType" type="avs:PriceInformationType">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A Type of the Price. This is represented in an XML schema as an XML Attribute. If no value is provided, a StandardRetailPrice is assumed.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Namespace" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Namespace of the PriceInformationType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="UserDefinedValue" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A UserDefined value of the PriceInformationType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="PurgedRelease">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a DDEX Release to be purged.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ReleaseId" minOccurs="0" type="ern:ReleaseId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of ReleaseIds. If available, a GRid has to be used. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Title" minOccurs="0" maxOccurs="unbounded" type="ern:Title">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Contributor" minOccurs="0" maxOccurs="unbounded" type="ern:DetailedResourceContributor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Contributor to the Release.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="Raga">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Raga.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Territory to which the Raga applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsDefault" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="RelatedRelease">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to a Resource, Release or Product.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ReleaseRelationshipType" type="ern:ReleaseRelationshipType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Type of the relationship between the two Releases.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ReleaseId" type="ern:ReleaseId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of ReleaseIds. If available, a GRid shall always to be used. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayTitleText" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayTitleText">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayTitle" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AdditionalTitle" minOccurs="0" maxOccurs="unbounded" type="ern:AdditionalTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an AdditionalTitle of the Release. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayArtistName" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayArtistNameWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the Name to be used by a DSP when presenting Artist details of the Release to a Consumer.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ReleaseLabelReference" minOccurs="0" maxOccurs="unbounded" type="ern:ReleaseLabelReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Reference for a label of the Release (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ReleaseDate" minOccurs="0" type="ern:EventDateWithoutFlags">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the related Release was or will be first made available for Usage in its current form, whether for physical or electronic/online distribution (in ISO 8601 format: YYYY-MM-DD).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="OriginalReleaseDate" minOccurs="0" type="ern:EventDateWithoutFlags">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the collection of tracks for the Release (e.g. the equivalent physical album on vinyl) was or will be first made available for Usage, whether for physical or electronic/online distribution (in ISO 8601 format: YYYY-MM-DD).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="RelatedResource">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a ResourceRelatedResourceReference for the case where one Resource is related to another one.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ResourceRelationshipType" type="avs:ResourceRelationshipType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of relationship between two Resources.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:choice>
+            <xs:element name="ResourceRelatedResourceReference">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Reference for a related Resource (specific to this Message). This is a LocalResourceAnchorReference starting with the letter A.</xs:documentation>
+               </xs:annotation>
+               <xs:simpleType>
+                  <xs:restriction base="xs:IDREF">
+                     <xs:pattern value="A[\d\-_a-zA-Z]+"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:element>
+            <xs:element name="ResourceId" type="ern:ResourceId">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of ResourceIds, which allows referencing a related Resource that is not in this message.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:choice>
+         <xs:element name="Timing" minOccurs="0" maxOccurs="unbounded" type="ern:Timing">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a StartTime and/or a Duration of the related Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="Release">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a DDEX Release.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ReleaseReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier (specific to the Message) of the Release. Used to link the Release to one or more Deal(s). This is a LocalReleaseAnchor starting with the letter R.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:ID">
+                  <xs:pattern value="R[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="ReleaseType" maxOccurs="unbounded" type="ern:ReleaseTypeForReleaseNotification">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the form in which a ReleaseCreator anticipates offering the Release to Consumers. The RelaseType is a marketing term and more than one value may be provided.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/release-types-for-trackreleases</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ReleaseId" type="ern:ReleaseId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of ReleaseIds. If available, a GRid has to be used. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayTitleText" maxOccurs="unbounded" type="ern:DisplayTitleText">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayTitle" maxOccurs="unbounded" type="ern:DisplayTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AdditionalTitle" minOccurs="0" maxOccurs="unbounded" type="ern:AdditionalTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an AdditionalTitle of the Release. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayArtistName" maxOccurs="unbounded" type="ern:DisplayArtistNameWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the Name to be used by a DSP when presenting Artist details of the Release to a Consumer.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayArtist" maxOccurs="unbounded" type="ern:DisplayArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the DisplayArtist for the Release. The DisplayArtist may be described through Name, Identifier and Roles.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ReleaseLabelReference" maxOccurs="unbounded" type="ern:ReleaseLabelReferenceWithParty">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Reference for a label of the Release (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AdministratingRecordCompany" minOccurs="0" maxOccurs="unbounded" type="ern:AdministratingRecordCompanyWithReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the AdministratingRecordCompany for the Release. </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PLine" minOccurs="0" maxOccurs="unbounded" type="ern:PLineWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the PLine for the Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CLine" minOccurs="0" maxOccurs="unbounded" type="ern:CLineWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the CLine for the Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CourtesyLine" minOccurs="0" maxOccurs="unbounded" type="ern:CourtesyLineWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for guests Artists or others featured on the Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Duration" minOccurs="0" type="xs:duration">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The sum of the Durations of all Resources contained in the Release (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Genre" maxOccurs="unbounded" type="ern:GenreWithTerritory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Genre to which the Release belongs.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ReleaseDate" minOccurs="0" maxOccurs="unbounded" type="ern:EventDateWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the Release was or will be first made available for Usage in its current form, whether for physical or electronic/online distribution (in ISO 8601 format: YYYY[-MM[-DD]]). This Element is for display and cataloguing purposes only.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="OriginalReleaseDate" minOccurs="0" maxOccurs="unbounded" type="ern:EventDateWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the collection of tracks for the Release (e.g. the equivalent physical album on vinyl) was or will be first made available for Usage, whether for physical or electronic/online distribution (in ISO 8601 format: YYYY[-MM[-DD]]). This Element is for display and cataloguing purposes only.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ReleaseVisibilityReference" minOccurs="0">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Reference for a set of visibility dates (specific to this Message) that applies to this Release. This defines when the Release can be shown to Consumers, not when a Consumer can get access to the Release. This is a LocalVisibilityAnchorReference starting with the letter V.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:IDREF">
+                  <xs:pattern value="V[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="ParentalWarningType" maxOccurs="unbounded" type="ern:ParentalWarningTypeWithTerritory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the classification of the Release according to advice which it carries about the level of explicitness or offensiveness of its content.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AvRating" minOccurs="0" maxOccurs="unbounded" type="ern:AvRating">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a rating for the Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RelatedRelease" minOccurs="0" maxOccurs="unbounded" type="ern:RelatedRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to this Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RelatedResource" minOccurs="0" maxOccurs="unbounded" type="ern:RelatedResource">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Resource which is related to this Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:choice minOccurs="0">
+            <xs:element name="IsSingleArtistCompilation" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Flag indicating whether the Release is a single-artist Compilation (=true) or not (=false). If this flag is set, the Release would typically be expected to be part of the discography of the main artist of the Release.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="IsMultiArtistCompilation" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether the Release is a multiartist Compilation (=true) or not (=false).</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:choice>
+         <xs:element name="ResourceGroup" type="ern:ResourceGroup">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a group of some or all of the Resources in the Release. ResourceGroups are used to signal groupings or sequences of Resources within a Release. Examples include individual carriers in a multi-carrier Release or classical Work groupings as well as the default order of Resources within a Release. ResourceGroups are typically not used with Releases that contain only one primary Resource such as TrackReleases.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/sequencing-resources</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ExternalResourceLink" minOccurs="0" maxOccurs="unbounded" type="ern:ExternalResourceLink">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of promotional or other material related to the Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="TargetURL" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A URL of a sub-site or channel in the DSP’s system, where the Release should be made available to Consumers. </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Keywords" minOccurs="0" maxOccurs="unbounded" type="ern:KeywordsWithTerritory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Description of the Release containing Keywords.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Synopsis" minOccurs="0" maxOccurs="unbounded" type="ern:SynopsisWithTerritory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Synopsis of the Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Raga" minOccurs="0" maxOccurs="unbounded" type="ern:Raga">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Description of the melodic mode of a MusicalWork in the Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Tala" minOccurs="0" maxOccurs="unbounded" type="ern:Tala">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Description of the rhythmic pattern of a MusicalWork in the Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Deity" minOccurs="0" maxOccurs="unbounded" type="ern:Deity">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A deity name relating to the Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="HiResMusicDescription" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Description containing an explanation that is required if not all the Tracks are eligible for HiResMusic (e.g. if some tracks were up-sampled to 96 kHz/24 bit from a 44.1 kHz/24 bit source during mastering).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsSoundtrack" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the Release is a Soundtrack (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsHiResMusic" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the Release meets the criteria to carry the HiResMusic logo, provided the MessageRecipient meets all the other requirements to use it (note that an album with a majority of tracks being eligible but the remainder not being eligible can still carry the logo) (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MarketingComment" minOccurs="0" maxOccurs="unbounded" type="ern:MarketingComment">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing a Comment about the promotion and marketing of the Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the Release as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:string">
+               <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="ReleaseAdmin">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of Release administration.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ReleaseAdminId" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Identifier specified by the MessageSender that identifies a group of record company personnel to be granted access to the MessageRecipient’s systems to administer the Release. Note that the communication of user access credentials is out of scope for the NewReleaseMessage.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PersonnelDescription" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A textual Description of the group of people that are to be given access to the DSP’s system. This information is auxiliary to the ReleaseAdminId element, which is the authoritative source of information for the DSP.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SystemDescription" minOccurs="0" maxOccurs="unbounded" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A textual Description indicating which system a person in the group identified by the Release is allowed to access.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="ReleaseDeal">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of one or more Deals pertaining to one or more Releases.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="DealReleaseReference" maxOccurs="unbounded">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier (specific to the Message) of a Release in the Deal. This is a LocalReleaseAnchorReference starting with the letter R.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:IDREF">
+                  <xs:pattern value="R[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="Deal" maxOccurs="unbounded" type="ern:Deal">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Deal governing the Usage of all Releases identified in the ReleaseDeal Composite.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/deals-and-commercial-aspects/no-takedown-in-initial-deal</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="ReleaseId">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a ReleaseId. If available, a GRid should always to be used. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="GRid" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The GRid identifying the Release. This is the preferred Element and is mandatory if a GRid is available. A GRid comprises four parts: the xs:string 'A1', followed by five alphanumeric characters, ten alphanumeric characters and and one alphanumeric character. DDEX will enforce the syntax [a-zA-Z0-9]{18} using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ICPN" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An ICPN used as proxy for identification of the Release. Only applicable when the Release is an abstraction of a complete PhysicalProduct. An ICPN comprises 12 or 13 digits, depending whether it is an EAN (13) or a UPC (12). DDEX will enforce the syntax [0-9]{12,13} using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CatalogNumber" minOccurs="0" type="ern:CatalogNumber">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the CatalogNumber of the Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ProprietaryId" minOccurs="0" maxOccurs="unbounded" type="ern:ProprietaryId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ProprietaryIdentifier of the Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="ReleaseLabelReference">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Reference to a label of a specific Release.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="ern:ddex_LocalPartyAnchorReference">
+            <xs:attribute name="LanguageAndScriptCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script of the LabelName as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+               <xs:simpleType>
+                  <xs:restriction base="xs:string">
+                     <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="IsDefault" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="LabelType" type="avs:LabelType">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Type of Label. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the LabelType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the LabelType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Territory to which the LabelName applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="ReleaseLabelReferenceWithParty">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Reference to a label of a specific Release.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named ReleaseLabelReferenceWithParty to disambiguate it from the basic ReleaseLabelReference Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="ern:ddex_LocalPartyAnchorReference">
+            <xs:attribute name="LanguageAndScriptCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script of the LabelName as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+               <xs:simpleType>
+                  <xs:restriction base="xs:string">
+                     <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="IsDefault" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="LabelType" type="avs:LabelType">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Type of Label. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="AccessControlParty" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Party who is allowed to administer a Release on a ReleaseDistributor’s system. ReleaseCreator and ReleaseDistributor shall agree what the access rules for those people are and the exchange of username and password (or other means of authentication) is left to ReleaseCreator and ReleaseDistributor.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the LabelType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the LabelType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Territory to which the LabelName applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="ReleaseList">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of one or more Releases.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="Release" minOccurs="0" type="ern:Release">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a DDEX Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="TrackRelease" minOccurs="0" maxOccurs="unbounded" type="ern:TrackRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a DDEX TrackRelease.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="ReleaseVisibility">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of Dates specifying when a Release can be shown to Consumers.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="VisibilityReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier (specific to the Message) of the visibility date. This is a LocalVisibilityAnchor starting with the letter V.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:ID">
+                  <xs:pattern value="V[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="ReleaseDisplayStartDateTime" minOccurs="0" type="xs:dateTime">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DateTime on which the Release is made first available for display. If no ReleaseDisplayStartDateTime is provided, the StartDate for the Deal is used instead. The ReleaseDisplayStartDateTime may not be later than the StartDate for the Deal. If the MessageRecipient is not able to cater for such granular display policies, the MessageRecipient may be forced to not display any Release information until a much later date. This is a string in ISO 8601 format: YYYY-MM-DDThh:mm:ss.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CoverArtPreviewStartDateTime" minOccurs="0" type="xs:dateTime">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DateTime on which the cover art is made first available for display (it overrides the generic ReleaseDisplayStartDate if supplied). If no CoverArtPreviewStartDateTime is provided, the StartDate for the Deal is used instead. The CoverArtPreviewStartDateTime shall not be later than the StartDate of the Deal allowing the general availability of the referenced Release. This is a string in ISO 8601 format: YYYY-MM-DDThh:mm:ss.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="FullTrackListingPreviewStartDateTime" minOccurs="0" type="xs:dateTime">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DateTime on which the full Track list is made first available for display (it overrides the generic ReleaseDisplayStartDate if supplied). If no TrackListingPreviewStartDateTime is provided, the StartDate for the Deal is used instead. The TrackListingPreviewStartDateTime shall not be later than the StartDate of the Deal allowing the general availability of the referenced Release. This element is not applicable on Track Releases. This is a string in ISO 8601 format: YYYY-MM-DDThh:mm:ss.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="ResourceGroup">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a ResourceGroup. ResourceGroups are used to signal groupings or sequences of Resources within a Release. Examples include individual Carriers in a multi-carrier Release or classical Work groupings as well as the default order of Resources within a Release.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="DisplayTitleText" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayTitleText">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayTitle" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AdditionalTitle" minOccurs="0" maxOccurs="unbounded" type="ern:AdditionalTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an AdditionalTitle of the ResourceGroup. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SequenceNumber" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The number indicating the logical order of the ResourceGroup within all ResourceGroups at this level. The default value is 1, and the value must be incremented by 1 for each ResourceGroup occurring at a particular level.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:choice minOccurs="0">
+            <xs:element name="NoDisplaySequence" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Flag indicating whether a display sequence exists (=true) or not (=false).</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="DisplaySequence" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A sequence Identifier used for display purposes, consisting of a string that corresponds to the SequenceNumber, e.g. 'Side B' corresponding to '2'.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:choice>
+         <xs:element name="DisplayArtist" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the DisplayArtist for the ResourceGroup. The DisplayArtist may be described through Name, Identifier and Roles.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CarrierType" minOccurs="0" maxOccurs="unbounded" type="ern:CarrierType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Carrier.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Duration" minOccurs="0" type="xs:duration">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Duration of the ResourceGroup, if it is a SoundRecording or Video (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:choice minOccurs="0">
+            <xs:element name="ResourceGroupReleaseReference">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Identifier (specific to the Message) of a Release which has the same content as the ResourceGroup. This is a LocalReleaseAnchorReference starting with the letter R.</xs:documentation>
+               </xs:annotation>
+               <xs:simpleType>
+                  <xs:restriction base="xs:IDREF">
+                     <xs:pattern value="R[\d\-_a-zA-Z]+"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:element>
+            <xs:element name="ReleaseId" type="ern:ReleaseId">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of ReleaseIds of a Release which has the same content as the ResourceGroup. If available, a GRid has to be used. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:choice>
+         <xs:element name="ResourceGroup" minOccurs="0" maxOccurs="unbounded" type="ern:ResourceSubGroup">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ResourceGroup contained within this ResourceGroup. ResourceGroups are used to signal groupings or sequences of Resources within a Release. Examples include individual Carriers in a multi-carrier Release or classical Work groupings as well as the default order of Resources within a Release.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/sequencing-resources</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceGroupContentItem" minOccurs="0" maxOccurs="unbounded" type="ern:ResourceGroupContentItem">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Resource contained in the ResourceGroup.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="LinkedReleaseResourceReference" minOccurs="0" maxOccurs="unbounded" type="ern:LinkedReleaseResourceReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this Release. Example:cover art images associated with the ResourceGroup. This LocalAnchorReference is a xs:string starting with the letter A.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="ResourceGroupContentItem">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Resource which is a ContentItem of a ResourceGroup.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="SequenceNumber" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The number indicating the logical order of the ContentItem in its ResourceGroup.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:choice minOccurs="0">
+            <xs:element name="NoDisplaySequence" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Flag indicating whether a display sequence exists (=true) or not (=false).</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="DisplaySequence" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A sequence Identifier used for display purposes, consisting of a string that corresponds to the SequenceNumber, e.g. 'Side B' corresponding to '2'.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:choice>
+         <xs:element name="ReleaseResourceReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ReleaseResourceReference for the ContentItem (specific to this Message). The LocalAnchorReference in this Composite is a xs:string starting with the letter A.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:IDREF">
+                  <xs:pattern value="A[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="LinkedReleaseResourceReference" minOccurs="0" maxOccurs="unbounded" type="ern:LinkedReleaseResourceReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this ContentItem. Example: an Image, Text or NonMusicalWorkVideo associated with a SoundRecording. This LocalAnchorReference is a xs:string starting with the letter A.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsBonusResource" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether a Resource in a Release is additional to those on the original Release of which this is a Version (=true) or not (=false). If this Element is not provided, it is assumed that this is False.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsInstantGratificationResource" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether a Resource in a Release may be made available to consumers despite the distribution of the containing Release not having been permitted (=true) or not (=false). If this Element is not provided, it is assumed that this is False. The actual status of a Resource as an InstantGratificationResource is determined in the relevant Deal.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsPreOrderIncentiveResource" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating whether a Resource that is only available when the Release is purchased during a pre-order period (delivery is typically at ReleaseDate) (=true) or not (=false). If this Element is not provided, it is assumed that this is False. The actual status of a Resource as an PreOrderIncentiveResource is determined in the relevant Deal.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="ResourceList">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of one or more Resources. ResourceList provides a simple means of aggregating Resources without any explicit sequencing or grouping: if that is needed it is provided by the ResourceGroup Composite. </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="SoundRecording" minOccurs="0" maxOccurs="unbounded" type="ern:SoundRecording">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Video" minOccurs="0" maxOccurs="unbounded" type="ern:Video">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Image" minOccurs="0" maxOccurs="unbounded" type="ern:Image">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an Image.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Text" minOccurs="0" maxOccurs="unbounded" type="ern:Text">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Text.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SheetMusic" minOccurs="0" maxOccurs="unbounded" type="ern:SheetMusic">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a SheetMusic.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Software" minOccurs="0" maxOccurs="unbounded" type="ern:Software">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an item of Software.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="ResourceRightsController">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a RightsController for a Resource. RightsControllers are typically described by Name, Identifier and Role(s).</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="RightsControllerPartyReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Reference for a Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:IDREF">
+                  <xs:pattern value="P[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="RightsControlType" minOccurs="0" maxOccurs="unbounded" type="avs:RightsControllerRole">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A role that describes the Party involved in the administration of Rights.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:choice minOccurs="0">
+            <xs:element name="RightShareUnknown" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether the RightSharePercentage is unknown (=true) or not (=false).</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="RightSharePercentage" type="ern:Percentage">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The share of the licensed Rights owned by the RightsController. RightShare information is given as a xs:decimal value with up to 6 digits (e.g. '12.5' represents 12.5%). If no information is given, 100% is assumed.</xs:documentation>
+                  <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/communication-of-percentages</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:choice>
+         <xs:element name="DelegatedUsageRights" maxOccurs="unbounded" type="ern:DelegatedUsageRights">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the kinds of usage for which rights have been delegated.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="SequenceNumber" type="xs:integer">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The number indicating the order of the RightsController in a group of RightsControllers. This is represented in an XML schema as an XML Attribute. </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="ResourceSubGroup">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a ResourceGroup that is contained in another ResourceGroup.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="DisplayTitleText" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayTitleText">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayTitle" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the ResourceGroup as the MessageSender suggests it should be shown to the Consumer. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AdditionalTitle" minOccurs="0" maxOccurs="unbounded" type="ern:AdditionalTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an AdditionalTitle of the ResourceGroup. Typically this will apply to 'sub' ResourceGroups within a hierarchy, e.g., different Albums in a Set. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SequenceNumber" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The number indicating the logical order of the ResourceGroup within all ResourceGroups at this level. The default value is 1, and the value must be incremented by 1 for each ResourceGroup occurring at a particular level.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:choice minOccurs="0">
+            <xs:element name="NoDisplaySequence" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Flag indicating whether a display sequence exists (=true) or not (=false).</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="DisplaySequence" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A sequence Identifier used for display purposes, consisting of a string that corresponds to the SequenceNumber, e.g. 'Side B' corresponding to '2'.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:choice>
+         <xs:element name="DisplayArtist" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the DisplayArtist for the ResourceGroup. The DisplayArtist may be described through Name, Identifier and Roles.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CarrierType" minOccurs="0" maxOccurs="unbounded" type="ern:CarrierType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Carrier.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Duration" minOccurs="0" type="xs:duration">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Duration of the ResourceGroup, if it is a SoundRecording or Video (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:choice minOccurs="0">
+            <xs:element name="ResourceGroupReleaseReference">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Identifier (specific to the Message) of a Release which has the same content as the ResourceGroup. This is a LocalReleaseAnchorReference starting with the letter R.</xs:documentation>
+               </xs:annotation>
+               <xs:simpleType>
+                  <xs:restriction base="xs:IDREF">
+                     <xs:pattern value="R[\d\-_a-zA-Z]+"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:element>
+            <xs:element name="ReleaseId" type="ern:ReleaseId">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of ReleaseIds of a Release which has the same content as the ResourceGroup. If available, a GRid has to be used. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:choice>
+         <xs:element name="ResourceGroup" minOccurs="0" maxOccurs="unbounded" type="ern:ResourceSubGroup">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ResourceGroup contained within this ResourceGroup. ResourceGroups are used to signal groupings or sequences of Resources within a Release. Examples include individual Carriers in a multi-carrier Release or classical Work groupings as well as the default order of Resources within a Release.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/sequencing-resources</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceGroupContentItem" minOccurs="0" maxOccurs="unbounded" type="ern:ResourceGroupContentItem">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Resource contained in the ResourceGroup.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="LinkedReleaseResourceReference" minOccurs="0" maxOccurs="unbounded" type="ern:LinkedReleaseResourceReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this Release. Example:cover art images associated with the ResourceGroup. This LocalAnchorReference is a xs:string starting with the letter A.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="ResourceGroupType" type="avs:ResourceGroupType" use="required">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A Type of ResourceGroup.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="RightsClaimPolicy">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a rights claim policy.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="Condition" minOccurs="0" maxOccurs="unbounded" type="ern:ConditionForRightsClaimPolicy">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of Conditions. If more than one Condition is specified, then all of them have to be fulfilled (i.e. they are combined using the logical operator AND).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RightsClaimPolicyType" type="avs:RightsClaimPolicyType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of rights claim policy.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="SheetMusic">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a SheetMusic.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ResourceReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier (specific to the Message) of the SheetMusic within the Release which contains it. This is a LocalResourceAnchor starting with the letter A.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:ID">
+                  <xs:pattern value="A[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="Type" type="ern:SheetMusicType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Type of the SheetMusic.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceId" maxOccurs="unbounded" type="ern:SheetMusicId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of Identifiers of the SheetMusic.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="WorkId" minOccurs="0" maxOccurs="unbounded" type="ern:MusicalWorkId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a MusicalWorkId of a MusicalWork used in the SheetMusic.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayTitleText" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayTitleText">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the SheetMusic as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayTitle" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the SheetMusic as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AdditionalTitle" minOccurs="0" maxOccurs="unbounded" type="ern:AdditionalTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an AdditionalTitle of the SheetMusic. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="VersionType" minOccurs="0" maxOccurs="unbounded" type="ern:VersionType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Type of Version of the SheetMusic. </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayArtistName" maxOccurs="unbounded" type="ern:DisplayArtistNameWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayArtist" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the DisplayArtist for the SheetMusic. The DisplayArtist may be described through Name, Identifier and Roles.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Contributor" minOccurs="0" maxOccurs="unbounded" type="ern:Contributor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Contributor to the SheetMusic.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceRightsController" minOccurs="0" maxOccurs="unbounded" type="ern:ResourceRightsController">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of RightsController of Rights in the SheetMusic.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="WorkRightsController" minOccurs="0" maxOccurs="unbounded" type="ern:WorkRightsController">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of RightsController of Rights in the Work.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CLine" minOccurs="0" maxOccurs="unbounded" type="ern:CLineWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the CLine for the SheetMusic.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CourtesyLine" minOccurs="0" maxOccurs="unbounded" type="ern:CourtesyLineWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured in the SheetMusic.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CreationDate" minOccurs="0" type="ern:EventDateWithoutFlags">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the SheetMusic was created. This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="FirstPublicationDate" minOccurs="0" maxOccurs="unbounded" type="ern:FulfillmentDateWithTerritory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the SheetMusic was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ParentalWarningType" minOccurs="0" maxOccurs="unbounded" type="ern:ParentalWarningTypeWithTerritory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the classification of the SheetMusic according to advice which it carries about the level of explicitness or offensiveness of its content.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RelatedRelease" minOccurs="0" maxOccurs="unbounded" type="ern:RelatedRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current SheetMusic.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RelatedResource" minOccurs="0" maxOccurs="unbounded" type="ern:RelatedResource">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current SheetMusic.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ContainsHiddenContent" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the SheetMusic contains content that is hidden in some way from the Consumer (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="LanguageOfLyrics" minOccurs="0">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Language of the Lyrics of the SheetMusic as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="ResourceContainedResourceReferenceList" minOccurs="0" type="ern:ResourceContainedResourceReferenceList">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current SheetMusic.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="TechnicalDetails" minOccurs="0" maxOccurs="unbounded" type="ern:TechnicalSheetMusicDetails">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing technical details of the SheetMusic.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the SheetMusic as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:string">
+               <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="IsSupplemental" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether the SheetMusic is provided in a addition to the Resources that form part of the Release (=true) or not (=false). If the flag is set to false (or absent) the SheetMusic is part of at least one Release in the message. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="Software">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of an item of Software.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ResourceReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier (specific to the Message) of the Software within the Release which contains it. This is a LocalResourceAnchor starting with the letter A.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:ID">
+                  <xs:pattern value="A[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="Type" type="ern:SoftwareType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Type of the Software.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceId" maxOccurs="unbounded" type="ern:ResourceProprietaryId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of Identifiers of the Software.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="WorkId" minOccurs="0" maxOccurs="unbounded" type="ern:MusicalWorkId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a MusicalWorkId of a MusicalWork used in the Software.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayTitleText" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayTitleText">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the Software as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayTitle" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the Software as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AdditionalTitle" minOccurs="0" maxOccurs="unbounded" type="ern:AdditionalTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an AdditionalTitle of the Software. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="VersionType" minOccurs="0" maxOccurs="unbounded" type="ern:VersionType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Type of Version of the Software. </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayArtistName" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayArtistNameWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayArtist" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the DisplayArtist for the Software. The DisplayArtist may be described through Name, Identifier and Roles.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Contributor" minOccurs="0" maxOccurs="unbounded" type="ern:Contributor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Contributor to the Software.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceRightsController" minOccurs="0" maxOccurs="unbounded" type="ern:ResourceRightsController">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of RightsController of Rights in the Software.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="WorkRightsController" minOccurs="0" maxOccurs="unbounded" type="ern:WorkRightsController">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of RightsController of Rights in the Work.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PLine" minOccurs="0" maxOccurs="unbounded" type="ern:PLineWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the PLine for the Software.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CLine" minOccurs="0" maxOccurs="unbounded" type="ern:CLineWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the CLine for the Software.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CourtesyLine" minOccurs="0" maxOccurs="unbounded" type="ern:CourtesyLineWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured in the Software.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CreationDate" minOccurs="0" type="ern:EventDateWithoutFlags">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the Software was created. This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="FirstPublicationDate" minOccurs="0" maxOccurs="unbounded" type="ern:FulfillmentDateWithTerritory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the Software was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ParentalWarningType" minOccurs="0" maxOccurs="unbounded" type="ern:ParentalWarningTypeWithTerritory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the classification of the Software according to advice which it carries about the level of explicitness or offensiveness of its content.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RelatedRelease" minOccurs="0" maxOccurs="unbounded" type="ern:RelatedRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Software.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RelatedResource" minOccurs="0" maxOccurs="unbounded" type="ern:RelatedResource">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Software.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ContainsHiddenContent" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the Software contains content that is hidden in some way from the Consumer (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceContainedResourceReferenceList" minOccurs="0" type="ern:ResourceContainedResourceReferenceList">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current Software.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="TechnicalDetails" minOccurs="0" maxOccurs="unbounded" type="ern:TechnicalSoftwareDetails">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing technical details of the Software.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the Software as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:string">
+               <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="IsSupplemental" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether the Software is provided in a addition to the Resources that form part of the Release (=true) or not (=false). If the flag is set to false (or absent) the Software is part of at least one Release in the message. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="SoundRecording">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a SoundRecording.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ResourceReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier (specific to the Message) of the SoundRecording within the Release which contains it. This is a LocalResourceAnchor starting with the letter A.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:ID">
+                  <xs:pattern value="A[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="Type" type="ern:SoundRecordingType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Type of the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceId" maxOccurs="unbounded" type="ern:SoundRecordingId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a SoundRecordingId.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="WorkId" minOccurs="0" maxOccurs="unbounded" type="ern:MusicalWorkId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a MusicalWorkId of a MusicalWork used in the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayTitleText" maxOccurs="unbounded" type="ern:DisplayTitleText">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the SoundRecording as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayTitle" maxOccurs="unbounded" type="ern:DisplayTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the SoundRecording as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AdditionalTitle" minOccurs="0" maxOccurs="unbounded" type="ern:AdditionalTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an AdditionalTitle of the SoundRecording. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="VersionType" minOccurs="0" maxOccurs="unbounded" type="ern:VersionType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Type of Version of the SoundRecording. </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayArtistName" maxOccurs="unbounded" type="ern:DisplayArtistNameWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayArtist" maxOccurs="unbounded" type="ern:DisplayArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the DisplayArtist for the SoundRecording. The DisplayArtist may be described through Name, Identifier and Roles.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Contributor" minOccurs="0" maxOccurs="unbounded" type="ern:Contributor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Contributor to the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Character" minOccurs="0" maxOccurs="unbounded" type="ern:Character">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Character in the SoundRecording. A Character may be described through Name, Identifier and Roles.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceRightsController" minOccurs="0" maxOccurs="unbounded" type="ern:ResourceRightsController">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of RightsController of Rights in the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="WorkRightsController" minOccurs="0" maxOccurs="unbounded" type="ern:WorkRightsController">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of RightsController of Rights in the Work.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PLine" minOccurs="0" maxOccurs="unbounded" type="ern:PLineWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the PLine for the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CourtesyLine" minOccurs="0" maxOccurs="unbounded" type="ern:CourtesyLineWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for guests Artists or others featured on the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Duration" type="xs:duration">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Duration of the SoundRecording (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CreationDate" minOccurs="0" type="ern:EventDateWithoutFlags">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the SoundRecording was created. This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MasteredDate" minOccurs="0" type="ern:EventDateWithoutFlags">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the SoundRecording was originally mastered (in either analogue or digital form). This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RemasteredDate" minOccurs="0" type="ern:EventDateWithoutFlags">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the SoundRecording was re-mastered (usually digitally). This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="FirstPublicationDate" minOccurs="0" maxOccurs="unbounded" type="ern:FirstPublicationDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the SoundRecording was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="LocationAndDateOfSession" minOccurs="0" maxOccurs="unbounded" type="ern:LocationAndDateOfSession">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a RecordingSession.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ParentalWarningType" maxOccurs="unbounded" type="ern:ParentalWarningTypeWithTerritory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the classification of the SoundRecording according to advice which it carries about the level of explicitness or offensiveness of its content.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RelatedRelease" minOccurs="0" maxOccurs="unbounded" type="ern:RelatedRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RelatedResource" minOccurs="0" maxOccurs="unbounded" type="ern:RelatedResource">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CompositeMusicalWorkType" minOccurs="0" type="avs:CompositeMusicalWorkType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of the SoundRecording indicating whether it is a Medley or a Potpourri.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsCover" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating whether the SoundRecording is a Cover (=true) or not (=false). This is not legal information, but meant to help consumers to differentiate originals from covers.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsInstrumental" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the SoundRecording is instrumental (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ContainsHiddenContent" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the SoundRecording contains content that is hidden in some way from the Consumer (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsRemastered" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the SoundRecording is remastered (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsHiResMusic" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the SoundRecording meets the criteria to carry the HiResMusic logo, provided the MessageRecipient meets all the other requirements to use it (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisableCrossfade" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating to a DSP whether the SoundRecording should not be crossfaded from/into another SoundRecording (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisableSearch" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating to a DSP whether the SoundRecording should not be included in any search results (=true) or not (=false). Note that exclusion from search results implies that the SoundRecording should not appear in any recommendations.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayCredits" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayCredits">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Role and instrumentation for which a Party is credited.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="LanguageOfPerformance" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Language of the Performance recorded in the SoundRecording as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="AudioChannelConfiguration" minOccurs="0" type="avs:RecordingMode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A configuration of audio channels.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="TechnicalDetails" minOccurs="0" maxOccurs="unbounded" type="ern:TechnicalSoundRecordingDetails">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing technical details of the SoundRecording.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Raga" minOccurs="0" maxOccurs="unbounded" type="ern:Raga">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Description of the melodic mode of a MusicalWork in the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Tala" minOccurs="0" maxOccurs="unbounded" type="ern:Tala">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Description of the rhythmic pattern of a MusicalWork in the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Deity" minOccurs="0" maxOccurs="unbounded" type="ern:Deity">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A deity name relating to the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AudioChapterReference" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Reference for a Chapter (specific to this Message). This is a LocalCollectionAnchorReference starting with the letter X.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:IDREF">
+                  <xs:pattern value="X[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the SoundRecording as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:string">
+               <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="IsSupplemental" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether the SoundRecording is provided in a addition to the Resources that form part of the Release (=true) or not (=false). If the flag is set to false (or absent) the SoundRecording is part of at least one Release in the message. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="SoundRecordingPreviewDetails">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a preview.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="StartPoint" minOccurs="0" type="xs:decimal">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The start point of the preview given in seconds from the start of the Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="EndPoint" minOccurs="0" type="xs:decimal">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The end point of the preview given in seconds from the start of the Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Duration" minOccurs="0" type="xs:duration">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Duration of the preview, measured from the StartPoint.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="TopLeftCorner" minOccurs="0">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The position of the top left corner of the preview measured in Pixels from the top left corner of the Resource. The position is given as two coordinate values separated by a comma, the top left pixel being 0,0.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:pattern value="[0-9]+,[0-9]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="BottomRightCorner" minOccurs="0">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The position of the bottom right corner of the preview measured in Pixels from the top left corner of the Resource. The position is given as two coordinate values separated by a comma, the top left pixel being 0,0.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:pattern value="[0-9]+,[0-9]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="ExpressionType" type="avs:ExpressionType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of expression indicating how this should be perceived, e.g. as instruction (meaning that this has to be done to create the preview) or as information (meaning that this has been done to craete the preview).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="SupplementalDocumentList">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of one or more supplemental documents.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="SupplementalDocument" maxOccurs="unbounded" type="ern:File">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a supplemental document.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="SynopsisWithTerritory">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Synopsis.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named SynopsisWithTerritory to disambiguate it from the basic Synopsis Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script of the Synopsis as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Territory to which the Synopsis applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsDefault" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsShortSynopsis" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether the Synopsis is short (=true) or not (=false). This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="Tala">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Tala.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Territory to which the Tala applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsDefault" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="TechnicalImageDetails">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing technical details of an Image.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="TechnicalResourceDetailsReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier (specific to the Message) of the TechnicalImageDetails within the Release which contains it. This is a LocalTechnicalResourceDetailsAnchor starting with the letter T.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:ID">
+                  <xs:pattern value="T[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="ImageCodecType" minOccurs="0" type="ern:ImageCodecType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Type of ImageCodec.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ImageHeight" minOccurs="0" type="ern:Extent">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the vertical Extent of an Image of the Image and a UnitOfMeasure (the default is Pixels).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ImageWidth" minOccurs="0" type="ern:Extent">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the horizontal Extent of an Image of the Image and a UnitOfMeasure (the default is Pixels).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AspectRatio" minOccurs="0" type="ern:AspectRatio">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the ratio formed by dividing the ImageHeight by the ImageWidth.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ColorDepth" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An amount of data determining the color of a Pixel of the Image (given in bits per pixel).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ImageResolution" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A number of Pixels of the Image displayed in a specific spatial range (given in dpi).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="BitDepth" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The BitDepth of the File.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsPreview" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the Image is technically a preview of the parent Resource (=true) or not (=false). Note that nothing can be implied from this element as to the conditions under which the preview can be made available.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PreviewDetails" minOccurs="0" type="ern:PreviewDetails">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a preview.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-previews/preview-resources</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="File" minOccurs="0" type="ern:File">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a File containing the Image that a DSP can obtain.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsProvidedInDelivery" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating whether a File containing the Image is a provided in a delivery (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Fingerprint" minOccurs="0" maxOccurs="unbounded" type="ern:Fingerprint">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Fingerprint and its governing algorithm.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the TechnicalImageDetails as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:string">
+               <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A Territory to which the TechnicalImageDetails apply. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IsDefault" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="TechnicalSheetMusicDetails">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing technical details of a SheetMusic.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="TechnicalResourceDetailsReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier (specific to the Message) of the TechnicalSheetMusicDetails within the Release which contains it. This is a LocalTechnicalResourceDetailsAnchor starting with the letter T.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:ID">
+                  <xs:pattern value="T[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="SheetMusicCodecType" minOccurs="0" type="ern:SheetMusicCodecType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Type of SheetMusic Codec.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="BitDepth" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The BitDepth of the File.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsPreview" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the SheetMusic is technically a preview of the parent Resource (=true) or not (=false). Note that nothing can be implied from this element as to the conditions under which the preview can be made available.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PreviewDetails" minOccurs="0" type="ern:PreviewDetails">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a preview.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-previews/preview-resources</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="File" minOccurs="0" type="ern:File">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a File containing the SheetMusic that a DSP can obtain.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsProvidedInDelivery" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating whether a File containing the SheetMusic is a provided in a delivery (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Fingerprint" minOccurs="0" maxOccurs="unbounded" type="ern:Fingerprint">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Fingerprint and its governing algorithm.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the TechnicalSheetMusicDetails as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:string">
+               <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A Territory to which the TechnicalSheetMusicDetails apply. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IsDefault" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="TechnicalSoftwareDetails">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing technical details of a Software.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="TechnicalResourceDetailsReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier (specific to the Message) of the TechnicalSoftwareDetails within the Release which contains it. This is a LocalTechnicalResourceDetailsAnchor starting with the letter T.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:ID">
+                  <xs:pattern value="T[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="OperatingSystemType" minOccurs="0" type="ern:OperatingSystemType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Type of OperatingSystem.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="BitDepth" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The BitDepth of the File.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsPreview" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the Software is technically a preview of the parent Resource (=true) or not (=false). Note that nothing can be implied from this element as to the conditions under which the preview can be made available.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PreviewDetails" minOccurs="0" type="ern:PreviewDetails">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a preview.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-previews/preview-resources</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="File" minOccurs="0" type="ern:File">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a File containing the Software that a DSP can obtain.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsProvidedInDelivery" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating whether a File containing the Software is a provided in a delivery (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Fingerprint" minOccurs="0" maxOccurs="unbounded" type="ern:Fingerprint">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Fingerprint and its governing algorithm.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the TechnicalSoftwareDetails as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:string">
+               <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A Territory to which the TechnicalSoftwareDetails apply. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IsDefault" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="TechnicalSoundRecordingDetails">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing technical details of a SoundRecording.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="TechnicalResourceDetailsReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier (specific to the Message) of the TechnicalSoundRecordingDetails within the Release which contains it. This is a LocalTechnicalResourceDetailsAnchor starting with the letter T.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:ID">
+                  <xs:pattern value="T[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="EncodingId" minOccurs="0" type="ern:SoundRecordingId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an identifier of the encoding. The default is that all encodings for a SoundRecording share a common identifier (as provided on the SoundRecording composite) and that, looking at the ISRC standard for instance, there should not be a different identifier for different encodings (unless there is a substantial difference). However, reality indicates that different identifiers have been allocated and therefore should be communicable.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AudioCodecType" minOccurs="0" type="ern:AudioCodecType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Type of AudioCodec.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="BitRate" minOccurs="0" type="ern:BitRate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the BitRate for the audio data and a UnitOfMeasure (the default is kbps).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="OriginalBitRate" minOccurs="0" type="ern:BitRate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the BitRate for the audio data recording and a UnitOfMeasure (the default is kbps).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NumberOfChannels" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A number of audio channels.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SamplingRate" minOccurs="0" type="ern:SamplingRate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the sampling rate of the SoundRecording and a UnitOfMeasure (the default is Hz).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="OriginalSamplingRate" minOccurs="0" type="ern:SamplingRate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the sampling rate of the SoundRecording during the recording, and a UnitOfMeasure (the default is Hz).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="BitsPerSample" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An amount of audio data in a sample.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Duration" minOccurs="0" type="xs:duration">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Duration of the instantiation of the SoundRecording if this differs from the Duration provided for the SoundRecording itself (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S). This element must only be used if and when there are no royalty reporting implications on this change in duration and when the specific technical instantiation is a clip taken from a technical instantiation representing the whole SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="BitDepth" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The BitDepth of the File.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsPreview" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the SoundRecording is technically a preview of the parent Resource (=true) or not (=false). Note that nothing can be implied from this element as to the conditions under which the preview can be made available.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PreviewDetails" minOccurs="0" type="ern:SoundRecordingPreviewDetails">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a preview.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="File" minOccurs="0" type="ern:File">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a File containing the SoundRecording that a DSP can obtain.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsProvidedInDelivery" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating whether a File containing the SoundRecording is a provided in a delivery (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Fingerprint" minOccurs="0" maxOccurs="unbounded" type="ern:Fingerprint">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Fingerprint and its governing algorithm.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="EncodingDescription" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A textual Description of the encoding.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the TechnicalSoundRecordingDetails as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:string">
+               <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A Territory to which the TechnicalSoundRecordingDetails apply. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IsDefault" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="TechnicalTextDetails">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing technical details of a Text.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="TechnicalResourceDetailsReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier (specific to the Message) of the TechnicalTextDetails within the Release which contains it. This is a LocalTechnicalResourceDetailsAnchor starting with the letter T.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:ID">
+                  <xs:pattern value="T[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="TextCodecType" minOccurs="0" type="ern:TextCodecType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Type of TextCodec.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="BitDepth" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The BitDepth of the File.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsPreview" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the Text is technically a preview of the parent Resource (=true) or not (=false). Note that nothing can be implied from this element as to the conditions under which the preview can be made available.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PreviewDetails" minOccurs="0" type="ern:PreviewDetails">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a preview.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-previews/preview-resources</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="File" minOccurs="0" type="ern:File">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a File containing the Text that a DSP can obtain.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsProvidedInDelivery" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating whether a File containing the Text is a provided in a delivery (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Fingerprint" minOccurs="0" maxOccurs="unbounded" type="ern:Fingerprint">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Fingerprint and its governing algorithm.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the TechnicalTextDetails as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:string">
+               <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A Territory to which the TechnicalTextDetails apply. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IsDefault" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="TechnicalVideoDetails">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing technical details of a Video.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="TechnicalResourceDetailsReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier (specific to the Message) of the TechnicalVideoDetails within the Release which contains it. This is a LocalTechnicalResourceDetailsAnchor starting with the letter T.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:ID">
+                  <xs:pattern value="T[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="EncodingId" minOccurs="0" type="ern:VideoId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an identifier of the encoding. The default is that all encodings for a Video share a common identifier (as provided on the Video composite) and that, looking at the ISRC standard for instance, there should not be a different identifier for different encodings (unless there is a substantial difference). However, reality indicates that different identifiers have been allocated and therefore should be communicable.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="OverallBitRate" minOccurs="0" type="ern:BitRate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the overall BitRate and a UnitOfMeasure (the default is kbps).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ContainerFormat" minOccurs="0" type="ern:ContainerFormat">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ContainerFormat.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="VideoCodecType" minOccurs="0" type="ern:VideoCodecType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Type of VideoCodec.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="VideoBitRate" minOccurs="0" type="ern:BitRate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the BitRate for the video data and a UnitOfMeasure (the default is kbps).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="FrameRate" minOccurs="0" type="ern:FrameRate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the Rate for a number of frames shown in the Video in a specific Period of Time and a UnitOfMeasure (the default is Hz, interlaced).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ImageHeight" minOccurs="0" type="ern:Extent">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the vertical Extent of an Image of the Video and a UnitOfMeasure (the default is Pixels).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ImageWidth" minOccurs="0" type="ern:Extent">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the horizontal Extent of an Image of the Video and a UnitOfMeasure (the default is Pixels).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AspectRatio" minOccurs="0" type="ern:AspectRatio">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the ratio formed by dividing the ImageHeight by the ImageWidth.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CoreArea" minOccurs="0" type="ern:CoreArea">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the core part of the Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ColorDepth" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An amount of data determining the color of a pixel of an Image of the Video (given in bits per pixel).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="VideoDefinitionType" minOccurs="0" type="ern:VideoDefinitionType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of resolution (or definition) in which the Video is provided.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AudioCodecType" minOccurs="0" type="ern:AudioCodecType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Type of AudioCodec.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AudioBitRate" minOccurs="0" type="ern:BitRate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the BitRate for the audio data and a UnitOfMeasure (the default is kbps).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NumberOfAudioChannels" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A number of audio channels.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AudioSamplingRate" minOccurs="0" type="ern:SamplingRate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the SamplingRate for the audio data and a UnitOfMeasure (the default is Hz).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AudioBitsPerSample" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An amount of audio data in a sample.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Duration" minOccurs="0" type="xs:duration">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Duration of the instantiation of the Video if this differs from the Duration provided for the Video itself (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S). This element must only be used if and when there are no royalty reporting implications on this change in duration and when the specific technical instantiation is a clip taken from a technical instantiation representing the whole Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="BitDepth" minOccurs="0" type="xs:integer">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The BitDepth of the File.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsPreview" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the Video is technically a preview of the parent Resource (=true) or not (=false). Note that nothing can be implied from this element as to the conditions under which the preview can be made available.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PreviewDetails" minOccurs="0" type="ern:SoundRecordingPreviewDetails">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a preview.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="File" minOccurs="0" type="ern:File">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a File containing the Video that a DSP can obtain.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsProvidedInDelivery" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating whether a File containing the Video is a provided in a delivery (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Fingerprint" minOccurs="0" maxOccurs="unbounded" type="ern:Fingerprint">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Fingerprint and its governing algorithm.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="EncodingDescription" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A textual Description of the encoding.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the TechnicalSoundRecordingDetails as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:string">
+               <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A Territory to which the TechnicalVideoDetails apply. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IsDefault" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="Text">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Text.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ResourceReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier (specific to the Message) of the Text within the Release which contains it. This is a LocalResourceAnchor starting with the letter A.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:ID">
+                  <xs:pattern value="A[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="Type" type="ern:TextType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Type of the Text.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceId" minOccurs="0" maxOccurs="unbounded" type="ern:TextId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an Identifier of the Text.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="WorkId" minOccurs="0" maxOccurs="unbounded" type="ern:MusicalWorkId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a MusicalWorkId of a MusicalWork used in the Text.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayTitleText" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayTitleText">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the Text as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayTitle" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the Text as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AdditionalTitle" minOccurs="0" maxOccurs="unbounded" type="ern:AdditionalTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an AdditionalTitle of the Text. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="VersionType" minOccurs="0" maxOccurs="unbounded" type="ern:VersionType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Type of Version of the Text. </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayArtistName" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayArtistNameWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayArtist" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the DisplayArtist for the Text. The DisplayArtist may be described through Name, Identifier and Roles.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Contributor" minOccurs="0" maxOccurs="unbounded" type="ern:Contributor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Contributor to the Text.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceRightsController" minOccurs="0" maxOccurs="unbounded" type="ern:ResourceRightsController">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of RightsController of Rights in the Text.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="WorkRightsController" minOccurs="0" maxOccurs="unbounded" type="ern:WorkRightsController">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of RightsController of Rights in the Work.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CLine" minOccurs="0" maxOccurs="unbounded" type="ern:CLineWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the CLine for the Text.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CourtesyLine" minOccurs="0" maxOccurs="unbounded" type="ern:CourtesyLineWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing an Annotation which acknowledges record companies and/or other Parties giving permission for Artists or others featured in the Text.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CreationDate" minOccurs="0" type="ern:EventDateWithoutFlags">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the Text was created. This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="FirstPublicationDate" minOccurs="0" maxOccurs="unbounded" type="ern:FulfillmentDateWithTerritory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the Text was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ParentalWarningType" minOccurs="0" maxOccurs="unbounded" type="ern:ParentalWarningTypeWithTerritory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the classification of the Text according to advice which it carries about the level of explicitness or offensiveness of its content.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RelatedRelease" minOccurs="0" maxOccurs="unbounded" type="ern:RelatedRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Text.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RelatedResource" minOccurs="0" maxOccurs="unbounded" type="ern:RelatedResource">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Text.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ContainsHiddenContent" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the Text contains content that is hidden in some way from the Consumer (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceContainedResourceReferenceList" minOccurs="0" type="ern:ResourceContainedResourceReferenceList">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current Text.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="TechnicalDetails" minOccurs="0" maxOccurs="unbounded" type="ern:TechnicalTextDetails">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing technical details of the Text.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the Text as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:string">
+               <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="IsSupplemental" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether the Text is provided in a addition to the Resources that form part of the Release (=true) or not (=false). If the flag is set to false (or absent) the Text is part of at least one Release in the message. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="TextWithFormat">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of an Annotation, e.g. a Description or a Comment.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="LanguageAndScriptCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script of the Annotation as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+               <xs:simpleType>
+                  <xs:restriction base="xs:string">
+                     <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Territory to which the Annotation applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsDefault" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="Format" type="avs:TextCodecType">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The format of the Annotation. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the Format. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the Format. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="Timing">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a StartTime and a Duration of a Resource.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="StartPoint" minOccurs="0" type="xs:duration">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The start point of the related Resource from the start of the referencing Resource (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DurationUsed" minOccurs="0" type="xs:duration">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The total Duration of the related Resource that has been used (this may be less than the total Duration of the Resource) (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="Title">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Title.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="TitleText" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The text of the Title.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SubTitle" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A SubTitle of the Title, including Titles of Versions used to differentiate different versions of the same Title, as required by the GRid and ISRC ReferenceDescriptiveMetadataSets.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the Title as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="TitleType" type="avs:AdditionalTitleType">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A Type of the Title which defines its origin or the function it fulfils in relation to a Creation. Note: A Title may fulfil more than one role. Example: 'Help' may be both the OriginalTitle and the DisplayTitle for the well-known Beatles song. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="TrackRelease">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a DDEX Release.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ReleaseReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier (specific to the Message) of the Release. Used to link the Release to one or more Deal(s). This is a LocalReleaseAnchor starting with the letter R.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:ID">
+                  <xs:pattern value="R[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="ReleaseId" type="ern:ReleaseId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of ReleaseIds. If available, a GRid has to be used. If the Release is an abstraction of a complete PhysicalProduct (such as a CD Album), the ICPN of the PhysicalProduct may be used instead.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayTitleText" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayTitleText">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayTitle" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the Release as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AdditionalTitle" minOccurs="0" maxOccurs="unbounded" type="ern:AdditionalTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an AdditionalTitle of the Release. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ReleaseResourceReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A ReleaseResourceReference for the Release (specific to this Message). The LocalAnchorReference in this Composite is a xs:string starting with the letter A.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:IDREF">
+                  <xs:pattern value="A[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="LinkedReleaseResourceReference" minOccurs="0" maxOccurs="unbounded" type="ern:LinkedReleaseResourceReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ReleaseResourceReference (specific to this Message) for a Resource which is linked to this Release. Example: an Image, Text or NonMusicalWorkVideo associated with a SoundRecording. This LocalAnchorReference is a xs:string starting with the letter A.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ReleaseLabelReference" maxOccurs="unbounded" type="ern:ReleaseLabelReferenceWithParty">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Reference for a label of the Release (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Genre" maxOccurs="unbounded" type="ern:GenreWithTerritory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Genre to which the Release belongs.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ReleaseVisibilityReference" minOccurs="0">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Reference for a set of visibility dates (specific to this Message) that applies to this Release. This defines when the Release can be shown to Consumers, not when a Consumer can get access to the Release. This is a LocalVisibilityAnchorReference starting with the letter V.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:IDREF">
+                  <xs:pattern value="V[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="RelatedRelease" minOccurs="0" maxOccurs="unbounded" type="ern:RelatedRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to this Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RelatedResource" minOccurs="0" maxOccurs="unbounded" type="ern:RelatedResource">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Resource which is related to this Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="TargetURL" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A URL of a sub-site or channel in the DSP’s system, where the Release should be made available to Consumers. </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Keywords" minOccurs="0" maxOccurs="unbounded" type="ern:KeywordsWithTerritory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Description of the Release containing Keywords.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Synopsis" minOccurs="0" maxOccurs="unbounded" type="ern:SynopsisWithTerritory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Synopsis of the Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MarketingComment" minOccurs="0" maxOccurs="unbounded" type="ern:MarketingComment">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing a Comment about the promotion and marketing of the Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="IsMainRelease" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether the Release is a main one as defined in the relevant Profile Standard (=true) or not (=false). This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="TrackReleaseVisibility">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Date specifying when a TrackRelease can be shown to Consumers.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="VisibilityReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier (specific to the Message) of the visibility date. This is a LocalVisibilityAnchor starting with the letter V.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:ID">
+                  <xs:pattern value="V[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="TrackListingPreviewStartDateTime" type="xs:dateTime">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DateTime on which the Track list is made first available for display (it overrides the generic ReleaseDisplayStartDate if supplied). If no TrackListingPreviewStartDateTime is provided, the StartDate for the Deal is used instead. The TrackListingPreviewStartDateTime shall not be later than the StartDate of the Deal allowing the general availability of the referenced Release. This element is not applicable on Track Releases. This is a string in ISO 8601 format: YYYY-MM-DDThh:mm:ss.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ClipPreviewStartDateTime" minOccurs="0" type="xs:dateTime">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A DateTime on which an audio or video clip is made first available for display (it overrides the generic ReleaseDisplayStartDate if supplied). If no ClipPreviewStartDateTime is provided, the StartDate for the Deal is used instead. The ClipPreviewStartDateTime shall not be later than the StartDate of the Deal allowing the general availability of the referenced Release. This is a string in ISO 8601 format: YYYY-MM-DDThh:mm:ss.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="UseType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a UseType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:UseType_ERN">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the UseType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the UseType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="UserInterfaceType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a UserInterfaceType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:UserInterfaceType_ERN">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the UserInterfaceType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the UserInterfaceType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="Video">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Video.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ResourceReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier (specific to the Message) of the Video within the Release which contains it. This is a LocalResourceAnchor starting with the letter A.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:ID">
+                  <xs:pattern value="A[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="Type" type="ern:VideoType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Type of the Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceId" minOccurs="0" maxOccurs="unbounded" type="ern:VideoId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an Identifier of the Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="WorkId" minOccurs="0" maxOccurs="unbounded" type="ern:MusicalWorkId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a MusicalWorkId of a MusicalWork used in the Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayTitleText" maxOccurs="unbounded" type="ern:DisplayTitleText">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the Video as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode. One such element is required for each DisplayTitle element and its content typically provides the same information as the concatenation of the DisplayTitle's sub-elements.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayTitle" maxOccurs="unbounded" type="ern:DisplayTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Title of the Video as the MessageSender suggests it should be shown to the Consumer. In many instances this is the only Title to be communicated for any given Creation. Multiple instances can be supplied with an ApplicableTerritoryCode and/or LanguageAndScriptCode.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AdditionalTitle" minOccurs="0" maxOccurs="unbounded" type="ern:AdditionalTitle">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of an AdditionalTitle of the Video. If multiple instances with an ApplicableTerritoryCode are provided, then the first one provides the default that is then superseded by subsequent instances.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="VersionType" minOccurs="0" maxOccurs="unbounded" type="ern:VersionType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Type of Version of the Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayArtistName" maxOccurs="unbounded" type="ern:DisplayArtistNameWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the Name to be used by a DSP when presenting Artist details of the Resource to a Consumer.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayArtist" maxOccurs="unbounded" type="ern:DisplayArtist">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the DisplayArtist for the Video. The DisplayArtist may be described through Name, Identifier and Roles.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/communicating-displayartists-and-displayartistname</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/genres</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers/information-on-displayartists%2C-displayartistnames%2C-contributors-and-indirectcontributors</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Contributor" minOccurs="0" maxOccurs="unbounded" type="ern:Contributor">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Contributor to the Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Character" minOccurs="0" maxOccurs="unbounded" type="ern:Character">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Character in the Video. A Character may be described through Name, Identifier and Roles.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceRightsController" minOccurs="0" maxOccurs="unbounded" type="ern:ResourceRightsController">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of RightsController of Rights in the Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="WorkRightsController" minOccurs="0" maxOccurs="unbounded" type="ern:WorkRightsController">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of RightsController of Rights in the Work.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PLine" minOccurs="0" maxOccurs="unbounded" type="ern:PLineWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the PLine for the Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CLine" minOccurs="0" maxOccurs="unbounded" type="ern:CLineWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the CLine for the Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CourtesyLine" minOccurs="0" maxOccurs="unbounded" type="ern:CourtesyLineWithDefault">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing an Annotation Annotation which acknowledges record companies and/or other Parties giving permission for guests Artists or others featured on the Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Duration" type="xs:duration">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Duration of the Video (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CreationDate" minOccurs="0" type="ern:EventDateWithoutFlags">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the Video was created. This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MasteredDate" minOccurs="0" type="ern:EventDateWithoutFlags">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the Video was originally mastered (in either analogue or digital form). This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RemasteredDate" minOccurs="0" maxOccurs="unbounded" type="ern:EventDateWithoutFlags">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the Video was re-mastered (usually digitally). This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="FirstPublicationDate" minOccurs="0" maxOccurs="unbounded" type="ern:FulfillmentDateWithTerritory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of the Event in which the Video was first published, whether for physical or electronic/online distribution. This is a string with the syntax YYYY[-MM[-DD]].</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ParentalWarningType" maxOccurs="unbounded" type="ern:ParentalWarningTypeWithTerritory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the classification of the Video according to advice which it carries about the level of explicitness or offensiveness of its content.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AvRating" minOccurs="0" maxOccurs="unbounded" type="ern:AvRating">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a rating for the Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RelatedRelease" minOccurs="0" maxOccurs="unbounded" type="ern:RelatedRelease">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Release (or a PhysicalProduct or a DigitalProduct derived from such a Release) which is related to current Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RelatedResource" minOccurs="0" maxOccurs="unbounded" type="ern:RelatedResource">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ResourceRelatedResourceReference referring to a Resource that is related to the current Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CompositeMusicalWorkType" minOccurs="0" type="avs:CompositeMusicalWorkType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of the Video indicating whether it is a Medley or a Potpourri.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:choice minOccurs="0">
+            <xs:element name="VideoCueSheetReference" maxOccurs="unbounded">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Reference for a CueSheet (specific to this Message). This is a LocalCueSheetAnchorReference starting with the letter Q.</xs:documentation>
+               </xs:annotation>
+               <xs:simpleType>
+                  <xs:restriction base="xs:IDREF">
+                     <xs:pattern value="Q[\d\-_a-zA-Z]+"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:element>
+            <xs:element name="ReasonForCueSheetAbsence" type="ern:Reason">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing the textual Description of the reason for the Identifier being used as a proxy.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:choice>
+         <xs:element name="IsCover" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating whether the Video is a Cover (=true) or not (=false). This is not legal information, but meant to help consumers to differentiate originals from covers.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsInstrumental" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the Video is instrumental (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ContainsHiddenContent" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the Video contains content that is hidden in some way from the Consumer (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="IsRemastered" minOccurs="0" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Flag indicating whether the Video is remastered (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DisplayCredits" minOccurs="0" maxOccurs="unbounded" type="ern:DisplayCredits">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Role and instrumentation for which a Party is credited.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="LanguageOfPerformance" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The original Language of the Performance as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="LanguageOfDubbing" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Language of dubbing used in the Video as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="SubTitleLanguage" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Language of SubTitles in the Video as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant].</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="ResourceContainedResourceReferenceList" minOccurs="0" type="ern:ResourceContainedResourceReferenceList">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of ResourceContainedResourceReferences referring to a Resource that is contained in the current Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="TechnicalDetails" minOccurs="0" maxOccurs="unbounded" type="ern:TechnicalVideoDetails">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing technical details of the Video.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-binaries/communicating-binaries</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Raga" minOccurs="0" maxOccurs="unbounded" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Description of the melodic mode of a MusicalWork in the Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Tala" minOccurs="0" maxOccurs="unbounded" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Description of the rhythmic pattern of a MusicalWork in the Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Deity" minOccurs="0" maxOccurs="unbounded" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A deity name relating to the Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="VideoChapterReference" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Reference for a Chapter (specific to this Message). This is a LocalCollectionAnchorReference starting with the letter X.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:IDREF">
+                  <xs:pattern value="X[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the Video as defined in IETF RfC 5646. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:string">
+               <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="IsSupplemental" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether the Video is provided in a addition to the Resources that form part of the Release (=true) or not (=false). If the flag is set to false (or absent) the Video is part of at least one Release in the message. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="WorkRightsController">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a RightsController for a Work. RightsControllers are typically described by Name, Identifier and Role(s).</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="RightsControllerPartyReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Reference for a Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:IDREF">
+                  <xs:pattern value="P[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="RightsControlType" minOccurs="0" maxOccurs="unbounded" type="avs:RightsControllerRole">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A role that describes the Party involved in the administration of Rights.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RightsControllerType" minOccurs="0" type="avs:RightsControllerType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A type of the RightsController.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:choice minOccurs="0">
+            <xs:element name="RightShareUnknown" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether the RightSharePercentage is unknown (=true) or not (=false).</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="RightSharePercentage" type="xs:decimal">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The share of the licensed Rights owned by the RightsController. RightShare information is given as a xs:decimal value with up to 6 digits (e.g. '12.5' represents 12.5%). If no information is given, 100% is assumed.</xs:documentation>
+                  <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/communication-of-percentages</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:choice>
+         <xs:element name="Territory" minOccurs="0" maxOccurs="unbounded" type="ern:AllTerritoryCode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The country of registration.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="StartDate" minOccurs="0" type="ern:ddex_IsoDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Date that marks the beginning of the title (in ISO 8601 format: YYYY-MM-DD).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="EndDate" minOccurs="0" type="ern:ddex_IsoDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Date that marks the end of the title (in ISO 8601 format: YYYY-MM-DD).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="AdministratingRecordCompanyRole">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a AdministratingRecordCompanyRole.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:AdministratingRecordCompanyRole">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the AdministratingRecordCompanyRole. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the AdministratingRecordCompanyRole. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="Affiliation">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a business deal with another Party.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:choice>
+            <xs:element name="CompanyName" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Name of the company.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="PartyAffiliateReference">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Reference for an affiliated Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.</xs:documentation>
+               </xs:annotation>
+               <xs:simpleType>
+                  <xs:restriction base="xs:IDREF">
+                     <xs:pattern value="P[\d\-_a-zA-Z]+"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:element>
+         </xs:choice>
+         <xs:element name="Type" type="avs:AffiliationType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Type of affiliated Party.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:choice>
+            <xs:element name="TerritoryCode" maxOccurs="unbounded" type="ern:CurrentTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Territory to which the affiliation details apply. Either this Element or ExcludedTerritory shall be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="ExcludedTerritoryCode" maxOccurs="unbounded" type="ern:CurrentTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Territory to which the affiliation details do not apply. Either this Element or Territory shall be present, but not both. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:choice>
+         <xs:element name="ValidityPeriod" minOccurs="0" type="ern:ValidityPeriod">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details about the Period of Time for which the society affiliation is valid.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/general-implementation-guidance/licensing-the-standards/ddex-party-identifier-(dpid)</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="RightsType" minOccurs="0" maxOccurs="unbounded" type="ern:SimpleRightsType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a rights type.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PercentageOfRightsAssignment" minOccurs="0" type="xs:decimal">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">Percentage of the specific Right that is represented by the society. A quarter share is represented by '25' (and not 0.25).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="AllTerritoryCode">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a TerritoryCode.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:AllTerritoryCode">
+            <xs:attribute name="IdentifierType" type="avs:TerritoryCodeTypeIncludingDeprecatedCodes">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A standard used for the TerritoryCode. This is represented in an XML schema as an XML Attribute. If this Attribute is not provided, it is assumed that the code is a TerritoryCode in accordance with ISO 3166-1 or 3166-2 standard (or Worldwide).</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="AspectRatio">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing an AspectRatio and an AspectRatioType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:decimal">
+            <xs:attribute name="AspectRatioType" type="avs:AspectRatioType">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Type of the AspectRatio. This is represented in an XML schema as an XML Attribute. If this Attribute is not provided, it is assumed that the AspectRatio is a PixelAspectRatio.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="AudioCodecType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of an AudioCodecType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:AudioCodecType">
+            <xs:attribute name="Version" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Identifier of the Version of the AudioCodecType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the AudioCodecType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the AudioCodecType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="BitRate">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing a BitRate and a UnitOfMeasure.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:decimal">
+            <xs:attribute name="UnitOfMeasure" type="avs:UnitOfBitRate">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The UnitOfMeasure of the BitRate. This is represented in an XML schema as an XML Attribute. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="CLine">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a CLine.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="Year" minOccurs="0" type="xs:gYear">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Year of the CLine.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CLineCompany" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Name of the company releasing the Creation. This may be an owner or a Licensee of the Creation.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CLineText" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The text of the CLine.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script of the CLineText as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="CarrierType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a CarrierType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:CarrierType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the CarrierType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the CarrierType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="CatalogNumber">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a CatalogNumber.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="Namespace" type="xs:string" use="required">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the CatalogNumber. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="ContainerFormat">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a ContainerFormat.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:ContainerFormat">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the ContainerFormat. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the ContainerFormat. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="ContributorRole">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a ContributorRole. Note: this can be used in a DdexMessage in relation to any Work, Performance or Fixation any of which may form the whole or part of the Resource itself.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:ContributorRole">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the ContributorRole. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the ContributorRole. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="CueOrigin">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a CueOrigin.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:CueOrigin">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the CueOrigin. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the CueOrigin. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="CueSheetType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a CueSheetType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:CueSheetType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the CueSheetType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the CueSheetType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="CueThemeType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a ThemeType for a Creation referenced in a Cue.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:ThemeType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the ThemeType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the ThemeType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="CueUseType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a CueUseType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:CueUseType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the CueUseType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the CueUseType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="CueVisualPerceptionType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a VisualPerceptionType for a Creation referenced in a Cue.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:VisualPerceptionType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the VisualPerceptionType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the VisualPerceptionType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="CueVocalType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a VocalType for a Creation referenced in a Cue.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:VocalType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the VocalType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the VocalType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="CurrentTerritoryCode">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a TerritoryCode.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:CurrentTerritoryCode">
+            <xs:attribute name="IdentifierType" type="avs:TerritoryCodeType">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A standard used for the TerritoryCode. This is represented in an XML schema as an XML Attribute. If this Attribute is not provided, it is assumed that the code is a TerritoryCode in accordance with ISO 3166-1 or 3166-2 standard (or Worldwide).</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="DSP">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a DSP acting as a Licensee in a commercial relationship.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:choice>
+            <xs:element name="PartyId" maxOccurs="unbounded" type="ern:DetailedPartyId">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:sequence>
+               <xs:element name="PartyName" maxOccurs="unbounded" type="ern:PartyName">
+                  <xs:annotation>
+                     <xs:documentation source="ddex:Definition">A Composite containing details of the PartyName(s).</xs:documentation>
+                     <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision</xs:documentation>
+                     <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers</xs:documentation>
+                  </xs:annotation>
+               </xs:element>
+               <xs:element name="PartyId" minOccurs="0" maxOccurs="unbounded" type="ern:DetailedPartyId">
+                  <xs:annotation>
+                     <xs:documentation source="ddex:Definition">A Composite containing details of the PartyId for the Party. If no Namespace is given, the Identifier is a DdexPartyId (DPID). Note that DPIDs are not normally used to identify Artists, producers or other Creators.</xs:documentation>
+                  </xs:annotation>
+               </xs:element>
+            </xs:sequence>
+         </xs:choice>
+         <xs:element name="TradingName" minOccurs="0" type="ern:Name">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing a TradingName of the DSP.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="URL" minOccurs="0" maxOccurs="unbounded" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A URL for the DSP's web site.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="DetailedHashSum">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a HashSum and its governing algorithm.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named DetailedHashSum to disambiguate it from the basic HashSum Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="Algorithm" type="ern:HashSumAlgorithmType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Type of HashSumAlgorithm governing the HashSum.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Version" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier of the Version of the HashSumAlgorithm.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Parameter" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A parameter of the HashSumAlgorithm.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DataType" minOccurs="0" type="avs:BinaryDataType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The datatype of the HashSum.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="HashSumValue" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The value of the HashSum.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="DetailedPartyId">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a PartyId.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named DetailedPartyId to disambiguate it from the basic PartyId Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ISNI" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An International Standard Name Identifier, the ISO 27729 Standard Identifier for names. DDEX will enforce the syntax [0-9]{15}[X0-9] using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DPID" minOccurs="0">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Identifier of a Party according to the DdexPartyId standard DDEX-DPID.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:pattern value="PADPIDA[a-zA-Z0-9]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="IpiNameNumber" minOccurs="0">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Interested Party Identifier, a CISAC standard Identifier. An IpiNameNumber comprises 11 digits.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:pattern value="[0-9]{11}"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="IPN" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An International Performer Number, an IPDA Identifier.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CisacSocietyId" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A CISAC Society Identifier, a CISAC standard Identifier for music rights societies.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ProprietaryId" minOccurs="0" maxOccurs="unbounded" type="ern:ProprietaryId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ProprietaryIdentifier of the Party.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="DisplayArtistNameWithDefault">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a DisplayArtistName.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named DisplayArtistNameWithDefault to disambiguate it from the basic DisplayArtistName Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script of the Name as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Territory to which the Name applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsDefault" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="DisplayArtistRole">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a DisplayArtistRole.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:DisplayArtistRole">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the DisplayArtistRole. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the DisplayArtistRole. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="DisplayCredits">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Role and instrumentation for which a Party is credited.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="DisplayCreditText" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The textual portion of the display credit.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="DisplayCreditParty">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Reference for a Party credited with the display credit.</xs:documentation>
+               </xs:annotation>
+               <xs:simpleType>
+                  <xs:restriction base="xs:IDREF">
+                     <xs:pattern value="P[\d\-_a-zA-Z]+"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:element>
+            <xs:element name="NameUsedInDisplayCredit" minOccurs="0" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Name for the Party as used in the DisplayCreditText. If no such element is present, the DisplayCreditText contains the Name of the credited Party as specified in the PartyName of the Party composite.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:sequence>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script of this Element as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A Territory to which this Element applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IsDefault" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Element provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="EventDate">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of an Event.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="ern:ddex_IsoDate">
+            <xs:attribute name="IsApproximate" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether the reported Date is approximate (=true) or exact (=false). This is represented in an XML schema as an XML Attribute. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsBefore" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether the Event being described occurred sometime before the reported Date (=true) or not (=false). This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsAfter" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether the Event being described occurred sometime after the reported Date (=true) or not (=false). This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="ApplicableTerritoryCode" type="avs:AllTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Territory in which the Event occurred. This is represented in an XML schema as an XML Attribute. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="LocationDescription" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Description of the location in which the Event occurred. It offers the opportunity to describe a place more precisely than using the TerritoryCode. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script for the LocationDescription as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="EventDateTime">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of the DateTime and Place of an Event.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:dateTime">
+            <xs:attribute name="IsApproximate" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether the reported DateTime is approximate (=true) or exact (=false). This is represented in an XML schema as an XML Attribute. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsBefore" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether the Event being described occurred sometime before the reported DateTime (=true) or not (=false). This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsAfter" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether the Event being described occurred sometime after the reported DateTime (=true) or not (=false). This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="TerritoryCode" type="avs:AllTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Territory in which the Event occurred. This is represented in an XML schema as an XML Attribute. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="LocationDescription" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Description of the location in which the Event occurred. It offers the opportunity to describe a place more precisely than using the TerritoryCode. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script for the LocationDescription as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="Extent">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing an Extent and a UnitOfMeasure.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:decimal">
+            <xs:attribute name="UnitOfMeasure" type="avs:UnitOfExtent">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The UnitOfMeasure of the Extent. This is represented in an XML schema as an XML Attribute. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="ExternallyLinkedResourceType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of an ExternallyLinkedResourceType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:ExternallyLinkedResourceType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the ExternallyLinkedResourceType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the ExternallyLinkedResourceType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="File">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a File.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="URI" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A URI of the File (this can be a URL or another type of Identifier using a scheme identifier, e.g. http or ftp, as defined in RFC 3986).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="HashSum" minOccurs="0" type="ern:DetailedHashSum">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing a HashSum of the File and information about the algorithm with which it has been generated.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="FileSize" minOccurs="0" type="xs:decimal">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The size of the File in kilobytes.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="FingerprintAlgorithmType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a FingerprintAlgorithmType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:FingerprintAlgorithmType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the FingerprintAlgorithmType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the FingerprintAlgorithmType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="FirstPublicationDate">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a FirstPublicationDate.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="ern:ddex_IsoDate">
+            <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Territory to which the FirstPublicationDate applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsDefault" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="FrameRate">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing a FrameRate and a UnitOfMeasure.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:decimal">
+            <xs:attribute name="UnitOfMeasure" type="avs:UnitOfFrameRate">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The UnitOfMeasure of the FrameRate. This is represented in an XML schema as an XML Attribute. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="FulfillmentDateWithTerritory">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a FulfillmentDate.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named FulfillmentDateWithTerritory to disambiguate it from the basic FulfillmentDate Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="FulfillmentDate" type="ern:ddex_IsoDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Date after which an end user can receive the Resource (in ISO 8601 format: YYYY-MM-DD). If no FulfillmentDate is provided the FulfillmentDate is the StartDate of the respective Deal. </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ResourceReleaseReference" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Identifier (specific to the Message) of a Release for a Resource. This is a LocalReleaseAnchorReference starting with the letter R.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:IDREF">
+                  <xs:pattern value="R[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A Territory to which the FulfillmentDate applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IsDefault" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="GenreCategory">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Genre Category.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="Value" type="ern:GenreCategoryValue">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Genre Category value.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Description" minOccurs="0" maxOccurs="unbounded" type="ern:TextWithoutTerritory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing a Description of the Genre Category.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A Territory to which the Genre Category applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="GenreCategoryValue">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Genre Category value.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:ClassifiedGenre">
+            <xs:attribute name="LanguageAndScriptCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script of this Element as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+               <xs:simpleType>
+                  <xs:restriction base="xs:string">
+                     <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the element. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the element. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="GenreWithTerritory">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Genre.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named GenreWithTerritory to disambiguate it from the basic Genre Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="GenreText" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Description of a genre or style (such as Musical, literary or audio-visual) with which a Creation is associated.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SubGenre" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Description of a secondary genre or style with which a Creation is associated.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="GenreCategory" minOccurs="0" maxOccurs="unbounded" type="ern:GenreCategory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Genre Category to which the Release belongs.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SubGenreCategory" minOccurs="0" maxOccurs="unbounded" type="ern:SubGenreCategory">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a sub-genre of the Release.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the Genre as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A Territory to which the Genre applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IsDefault" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="HashSumAlgorithmType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a HashSumAlgorithmType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:HashSumAlgorithmType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the HashSumAlgorithmType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the HashSumAlgorithmType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="ImageCodecType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of an ImageCodecType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:ImageCodecType">
+            <xs:attribute name="Version" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Identifier of the Version of the ImageCodecType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the ImageCodecType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the ImageCodecType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="ImageType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of an ImageType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:ImageType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the ImageType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the ImageType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="InstrumentType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of an InstrumentType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:InstrumentType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the InstrumentType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the InstrumentType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="KeywordsWithTerritory">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Description containing Keywords.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named KeywordsWithTerritory to disambiguate it from the basic Keywords Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script of the Keywords as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Territory to which the Keywords applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsDefault" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="MarketingComment">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a MarketingComment.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script of the Comment as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Territory to which the Comment applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsDefault" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="MessageAuditTrail">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing information about Parties in between the original MessageSender and ultimate MessageRecipient.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="MessageAuditTrailEvent" maxOccurs="unbounded" type="ern:MessageAuditTrailEvent">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a Party handling the Message and the Time at which the handling took place.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="MessageAuditTrailEvent">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Party handling a Message and the Time at which the handling took place.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="MessagingPartyDescriptor" type="ern:MessagingPartyWithoutCode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a MessagingParty.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="DateTime" type="xs:dateTime">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The DateTime at which the Message was handled by the MessagingParty (the only allowed format is ISO 8601: YYYY-MM-DDThh:mm:ssTZD).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="MessageHeader">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite placed at the beginning of each DdexMessage providing information about the Message, such as MessageSender, MessageRecipient and a Message creation time stamp.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="MessageThreadId" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A xs:string used to uniquely identify the thread of Messages of which the current Message is a part. The MessageThreadId shall be, in combination with the DdexPartyId (DPID) of the MessageSender, globally unique. Thus, a MessageSender shall never re-use a MessageThreadId. One example of such a 'thread' is the chain of NewReleaseMessages being sent from ReleaseCreator to wholesale ReleaseDistributor 1 to retail DSP when communicating information about the same Release(s). A common MessageThreadId will allow all these messages to be tied together.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MessageId" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A xs:string used to uniquely identify the current Message. The MessageId shall be, in combination with the DdexPartyId (DPID) of the MessageSender, globally unique. Thus, a MessageSender shall never re-use a MessageId.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MessageFileName" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The FileName, possibly including the FilePath, of the XML File containing the current Message.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MessageSender" type="ern:MessagingPartyWithoutCode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the MessageSender.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SentOnBehalfOf" minOccurs="0" type="ern:MessagingPartyWithoutCode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Party on whose behalf the Message is sent.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MessageRecipient" maxOccurs="unbounded" type="ern:MessagingPartyWithoutCode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the MessageRecipient. Note that if multiple MessageRecipients are provided, all of them will be able to read this information.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MessageCreatedDateTime" type="xs:dateTime">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The DateTime on which the Message was created (the only allowed format is ISO 8601: YYYY-MM-DDThh:mm:ssTZD).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MessageAuditTrail" minOccurs="0" type="ern:MessageAuditTrail">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing information about Parties in between the original MessageSender and ultimate MessageRecipient.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="MessageControlType" minOccurs="0" type="avs:MessageControlType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The indicator used to distinguish a live Message from a test Message.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="MessagingPartyWithoutCode">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a MessagingParty.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named MessagingPartyWithoutCode to disambiguate it from the basic MessagingParty Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="PartyId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Identifier of a Party according to the DdexPartyId standard DDEX-DPID.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:pattern value="PADPIDA[a-zA-Z0-9]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="PartyName" minOccurs="0" type="ern:PartyNameWithoutCode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the PartyNames for the Party handling the Message.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="TradingName" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing a TradingName for the Party handling the Message.</xs:documentation>
+               <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="MusicalWorkId">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a MusicalWorkId.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ISWC" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The ISWC (International Standard Musical Work Code defined in ISO 15707) identifying the MusicalWork. An ISWC comprises three parts: the letter 'T', followed by nine digits and then one check digit. DDEX will enforce the syntax [a-zA-Z][0-9]{10} using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="OpusNumber" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The MusicalWorkId identifying the MusicalWork within the catalog of its Composer (typically of classical music) as an opus number.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ComposerCatalogNumber" minOccurs="0" maxOccurs="unbounded" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A MusicalWorkId identifying a MusicalWork within the catalog of its Composer (typically of classical music) according to a standardized numbering (e.g. 'K' numbers for Koechel's catalog of Mozart).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ProprietaryId" minOccurs="0" maxOccurs="unbounded" type="ern:ProprietaryId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ProprietaryIdentifier of the MusicalWork.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="IsReplaced" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="Name">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Name.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script of the Name as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="OperatingSystemType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of an OperatingSystemType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:OperatingSystemType">
+            <xs:attribute name="Version" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Identifier of the Version of the OperatingSystemType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the OperatingSystemType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the OperatingSystemType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="PLine">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a PLine.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="Year" minOccurs="0" type="xs:gYear">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Year of the PLine.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PLineCompany" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Name of the company releasing the Creation. This may be an owner or a Licensee of the Creation.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PLineText" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The text of the PLine.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script of the PLineText as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="PLineType" type="avs:PLineType">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A Type of PLine. This is represented in an XML schema as an XML Attribute. If this Attribute is not provided, it is assumed that the PLine is an OriginalPLine.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="PLineWithDefault">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a PLine.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named PLineWithDefault to disambiguate it from the basic PLine Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="Year" minOccurs="0" type="xs:gYear">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Year of the PLine.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PLineCompany" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Name of the company releasing the Creation. This may be an owner or a Licensee of the Creation.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="PLineText" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The text of the PLine.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A Territory to which the PLine applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IsDefault" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script of the PLineText as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="ParentalWarningTypeWithTerritory">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a ParentalWarningType.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named ParentalWarningTypeWithTerritory to disambiguate it from the basic ParentalWarningType Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:ParentalWarningType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the ParentalWarningType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Territory to which the ParentalWarningType applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the ParentalWarningType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsDefault" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="PartyName">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a PartyName. Name details for a Party typically either contain a FullName or a KeyName.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision</xs:documentation>
+         <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="FullName" type="ern:Name">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the complete Name of the Party, in its normal form of presentation (e.g. John H. Smith, Acme Music Inc, the Beatles).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="FullNameAsciiTranscribed" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The FullName transcribed using 7-bit ASCII code.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="FullNameIndexed" minOccurs="0" type="ern:Name">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the complete Name of the Party in the form in which it normally appears in an alphabetic index, with the KeyName first (e.g. Smith, John H.; Beatles, The).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NamesBeforeKeyName" minOccurs="0" type="ern:Name">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the Name(s) preceding the KeyName in the FullName (and that is placed after it in a FullNameIndexed). Examples: 'George' in 'George Michael'; 'John Fitzgerald' in 'John Fitzgerald Kennedy'. Not all PartyNames have a NamesBeforeKeyName (e.g. Madonna, EMI Music Inc).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="KeyName" minOccurs="0" type="ern:Name">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the Part of a Name of the Party normally used to index an entry in an alphabetical list, such as 'Smith' (in John Smith) or 'Garcia Marquez' or 'Madonna' or 'Francis de Sales' (in Saint Francis de Sales). For persons, this normally corresponds to the 'family name' or names, which in Western name forms usually comes as a surname at the end of a FullName, and in Asian name forms often at the beginning of a FullName. </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NamesAfterKeyName" minOccurs="0" type="ern:Name">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing the Name(s) following the KeyName. Example:'Ibrahim' (in Anwar Ibrahim). This is common, e.g., in many Asian personal name forms where a FullName begins with the KeyName, which is followed by other names.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AbbreviatedName" minOccurs="0" type="ern:Name">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing a short version of the PartyName (e.g. for use on devices with a small display).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script for the Elements of the PartyName as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="PartyNameWithoutCode">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a PartyName. Name details for a Party typically either contain a FullName or a KeyName.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named PartyNameWithoutCode to disambiguate it from the basic PartyName Composite.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/general-guidance-on-messages/field-length-and-precision</xs:documentation>
+         <xs:documentation source="ddex:Comment">Further Reading: https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-contributors%2C-artists-and-writers</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="FullName" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The complete Name of the Party, in its normal form of presentation (e.g. John H. Smith, Acme Music Inc, the Beatles).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="FullNameAsciiTranscribed" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The FullName transcribed using 7-bit ASCII code.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="FullNameIndexed" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The complete Name of the Party in the form in which it normally appears in an alphabetic index, with the KeyName first (e.g. Smith, John H.; Beatles, The).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NamesBeforeKeyName" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Name(s) preceding the KeyName in the FullName (and that is placed after it in a FullNameIndexed). Examples: 'George' in 'George Michael'; 'John Fitzgerald' in 'John Fitzgerald Kennedy'. Not all PartyNames have a NamesBeforeKeyName (e.g. Madonna, EMI Music Inc).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="KeyName" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Part of a Name of the Party normally used to index an entry in an alphabetical list, such as 'Smith' (in John Smith) or 'Garcia Marquez' or 'Madonna' or 'Francis de Sales' (in Saint Francis de Sales). For persons, this normally corresponds to the 'family name' or names, which in Western name forms usually comes as a surname at the end of a FullName, and in Asian name forms often at the beginning of a FullName. </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="NamesAfterKeyName" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Name(s) following the KeyName. Example: 'Ibrahim' (in Anwar Ibrahim). This is common, e.g., in many Asian personal name forms where a FullName begins with the KeyName, which is followed by other names.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="AbbreviatedName" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A short version of the PartyName (e.g. for use on devices with a small display).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="PartyRelationshipType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a PartyRelationshipType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:PartyRelationshipType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the PartyRelationshipType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the PartyRelationshipType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="MayBeShared" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Flag indicating whether this information may be shared (=true) or not (=false). If the Flag is not present, the information may be shared.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="Percentage">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a PercentageRate.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:decimal">
+            <xs:attribute name="HasMaxValueOfOne" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Flag indicating whether a PercentageRate is given as a value in the range [0,1] (=true) instead of a value in the range [0,100] (=false). This is represented in an XML schema as an XML Attribute. Absence of this attribute is synonymous with false.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="Period">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details about a Period of Time. Periods are typically describedby at least a StartDate or EndDate (or StartDateTime or EndDateTime) where the StartDate(Time) and EndDate(Time) are included in the Period. Thus a one-day period can be described by using the same date in the StartDate and EndDate. If two subsequent Periods form a continuum (i.e. with no break in-between) there are two ways to express this: (a) if using dates, the EndDate of the first Period must be one day before the StartDate of the second Period; (b) if using date times, the EndDateTime of the first Period must be the same as the StartDateTime of the second Period.</xs:documentation>
+      </xs:annotation>
+      <xs:choice>
+         <xs:sequence>
+            <xs:element name="StartDate" minOccurs="0" type="ern:EventDate">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DD). The StartDate must be no later than the EndDate if both are provided.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="EndDate" minOccurs="0" type="ern:EventDate">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DD). The EndDate must not be earlier than the StartDate if both are provided.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:sequence>
+         <xs:sequence>
+            <xs:element name="StartDateTime" minOccurs="0" type="ern:EventDateTime">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the DateTime and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DDThh:mm:ss). The StartDateTime must be no later than the EndDateTime if both are provided.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+            <xs:element name="EndDateTime" minOccurs="0" type="ern:EventDateTime">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Composite containing details of the DateTime and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DDThh:mm:ss). The EndDateTime must not be earlier than the StartDateTime if both are provided.</xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:sequence>
+      </xs:choice>
+   </xs:complexType>
+   <xs:complexType name="Prefix">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Descriptor that precedes the display artist name when multiple display artist names are given.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script of the Prefix as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="Price">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Price.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:decimal">
+            <xs:attribute name="CurrencyCode" type="avs:CurrencyCode" use="required">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Currency of the Price (represented by an ISO 4217 CurrencyCode). This is represented in an XML schema as an XML Attribute. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="PriceType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a PriceType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="Namespace" type="xs:string" use="required">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the PriceType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="PromotionalCode">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a PromotionalCode.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the PromotionalCode. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="ProprietaryId">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a ProprietaryIdentifier.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="Namespace" type="xs:string" use="required">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the ProprietaryIdentifier. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="Purpose">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Purpose.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:Purpose">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the Purpose. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the Purpose. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="RatingAgency">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a RatingAgency.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:RatingAgency">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the RatingAgency. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the RatingAgency. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="RatingReason">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a RatingReason.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:RatingReason">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the RatingReason. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the RatingReason. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="Reason">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a Reason.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script of the Reason as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="RelatedParty">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a PartyRelatedPartyReference for the case where one Party is related to another one.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="PartyRelatedPartyReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Reference for a related Party (specific to this Message). This is a LocalPartyAnchorReference starting with the letter P.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:IDREF">
+                  <xs:pattern value="P[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="PartyRelationshipType" type="ern:PartyRelationshipType">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Type of relationship between two Parties.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="ReleaseRelationshipType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a ReleaseRelationshipType, e.g. between an AudioClipRelease and a VideoClipRelease.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:ReleaseRelationshipType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the ReleaseRelationshipType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the ReleaseRelationshipType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="ReleaseTypeForReleaseNotification">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a ReleaseType.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named ReleaseTypeForReleaseNotification to disambiguate it from the basic ReleaseType Composite. The name indicates that it is ERN specific.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:ReleaseType_ERN4">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the ReleaseType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the ReleaseType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="ResourceContainedResourceReference">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a ResourceContainedResourceReference for the case where one Resource contains another one.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ResourceContainedResourceReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Reference for a Resource (specific to this Message). This is a LocalResourceAnchorReference starting with the letter A.</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:IDREF">
+                  <xs:pattern value="A[\d\-_a-zA-Z]+"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="DurationUsed" minOccurs="0" type="xs:duration">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The total Duration of the Resource that has been used in a specified context (this may be less than the total Duration of the Resource) (using the ISO 8601 PT[[hhH]mmM]ssS format, where lower case characters indicate variables, upper case characters are part of the xs:string, e.g. one hour, two minutes and three seconds would be PT1H2M3S). The seconds section ss may include fractions (e.g. one minute and 30.5 seconds would be PT1M30.5S).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="StartPoint" minOccurs="0" type="xs:decimal">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The start point of the preview given in seconds from the start of the referenced Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Purpose" minOccurs="0" type="ern:Purpose">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Purpose of the usage.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="ResourceContainedResourceReferenceList">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of one or more ResourceContainedResourceReferences. </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ResourceContainedResourceReference" maxOccurs="unbounded" type="ern:ResourceContainedResourceReference">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ResourceContainedResourceReference.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="ResourceContributorRole">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a StudioRole.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:ResourceContributorRole">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the StudioRole. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the StudioRole. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="ResourceId">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of ResourceIds.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ISRC" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The ISRC (International Standard Recording Code as defined in ISO 3901) for the Resource. An ISRC comprises four parts: two characters, followed by three alphanumeric characters, then two digits and five digits. DDEX will enforce the syntax [a-zA-Z]{2}[a-zA-Z0-9]{3}[0-9]{7} using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ISMN" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The ISMN (International Standard Music Number defined in ISO 10957) for the Resource. An ISMN is a thirteen-digit number. Pre-2008 ISMNs, which had 10 characters and are now deprecated, are converted by replacing the initial letter ('M') with '979-0'. DDEX will enforce the syntax 979[0-9]{9}[X0-9] using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ISAN" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The ISAN (International Standard Audiovisual Number as defined in ISO 15706) for the Resource. An ISAN comprises four blocks of four hexadecimal charaters followed by a check character. DDEX will enforce the syntax [A-F0-9]{12} using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="VISAN" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The V-ISAN (Version Identifier of a International Standard Audiovisual Number as defined in ISO 15706-2) for the Resource. A V-ISAN comprises four blocks of four hexadecimal charaters followed by a check character, followed by two further blocks of four hexadecimal characters, followed by a further check character. DDEX will enforce the syntax [A-F0-9]{24} using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ISBN" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The ISBN (International Standard Book Number defined in ISO 2108) for the Resource. An ISBN is a 13-digit number. Pre-2007, ISBNs, which had 10-digits and are now deprecated, are converted by adding the prefix '978' and re-calculating the check character. DDEX will enforce the syntax 97[8-9][0-9]{9}[X0-9] using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ISSN" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The ISSN (International Standard Serial Number defined in ISO 3297) for the Resource. An ISSN comprises two groups of four digits, separated by a hyphen and a control digit. DDEX will enforce the syntax [0-9]{4}-[0-9]{3}[X0-9] using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SICI" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The SICI (Serial Item and Contribution Identifier defined in ANSI/NISO Z39.56-199) for the Resource. DDEX will enforce the syntax [0-9]{4}-[0-9]{3}[X0-9].+ using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CatalogNumber" minOccurs="0" type="ern:CatalogNumber">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the CatalogNumber of the Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ProprietaryId" minOccurs="0" maxOccurs="unbounded" type="ern:ProprietaryId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ProprietaryIdentifier of the Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="IsReplaced" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="ResourceProprietaryId">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of ProprietaryIdentifiers of a Resource.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ProprietaryId" maxOccurs="unbounded" type="ern:ProprietaryId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ProprietaryIdentifier of the Resource.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="IsReplaced" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="SamplingRate">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing a SamplingRate and a UnitOfMeasure.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:decimal">
+            <xs:attribute name="UnitOfMeasure" type="avs:UnitOfFrequency">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The UnitOfMeasure of the SamplingRate. This is represented in an XML schema as an XML Attribute. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="SessionType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a SessionType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:SessionType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the SessionType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the SessionType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="SheetMusicCodecType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a SheetMusicCodecType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:SheetMusicCodecType">
+            <xs:attribute name="Version" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Identifier of the Version of the SheetMusicCodecType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the SheetMusicCodecType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the SheetMusicCodecType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="SheetMusicId">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of Identifiers of a SheetMusic.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ISMN" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The ISMN (International Standard Music Number defined in ISO 10957) for the SheetMusic. An ISMN is a thirteen-digit number. Pre-2008 ISMNs, which had 10 characters and are now deprecated, are converted by replacing the initial letter ('M') with '979-0'. DDEX will enforce the syntax 979[0-9]{9}[X0-9] using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ProprietaryId" minOccurs="0" maxOccurs="unbounded" type="ern:ProprietaryId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ProprietaryIdentifier of the SheetMusic.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="IsReplaced" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="SheetMusicType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a SheetMusicType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:SheetMusicType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the SheetMusicType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the SheetMusicType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="SimpleRightsType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a RightsType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:RightsCoverage">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the RightsType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the RightsType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="SoftwareType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a SoftwareType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:SoftwareType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the SoftwareType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the SoftwareType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="SoundRecordingId">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of SoundRecordingIds.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ISRC" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The ISRC (International Standard Recording Code as defined in ISO 3901) for the SoundRecording. An ISRC comprises four parts: two characters, followed by three alphanumeric characters, then two digits and five digits. DDEX will enforce the syntax [a-zA-Z]{2}[a-zA-Z0-9]{3}[0-9]{7} using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CatalogNumber" minOccurs="0" type="ern:CatalogNumber">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the CatalogNumber of the SoundRecording.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ProprietaryId" minOccurs="0" maxOccurs="unbounded" type="ern:ProprietaryId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ProprietaryIdentifier of the SoundRecording (usually one per society involved in the messaging).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="IsReplaced" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="SoundRecordingType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a SoundRecordingType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:SoundRecordingType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the SoundRecordingType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the SoundRecordingType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="SubGenreCategory">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a sub-genre within the classical genre.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="Value" maxOccurs="unbounded" type="ern:SubGenreCategoryValue">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The text of the sub-genre.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="SubGenreCategoryValue">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a sub-genre within the classical genre.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:SubGenre">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the classical sub-genre. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the vocal register. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="TextCodecType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a TextCodecType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:TextCodecType">
+            <xs:attribute name="Version" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Identifier of the Version of the TextCodecType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the TextCodecType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the TextCodecType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="TextId">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of Identifiers of a Text.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ISBN" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The ISBN (International Standard Book Number defined in ISO 2108) for the Text. An ISBN is a 13-digit number. Pre-2007, ISBNs, which had 10-digits and are now deprecated, are converted by adding the prefix '978' and re-calculating the check character. DDEX will enforce the syntax 97[8-9][0-9]{9}[X0-9] using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ISSN" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The ISSN (International Standard Serial Number defined in ISO 3297) identifying the Text. An ISSN comprises two groups of four digits, separated by a hyphen and a control digit. DDEX will enforce the syntax [0-9]{4}-[0-9]{3}[X0-9] using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="SICI" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The SICI (Serial Item and Contribution Identifier defined in ANSI/NISO Z39.56-199) for the Text. DDEX will enforce the syntax [0-9]{4}-[0-9]{3}[X0-9].+ using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ProprietaryId" minOccurs="0" maxOccurs="unbounded" type="ern:ProprietaryId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ProprietaryIdentifier of the Text (usually one per society involved in the messaging).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="IsReplaced" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="TextType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a TextType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:TextType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the TextType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the TextType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="TextWithoutTerritory">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of an Annotation, e.g. a Description or a Comment.</xs:documentation>
+         <xs:documentation source="ddex:Comment">Explanatory Note: This Composite is named TextWithoutTerritory to disambiguate it from the basic TextWithFormat Composite.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="LanguageAndScriptCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Language and script of the Annotation as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+               <xs:simpleType>
+                  <xs:restriction base="xs:string">
+                     <xs:pattern value="[a-zA-Z]{2,3}(-[a-zA-Z]+){0,1}(-[a-zA-Z]{2}|-[0-9]{3}){0,1}(-[a-zA-Z][a-zA-Z0-9]{4}[a-zA-Z0-9]*){0,1}"/>
+                  </xs:restriction>
+               </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="ApplicableTerritoryCode" type="avs:CurrentTerritoryCode">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A Territory to which the Annotation applies. The use of ISO TerritoryCodes (or the term 'Worldwide') is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard. </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="IsDefault" type="xs:boolean">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Flag indicating whether this Composite provides default values (=true). This Flag should not be set if this is not the case. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="Format" type="avs:TextCodecType">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The format of the Annotation. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the Format. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the Format. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="TitleDisplayInformation">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing information on how a RecordCompany wishes Artist information to be presented to Consumers as part of the Title (and in addition to displaying the DisplayArtist information).</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="IsDisplayedInTitle" type="xs:boolean">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Flag indicating whether the information is displayed in the Title of a Resource (=true) or not (=false).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="Prefix" minOccurs="0" maxOccurs="unbounded" type="ern:Prefix">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Descriptor that precedes the display artist name when multiple display artist names are given.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="LanguageAndScriptCode" type="xs:string">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Language and script of the Information as defined in IETF RfC 5646. The default is the same as indicated for the containing composite. Language and Script are provided as lang[-script][-region][-variant]. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SequenceNumber" type="xs:integer">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">A number indicating the order of the display artist name in a group of display artist names, to allow sequencing different display artists. This is represented in an XML schema as an XML Attribute. </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="ValidityPeriod">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details about a ValidityPeriod of Time. Periods are typically describedby at least a StartDate or EndDate where the StartDate and EndDate are included in the Period. Thus a one-day period can be described by using the same date in the StartDate and EndDate.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="StartDate" minOccurs="0" type="ern:EventDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of an Event that marks the beginning of the Period (in ISO 8601 format: YYYY-MM-DD). The StartDate must be no later than the EndDate if both are provided.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="EndDate" minOccurs="0" type="ern:EventDate">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the Date and Place of an Event that marks the end of the Period (in ISO 8601 format: YYYY-MM-DD). The EndDate must not be earlier than the StartDate if both are provided.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="Venue">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a venue.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="VenueName" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Name of the venue.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="VenueAddress" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The Address of the venue. The level of description may be more or less granular, possibly including only the name of the city.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="TerritoryCode" minOccurs="0" type="ern:AllTerritoryCode">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Territory of the VenueAddress. The use of ISO TerritoryCodes is strongly encouraged; TIS TerritoryCodes should only be used if both MessageSender and MessageRecipient are familiar with this standard.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="LocationCode" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An UN/Locode of the venue.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="VenueRoom" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A specific studio of the venue where a Session took place.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="VersionType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a VersionType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:VersionType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the VersionType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the VersionType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="VideoCodecType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a VideoCodecType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:VideoCodecType">
+            <xs:attribute name="Version" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Identifier of the Version of the VideoCodecType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the VideoCodecType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the VideoCodecType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="VideoDefinitionType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a VideoDefinitionType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:VideoDefinitionType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the VideoDefinitionType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the VideoDefinitionType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="VideoId">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of Identifiers of a Video.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="ISRC" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The ISRC (International Standard Recording Code as defined in ISO 3901) for the Video. An ISRC comprises four parts: two characters, followed by three alphanumeric characters, then two digits and five digits. DDEX will enforce the syntax [a-zA-Z]{2}[a-zA-Z0-9]{3}[0-9]{7} using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ISAN" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The ISAN (International Standard Audiovisual Number as defined in ISO 15706) for the Video. An ISAN comprises four blocks of four hexadecimal charaters followed by a check character. DDEX will enforce the syntax [A-F0-9]{12} using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="VISAN" minOccurs="0" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">The V-ISAN (Version Identifier of a International Standard Audiovisual Number as defined in ISO 15706-2) for the Video. A V-ISAN comprises four blocks of four hexadecimal charaters followed by a check character, followed by two further blocks of four hexadecimal characters, followed by a further check character. DDEX will enforce the syntax [A-F0-9]{24} using XML Schema in the future.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="CatalogNumber" minOccurs="0" type="ern:CatalogNumber">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of the CatalogNumber of the Video.</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="ProprietaryId" minOccurs="0" maxOccurs="unbounded" type="ern:ProprietaryId">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">A Composite containing details of a ProprietaryIdentifier of the Video (usually one per society involved in the messaging).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element name="EIDR" minOccurs="0" maxOccurs="unbounded" type="xs:string">
+            <xs:annotation>
+               <xs:documentation source="ddex:Definition">An Identifier of the Video assigned by the Entertainment Identifier Registry Association (EIDR).</xs:documentation>
+            </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="IsReplaced" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation source="ddex:Definition">The Flag indicating whether this Identifier is old and has been replaced by a new one (=true) or not (=false). The Flag may only be set to True when the new Identifier is also provided. If the Flag is not set, this Identifier is deemed to be the current one.</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="VideoType">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Composite containing details of a VideoType.</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="avs:VideoType">
+            <xs:attribute name="Namespace" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">The Namespace of the VideoType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UserDefinedValue" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation source="ddex:Definition">A UserDefined value of the VideoType. This is represented in an XML schema as an XML Attribute.</xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:simpleType name="ddex_IsoDate">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A Date represented in ISO 8601 format: YYYY[-MM[-DD]].</xs:documentation>
+         <xs:documentation source="ddex:Comment">Format: A Date represented as a calendar Year, Month or Day (in ISO 8601 format: YYYY, YYYY-MM or YYYY-MM-DD).</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:pattern value="[0-9]{4}(-[0-9]{2}){0,1}(-[0-9]{2}){0,1}"/>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ddex_LocalPartyAnchorReference">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A LocalAnchorReference which acts as a reference to a local Identifier of a Party. This LocalAnchorReference is a xs:string starting with the letter P.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:IDREF">
+         <xs:pattern value="P[\d\-_a-zA-Z]+"/>
+      </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="ddex_LocalResourceAnchorReference">
+      <xs:annotation>
+         <xs:documentation source="ddex:Definition">A LocalAnchorReference which acts as a reference to a local Identifier of a Resource. This LocalAnchorReference is a xs:string starting with the letter A.</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:IDREF">
+         <xs:pattern value="A[\d\-_a-zA-Z]+"/>
+      </xs:restriction>
+   </xs:simpleType>
+</xs:schema>


### PR DESCRIPTION
Support for 42 with:
- XSD and PHP files (generated with `xsd2php`)
- Unit test

Most importantly: make the Simplifiers more compatible with 4.x versions. In the past, adding 4.x versions (41 and 411), simplifiers didn't support all the fields correctly. This should be fixed for all 4.x version now. Since 3.x and 4.x have significant structural changes, code conditions on the version (3x or 4x) were introduced in many places. The Simplifiers now need the version to perform the retrievals.