### PR TITLE
Fix PHPUnit argument injection vulnerability (GHSA-qrr6-mg7r-m243)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "goetas-webservices/xsd2php-runtime": "v0.2.16",
         "goetas-webservices/xsd2php": "^0.4.4",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5 || ^12.5.22"
     },
     "config": {
         "preferred-install": {


### PR DESCRIPTION
Widen phpunit dev constraint to allow ^12.5.22 which includes the fix for INI directive injection in child processes.